### PR TITLE
fix: Improve lazy loading and caching for Rapla events

### DIFF
--- a/docs/plans/2026-01-28-fix-rapla-events-lazy-loading-cache-plan.md
+++ b/docs/plans/2026-01-28-fix-rapla-events-lazy-loading-cache-plan.md
@@ -1,0 +1,138 @@
+---
+title: fix: Rapla events lazy loading cache
+type: fix
+date: 2026-01-28
+---
+
+# fix: Rapla events lazy loading cache
+
+🐛 The Rapla events page fetches a multi-year range and uses a custom JSON cache, making it feel slow and inconsistent with the main schedule. This plan switches the events page to the shared schedule cache and adds lazy loading so the first screen appears quickly.
+
+## Overview
+
+Align the Date Management (Rapla events) data path with the main schedule cache (ScheduleProvider + repositories) and introduce paged loading. The first page loads quickly from cache, then fetches additional future windows on scroll. This removes the multi-year fetch and makes perceived performance consistent with the schedule tab.
+
+## Problem Statement / Motivation
+
+- The Rapla events page requests a large date range and blocks on network/parsing, which appears broken to users.
+- The page uses a separate Preferences JSON cache, so freshness differs from the schedule view.
+- The UI builds a full list inside a non-lazy scroll container, increasing frame and memory cost.
+
+## Proposed Solution
+
+- Replace the custom Rapla events cache with the shared schedule cache.
+- Page the Rapla events list by fixed 3-month windows.
+- Switch the UI to a single lazy list with a load-more trigger near the end.
+
+## Technical Considerations
+
+- **Caching**: use ScheduleProvider / ScheduleEntryRepository for cache reads; rely on ScheduleQueryInformationRepository + ScheduleFreshnessGate for staleness checks.
+- **Pagination**: default to 3-month windows; fetch the next future window when user scrolls near the end.
+- **Filters**: hide the date selector; the Rapla events list is future-only.
+- **Ordering & dedupe**: merge pages in chronological order; dedupe by title/type/start/end (same as existing RaplaImportantEventsProvider logic).
+- **UI**: remove nested scrolls and render a single ListView.builder with a loading footer.
+
+## Acceptance Criteria
+
+- [x] Rapla events are derived from the schedule cache (ScheduleProvider-backed), not Preferences JSON.
+- [x] Initial load fetches only the next 3 months and shows cached results immediately when present.
+- [x] Events render incrementally as cache results and network updates arrive, without waiting for the full page to finish.
+- [x] Additional pages load lazily on scroll; no multi-year fetch happens on first load.
+- [x] Date selector is hidden on the Rapla events page; only future events are shown.
+- [x] Events stay sorted chronologically and are deduped across pages.
+- [x] The events list uses a single lazy list (no nested scroll) and remains smooth.
+- [x] Error states are per-page and allow retry without losing prior pages.
+
+## Success Metrics
+
+- First contentful events list appears within 1 second on a warm cache.
+- Network requests per session drop compared to full-range fetches.
+- No reports of the events page appearing stuck on slow connections.
+
+## Dependencies & Risks
+
+- **Risk**: Wrong cache range could show missing events. Mitigation: align page windows to week boundaries and reuse ScheduleFreshnessGate range checks.
+- **Risk**: Overlapping pages could duplicate events. Mitigation: reuse existing dedupe key.
+- **Dependency**: ScheduleProvider and RaplaScheduleSource behavior, including isolate parsing and Rapla URL validation.
+
+## Implementation Sketch
+
+1. **Data layer**
+   - Update `RaplaImportantEventsProvider` to read from the schedule cache (ScheduleProvider or ScheduleEntryRepository) for a given range.
+   - If stale, request updates through ScheduleProvider, then re-read from cache.
+   - Keep the existing `filterImportantEntries` and `mergeImportantEntries` logic.
+
+2. **ViewModel paging**
+   - Add pagination state to `DateManagementViewModel`:
+     - current page window (start/end)
+     - loaded events list
+     - isLoadingNextPage / nextPageFailed
+   - Replace `_readRaplaImportantEvents` with `_readRaplaImportantEventsPage`.
+   - Set the initial window to now..now+3 months, and advance forward-only.
+
+3. **UI lazy list**
+   - Replace `SingleChildScrollView` + nested `ListView.separated` with a single `ListView.builder`.
+   - Use a scroll controller to trigger `loadNextPage` when nearing the end.
+   - Add a loading footer and retry action for page failures.
+
+4. **Freshness / caching**
+   - Reuse `ScheduleFreshnessGate` for Rapla events pages.
+   - Use `ScheduleProvider.getCachedSchedule()` first, then fetch if stale.
+
+## Example (pseudo)
+
+### lib/date_management/ui/viewmodels/date_management_view_model.dart
+
+```dart
+Future<void> loadNextRaplaPage() async {
+  if (_isLoadingNextPage || !_hasMorePages) return;
+  _isLoadingNextPage = true;
+  notifyListeners("isLoadingNextPage");
+
+  final window = _nextPageWindow();
+  final cached = await _scheduleProvider.getCachedSchedule(
+    window.start,
+    window.end,
+  );
+  _appendImportantEvents(_toImportantEvents(cached));
+
+  if (_freshnessGate.isStale(window.start, window.end, DateTime.now())) {
+    await _scheduleProvider.getUpdatedSchedule(
+      window.start,
+      window.end,
+      _updateMutex.token,
+    );
+    final updated = await _scheduleProvider.getCachedSchedule(
+      window.start,
+      window.end,
+    );
+    _replaceEventsForWindow(window, _toImportantEvents(updated));
+  }
+
+  _isLoadingNextPage = false;
+  notifyListeners("isLoadingNextPage");
+}
+```
+
+## References & Research
+
+### Internal References
+
+- `lib/date_management/ui/viewmodels/date_management_view_model.dart`
+- `lib/date_management/ui/date_management_page.dart`
+- `lib/date_management/business/rapla_important_events_provider.dart`
+- `lib/schedule/business/schedule_provider.dart`
+- `lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart`
+- `lib/schedule/ui/viewmodels/schedule_freshness_gate.dart`
+- `docs/solutions/ui-bugs/swipe-unloaded-week-no-fetch-schedule-ui-20260127.md`
+- `docs/rapla_dates_integration.md`
+
+### External Research
+
+- Not required; strong local patterns exist for caching and range freshness.
+
+## AI-Era Considerations
+
+- Use rapid iteration to validate paging behavior on-device and ensure no UI jank.
+- Prioritize regression tests and manual device validation due to the cross-module cache change.
+- Record any AI-assisted changes in the PR description for human review.

--- a/docs/rapla-cache-refresh-behavior.md
+++ b/docs/rapla-cache-refresh-behavior.md
@@ -1,0 +1,63 @@
+# Rapla + Schedule cache and refresh behavior
+
+This document describes how the Rapla events page and the weekly schedule view
+use caching, lazy loading, and background refresh.
+
+## Rapla events (Date Management)
+
+### Cache source
+- Events are built from the shared schedule cache (ScheduleProvider-backed).
+- Important events are derived from schedule entries and merged/deduped in the
+  RaplaImportantEventsProvider.
+
+### Initial load
+- The first window is 3 months starting today.
+- Cached windows (up to the last stored window end) are loaded immediately so
+  previously seen events appear instantly.
+- After cached windows load, the first window fetch happens; results update as
+  they arrive.
+
+### Lazy loading
+- Pages load in 3-month windows as the user scrolls.
+- Loading is throttled with a cooldown to avoid repeated requests.
+- If a page loads no new non-duplicate events, pagination stops and the UI shows
+  "No more events".
+
+### Scraping optimizations
+- Cooldown between Rapla window fetches to prevent rapid repeat requests.
+- Stop requesting further windows when a fetch yields no new events.
+- Clamp total fetch range to the next 3 years.
+- If the last non-holiday event ends at date X, stop at X + 365 days.
+
+### Refresh behavior
+- Each window has its own freshness gate; stale windows refresh in the
+  background after cached results are displayed.
+- The furthest loaded window end is persisted in preferences so cached windows
+  can be restored on next open.
+
+### Fetch limits
+- Hard limit: do not fetch beyond 3 years from today.
+- Additional limit: if the last non-holiday event ends at date X, do not fetch
+  beyond X + 365 days (even if the 3-year limit is further out).
+
+## Weekly schedule (Classes)
+
+### Cache source
+- Weekly schedule reads cached entries for the visible week first, then updates.
+
+### Initial load
+- If the cached week is empty and the schedule source can query, a network fetch
+  is forced to avoid showing an empty schedule as "fresh".
+
+### Refresh behavior
+- Each viewed week has a per-window freshness gate to avoid stale data.
+- The next 14 days are refreshed regularly (periodic background update) so the
+  widget and schedule stay current.
+
+## Related files
+- lib/date_management/ui/viewmodels/date_management_view_model.dart
+- lib/date_management/business/rapla_important_events_provider.dart
+- lib/date_management/ui/date_management_page.dart
+- lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+- lib/schedule/business/schedule_provider.dart
+- lib/schedule/background/background_schedule_update.dart

--- a/docs/rapla-schedule-cache-merge.md
+++ b/docs/rapla-schedule-cache-merge.md
@@ -1,0 +1,39 @@
+# Rapla events share the schedule cache
+
+This document explains how the Date Management (Rapla events) view now reuses
+the same schedule cache as the main schedule page.
+
+## Goal
+
+Keep a single source of truth for Rapla data so both the schedule and events
+pages use identical cached entries, freshness logic, and update paths.
+
+## What changed
+
+- The Rapla events pipeline no longer uses the old Preferences JSON cache.
+- Events are derived from the schedule cache (ScheduleProvider-backed).
+- Rapla events refresh uses the same schedule update path as the weekly view.
+- Cached windows are restored on open and refreshed in the background.
+
+## Data flow
+
+1. Date Management requests a Rapla window.
+2. ScheduleProvider reads cached ScheduleEntry rows for the window.
+3. RaplaImportantEventsProvider filters/merges ScheduleEntries into
+   ImportantEvents.
+4. If the window is stale, ScheduleProvider fetches updates and the cache is
+   refreshed, then the events list is rebuilt from the updated cache.
+
+## Why this matters
+
+- Consistent data between schedule and events.
+- Reduced duplicate fetching and parsing work.
+- Single freshness gate strategy with shared schedule infrastructure.
+
+## Related files
+
+- lib/date_management/business/rapla_important_events_provider.dart
+- lib/date_management/ui/viewmodels/date_management_view_model.dart
+- lib/schedule/business/schedule_provider.dart
+- lib/schedule/data/schedule_entry_repository.dart
+- lib/schedule/data/schedule_query_information_repository.dart

--- a/docs/solutions/ui-bugs/rapla-events-not-loading-first-open-schedule-20260128.md
+++ b/docs/solutions/ui-bugs/rapla-events-not-loading-first-open-schedule-20260128.md
@@ -1,0 +1,93 @@
+---
+module: Schedule & Date Management
+date: 2026-01-28
+problem_type: ui_bug
+component: service_object
+symptoms:
+  - "Schedule shows empty on first open and logs 'Schedule fresh; skip network fetch' with 0 cached entries"
+  - "Rapla events page shows empty state or only first 3 months until user scrolls"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [rapla, lazy-loading, cache, schedule, freshness-gate, first-open]
+---
+
+# Troubleshooting: Rapla events and schedule empty on first open
+
+## Problem
+On first launch with an empty cache, the schedule page marked the range as fresh
+and skipped the network fetch, leaving the list empty. The Rapla events page
+also failed to load beyond the first window unless the user scrolled, showing an
+empty-state message while data was still loading.
+
+## Environment
+- Module: Schedule & Date Management
+- Affected Component: schedule cache/refresh + Rapla events paging
+- Date: 2026-01-28
+
+## Symptoms
+- Schedule logs "Schedule fresh; skip network fetch" despite zero cached entries.
+- Events page shows "no events" while initial fetch is in progress.
+- Events list only loads the first 3-month window unless the user scrolls.
+
+## What Didn't Work
+
+**Attempted behavior:** rely on existing freshness gates and lazy-load triggers.
+- **Why it failed:** freshness gates treated empty caches as fresh; lazy-load was
+  only triggered by scroll position, which never changed on first open.
+
+## Solution
+
+1. Force a schedule fetch when cached entries are empty and the source can query.
+2. Prefetch additional Rapla pages on first open to fill the screen.
+3. Hide the Rapla empty-state message until loading finishes.
+4. Add paging cooldown + "no more events" state to prevent infinite refresh.
+5. Clamp Rapla paging to the next 3 years and stop at last non-holiday + 365 days.
+
+**Code changes** (Dart):
+```dart
+// lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+final shouldForceFetch = cachedSchedule.entries.isEmpty &&
+    scheduleSourceProvider.currentScheduleSource.canQuery();
+final isStale = shouldForceFetch ||
+    _freshnessGate.isStale(start, end, now) ||
+    _isWindowStale(start, end, now);
+```
+
+```dart
+// lib/date_management/ui/viewmodels/date_management_view_model.dart
+Future<void> _prefetchRaplaUntilFilled() async {
+  for (var i = 0; i < 3; i++) {
+    if (!_hasMoreRaplaPages) return;
+    if (importantEventSections.isNotEmpty) return;
+    await loadNextRaplaPage();
+  }
+}
+```
+
+```dart
+// lib/date_management/ui/date_management_page.dart
+if (!model.isLoading && !model.isLoadingNextRaplaPage)
+  Center(child: Text(L.of(context).dateManagementRaplaEmpty))
+```
+
+**Commands run:**
+```bash
+flutter test
+flutter run -d <DEVICE_ID>
+```
+
+## Why This Works
+- Empty-cache schedules now bypass the freshness gate and fetch from Rapla.
+- Rapla pages can load without user scroll, so the first view is populated.
+- The empty-state message is only shown after loading completes.
+- Cooldowns and cutoffs prevent repeated scraping and runaway pagination.
+
+## Prevention
+- Treat empty caches as stale for critical entry lists.
+- Trigger pagination when content does not fill the viewport.
+- Keep explicit paging caps (time-based and "no new events" stop rules).
+- Verify initial open behavior on a cold cache during QA.
+
+## Related Issues
+- See also: [swipe-unloaded-week-no-fetch-schedule-ui-20260127.md](../ui-bugs/swipe-unloaded-week-no-fetch-schedule-ui-20260127.md)

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -82,6 +82,8 @@ void injectServices(bool isBackground) {
   ));
   c.registerInstance(RaplaImportantEventsProvider(
     c.resolve(),
+    c.resolve(),
+    c.resolve(),
   ));
   c.registerInstance(WidgetHelper());
   c.registerInstance(ListDateEntries30d(List<DateEntry>.empty(growable: true)));

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -81,9 +81,9 @@ void injectServices(bool isBackground) {
     DateEntryRepository(c.resolve()),
   ));
   c.registerInstance(RaplaImportantEventsProvider(
-    c.resolve(),
-    c.resolve(),
-    c.resolve(),
+    c.resolve<PreferencesProvider>(),
+    c.resolve<ScheduleProvider>(),
+    c.resolve<ScheduleSourceProvider>(),
   ));
   c.registerInstance(WidgetHelper());
   c.registerInstance(ListDateEntries30d(List<DateEntry>.empty(growable: true)));

--- a/lib/common/data/preferences/preferences_provider.dart
+++ b/lib/common/data/preferences/preferences_provider.dart
@@ -31,6 +31,8 @@ class PreferencesProvider {
       "SynchronizeScheduleWithCalendar";
   static const String UseDhMineForDates = "UseDhMineForDates";
   static const String RaplaImportantEventsCache = "RaplaImportantEventsCache";
+  static const String RaplaImportantEventsWindowEnd =
+      "RaplaImportantEventsWindowEnd";
 
   final PreferencesAccess _preferencesAccess;
   final SecureStorageAccess _secureStorageAccess;
@@ -65,14 +67,13 @@ class PreferencesProvider {
   }
 
   Future<bool> isCalendarSyncEnabled() async {
-    return await _preferencesAccess.get<bool>('isCalendarSyncEnabled') ??
-        false;
+    return await _preferencesAccess.get<bool>('isCalendarSyncEnabled') ?? false;
   }
 
   Future<void> setSelectedCalendar(Calendar? selectedCalendar) async {
     String? selectedCalendarId = selectedCalendar?.id;
     await _preferencesAccess.set<String>(
-      'SelectedCalendarId', selectedCalendarId ?? '');
+        'SelectedCalendarId', selectedCalendarId ?? '');
   }
 
   Future<Calendar?> getSelectedCalendar() async {
@@ -222,18 +223,16 @@ class PreferencesProvider {
 
   Future<bool> getSynchronizeScheduleWithCalendar() async {
     return await _preferencesAccess
-        .get<bool>(SynchronizeScheduleWithCalendar) ??
-      true;
+            .get<bool>(SynchronizeScheduleWithCalendar) ??
+        true;
   }
 
   Future<void> setSynchronizeScheduleWithCalendar(bool value) {
-    return _preferencesAccess.set<bool>(
-        SynchronizeScheduleWithCalendar, value);
+    return _preferencesAccess.set<bool>(SynchronizeScheduleWithCalendar, value);
   }
 
   Future<bool> getDidShowWidgetHelpDialog() async {
-    return await _preferencesAccess.get<bool>(DidShowWidgetHelpDialog) ??
-        false;
+    return await _preferencesAccess.get<bool>(DidShowWidgetHelpDialog) ?? false;
   }
 
   Future<void> setDidShowWidgetHelpDialog(bool value) {
@@ -256,6 +255,14 @@ class PreferencesProvider {
     return _preferencesAccess.set<String>(RaplaImportantEventsCache, value);
   }
 
+  Future<String?> getRaplaImportantEventsWindowEnd() async {
+    return await _preferencesAccess.get<String>(RaplaImportantEventsWindowEnd);
+  }
+
+  Future<void> setRaplaImportantEventsWindowEnd(String value) async {
+    return _preferencesAccess.set<String>(RaplaImportantEventsWindowEnd, value);
+  }
+
   Future<void> set<T>(String key, T value) async {
     return _preferencesAccess.set<T>(key, value);
   }
@@ -273,14 +280,13 @@ class PreferencesProvider {
   }
 
   Future<int> getNextRateInStoreLaunchCount() async {
-    return await _preferencesAccess
-        .get<int>("NextRateInStoreLaunchCount") ??
-      RateInStoreLaunchAfter;
+    return await _preferencesAccess.get<int>("NextRateInStoreLaunchCount") ??
+        RateInStoreLaunchAfter;
   }
 
   Future<void> setNextRateInStoreLaunchCount(int value) async {
-    return await _preferencesAccess
-        .set<int>("NextRateInStoreLaunchCount", value);
+    return await _preferencesAccess.set<int>(
+        "NextRateInStoreLaunchCount", value);
   }
 
   Future<bool> getDidShowDonateDialog() async {

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -150,6 +150,8 @@ final de = {
       "Keine Rapla-Termine für diesen Zeitraum gefunden.",
   "scheduleQueryFailedMessage":
       "Ups, da ist etwas schief gelaufen. Möglicherweise wird nicht der gesamte Plan angezeigt. Schaue Dir daher den Plan im Browser an um sicher zu gehen, dass Du nichts verpasst.",
+  "retry": "Erneut versuchen",
+  "noMoreEvents": "Keine weiteren Termine",
   "scheduleQueryFailedOpenInBrowser": "Im Browser öffnen",
   "onboardingScheduleSourceTitle": "Vorlesungsplan",
   "onboardingScheduleSourceDescription":

--- a/lib/common/i18n/localization_strings_en.dart
+++ b/lib/common/i18n/localization_strings_en.dart
@@ -138,6 +138,8 @@ final en = {
   "dateManagementRaplaEmpty": "No Rapla events found for this period.",
   "scheduleQueryFailedMessage":
       "Oops, something went wrong. It is possible that the schedule is incomplete. To ensure that you do not miss something, view the schedule in the browser.",
+  "retry": "Retry",
+  "noMoreEvents": "No more events",
   "scheduleQueryFailedOpenInBrowser": "View in browser",
   "onboardingScheduleSourceTitle": "Schedule",
   "onboardingScheduleSourceDescription":

--- a/lib/common/i18n/localizations.dart
+++ b/lib/common/i18n/localizations.dart
@@ -342,6 +342,10 @@ class L {
   String get scheduleQueryFailedMessage =>
       _getValue("scheduleQueryFailedMessage");
 
+  String get retry => _getValue("retry");
+
+  String get noMoreEvents => _getValue("noMoreEvents");
+
   String get scheduleQueryFailedOpenInBrowser =>
       _getValue("scheduleQueryFailedOpenInBrowser");
 

--- a/lib/date_management/business/rapla_important_events_provider.dart
+++ b/lib/date_management/business/rapla_important_events_provider.dart
@@ -1,128 +1,83 @@
-import 'dart:convert';
-
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/date_management/model/important_event.dart';
+import 'package:dualmate/schedule/business/schedule_provider.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/model/schedule_query_result.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:dualmate/schedule/service/rapla/rapla_schedule_source.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 
 class RaplaImportantEventsProvider {
   final PreferencesProvider _preferencesProvider;
-  final RaplaScheduleSource _scheduleSource;
+  final ScheduleProvider _scheduleProvider;
+  final ScheduleSourceProvider _scheduleSourceProvider;
 
   RaplaImportantEventsProvider(
-    this._preferencesProvider, {
-    RaplaScheduleSource? scheduleSource,
-  }) : _scheduleSource = scheduleSource ?? RaplaScheduleSource();
+    this._preferencesProvider,
+    this._scheduleProvider,
+    this._scheduleSourceProvider,
+  );
 
-  Future<List<ImportantEvent>> getImportantEvents(
+  Future<List<ImportantEvent>> getCachedImportantEvents(
     DateTime start,
     DateTime end,
-    CancellationToken cancellationToken, {
-    bool forceRefresh = false,
-  }) async {
-    var raplaUrl = await _preferencesProvider.getRaplaUrl();
-    if (!RaplaScheduleSource.isValidUrl(raplaUrl)) {
-      return [];
-    }
-
-    var cached = await _readCache(start, end, raplaUrl);
-    if (cached != null && !forceRefresh) {
-      return cached;
-    }
-
-    _scheduleSource.setEndpointUrl(raplaUrl);
-    ScheduleQueryResult scheduleResult;
-    try {
-      scheduleResult =
-          await _scheduleSource.querySchedule(start, end, cancellationToken);
-    } catch (error, trace) {
-      print("Failed to query Rapla schedule");
-      print(error);
-      print(trace);
-      return cached ?? [];
-    }
-
-    var importantEntries = filterImportantEntries(scheduleResult.schedule);
-    var mergedEntries = mergeImportantEntries(importantEntries);
-
-    if (scheduleResult.hasError && mergedEntries.isEmpty) {
-      return cached ?? [];
-    }
-
-    await _writeCache(start, end, raplaUrl, mergedEntries);
-    return mergedEntries;
+  ) async {
+    var schedule = await _scheduleProvider.getCachedSchedule(start, end);
+    return _buildImportantEvents(schedule);
   }
 
-  List<ScheduleEntry> filterImportantEntries(Schedule schedule) {
+  Future<ScheduleQueryResult?> refreshImportantEvents(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken,
+  ) async {
+    if (!await _ensureRaplaSource()) {
+      return null;
+    }
+
+    try {
+      var updatedSchedule = await _scheduleProvider.getUpdatedSchedule(
+        start,
+        end,
+        cancellationToken,
+      );
+      return updatedSchedule;
+    } on OperationCancelledException {
+      return null;
+    } on ScheduleQueryFailedException {
+      return null;
+    }
+  }
+
+  Future<bool> _ensureRaplaSource() async {
+    var raplaUrl = await _preferencesProvider.getRaplaUrl();
+    if (!RaplaScheduleSource.isValidUrl(raplaUrl)) {
+      return false;
+    }
+
+    if (!_scheduleSourceProvider.didSetupCorrectly()) {
+      await _scheduleSourceProvider.setupScheduleSource();
+    }
+    return _scheduleSourceProvider.didSetupCorrectly();
+  }
+
+  static List<ScheduleEntry> filterImportantEntries(Schedule schedule) {
     var filteredEntries = schedule.entries
         .where((entry) => _isImportantEntry(entry))
         .toList(growable: false);
     return _dedupeEntries(filteredEntries);
   }
 
-  bool _isImportantEntry(ScheduleEntry entry) {
+  static bool _isImportantEntry(ScheduleEntry entry) {
     return entry.type == ScheduleEntryType.Exam ||
         entry.type == ScheduleEntryType.PublicHoliday ||
         entry.type == ScheduleEntryType.SpecialEvent;
   }
 
-  Future<List<ImportantEvent>?> _readCache(
-    DateTime start,
-    DateTime end,
-    String raplaUrl,
-  ) async {
-    try {
-      var cacheJson = await _preferencesProvider.getRaplaImportantEventsCache();
-      if (cacheJson == null || cacheJson.isEmpty) return null;
-
-      var decoded = jsonDecode(cacheJson) as Map<String, dynamic>;
-      var cacheStart = DateTime.parse(decoded['start'] as String);
-      var cacheEnd = DateTime.parse(decoded['end'] as String);
-      var cacheUrl = decoded['raplaUrl'] as String?;
-      if (cacheUrl == null || cacheUrl != raplaUrl) {
-        return null;
-      }
-      if (!_isSameMoment(cacheStart, start) || !_isSameMoment(cacheEnd, end)) {
-        return null;
-      }
-
-      var events = (decoded['events'] as List<dynamic>)
-          .map(
-              (event) => ImportantEvent.fromJson(event as Map<String, dynamic>))
-          .toList(growable: false);
-      return events;
-    } catch (_) {
-      return null;
-    }
-  }
-
-  Future<void> _writeCache(
-    DateTime start,
-    DateTime end,
-    String raplaUrl,
-    List<ImportantEvent> events,
-  ) async {
-    var payload = {
-      'start': start.toIso8601String(),
-      'end': end.toIso8601String(),
-      'raplaUrl': raplaUrl,
-      'storedAt': DateTime.now().toIso8601String(),
-      'events': events.map((event) => event.toJson()).toList(growable: false),
-    };
-
-    await _preferencesProvider
-        .setRaplaImportantEventsCache(jsonEncode(payload));
-  }
-
-  bool _isSameMoment(DateTime first, DateTime second) {
-    return first.isAtSameMomentAs(second);
-  }
-
-  List<ScheduleEntry> _dedupeEntries(List<ScheduleEntry> entries) {
+  static List<ScheduleEntry> _dedupeEntries(List<ScheduleEntry> entries) {
     var seenKeys = <String>{};
     var result = <ScheduleEntry>[];
 
@@ -137,7 +92,8 @@ class RaplaImportantEventsProvider {
     return result;
   }
 
-  List<ImportantEvent> mergeImportantEntries(List<ScheduleEntry> entries) {
+  static List<ImportantEvent> mergeImportantEntries(
+      List<ScheduleEntry> entries) {
     if (entries.isEmpty) return [];
 
     var grouped = <String, List<ScheduleEntry>>{};
@@ -203,7 +159,7 @@ class RaplaImportantEventsProvider {
     return mergedEntries;
   }
 
-  bool _shouldMerge(
+  static bool _shouldMerge(
     ScheduleEntry entry,
     String currentTitle,
     ScheduleEntryType currentType,
@@ -215,5 +171,10 @@ class RaplaImportantEventsProvider {
 
     var entryDate = toStartOfDay(entry.start);
     return isAtSameDay(entryDate, addDays(currentEnd, 1));
+  }
+
+  List<ImportantEvent> _buildImportantEvents(Schedule schedule) {
+    var importantEntries = filterImportantEntries(schedule);
+    return mergeImportantEntries(importantEntries);
   }
 }

--- a/lib/date_management/ui/date_management_page.dart
+++ b/lib/date_management/ui/date_management_page.dart
@@ -22,6 +22,8 @@ class DateManagementPage extends StatefulWidget {
 }
 
 class _DateManagementPageState extends State<DateManagementPage> {
+  final ScrollController _raplaScrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
@@ -30,6 +32,12 @@ class _DateManagementPageState extends State<DateManagementPage> {
           Provider.of<DateManagementViewModel>(context, listen: false);
       viewModel.reloadUseDhMineSetting();
     });
+  }
+
+  @override
+  void dispose() {
+    _raplaScrollController.dispose();
+    super.dispose();
   }
 
   @override
@@ -42,15 +50,20 @@ class _DateManagementPageState extends State<DateManagementPage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          DateFilterOptions(viewModel: viewModel),
+          if (viewModel.useDhMineForDates)
+            DateFilterOptions(viewModel: viewModel),
           Stack(
             children: <Widget>[
               const Divider(),
               AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 200),
-                  child: viewModel.isLoading
-                      ? const LinearProgressIndicator()
-                      : Container()),
+                duration: const Duration(milliseconds: 200),
+                child: (viewModel.isLoading ||
+                        (!viewModel.useDhMineForDates &&
+                            viewModel.isLoadingNextRaplaPage &&
+                            viewModel.importantEventSections.isEmpty))
+                    ? const LinearProgressIndicator()
+                    : Container(),
+              ),
             ],
           ),
           _buildBody(viewModel, context),
@@ -63,27 +76,18 @@ class _DateManagementPageState extends State<DateManagementPage> {
     return Expanded(
       child: Stack(
         children: <Widget>[
-          SingleChildScrollView(
-            scrollDirection: Axis.vertical,
-            child: PropertyChangeConsumer<DateManagementViewModel, String>(
-              builder: (
-                BuildContext context,
-                DateManagementViewModel? model,
-                Set<String>? properties,
-              ) {
-                if (model == null) return Container();
-                return AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 200),
-                  child: Column(
-                    key: ValueKey(viewModel.dateSearchParameters.toString()),
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      _buildContent(model, context),
-                    ],
-                  ),
-                );
-              },
-            ),
+          PropertyChangeConsumer<DateManagementViewModel, String>(
+            builder: (
+              BuildContext context,
+              DateManagementViewModel? model,
+              Set<String>? properties,
+            ) {
+              if (model == null) return Container();
+              return AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                child: _buildContent(model, context),
+              );
+            },
           ),
           Align(
             child: buildErrorDisplay(context),
@@ -184,39 +188,105 @@ class _DateManagementPageState extends State<DateManagementPage> {
       );
     }
 
-    return _buildImportantEventsList(model.importantEventSections, context);
+    return _buildImportantEventsList(model, context);
   }
 
   Widget _buildImportantEventsList(
-    List<ImportantEventSection> sections,
+    DateManagementViewModel model,
     BuildContext context,
   ) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        if (sections.isEmpty)
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: Center(
+    var sections = model.importantEventSections;
+    if (sections.isEmpty) {
+      _scheduleRaplaAutoload(model);
+      return ListView(
+        controller: _raplaScrollController,
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (!model.isLoading && !model.isLoadingNextRaplaPage)
+            Center(
               child: Text(
                 L.of(context).dateManagementRaplaEmpty,
               ),
             ),
-          )
-        else
-          ListView.separated(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            itemBuilder: (context, index) {
-              var section = sections[index];
-              return _buildSectionCard(section, context);
-            },
-            separatorBuilder: (context, index) => const SizedBox(height: 12),
-            itemCount: sections.length,
-          ),
-      ],
+          _buildRaplaFooter(model, context),
+        ],
+      );
+    }
+
+    var itemCount = sections.length + 1;
+    _scheduleRaplaAutoload(model);
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification.metrics.pixels >=
+            notification.metrics.maxScrollExtent - 200) {
+          model.loadNextRaplaPage();
+        }
+        return false;
+      },
+      child: ListView.separated(
+        controller: _raplaScrollController,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        itemBuilder: (context, index) {
+          if (index < sections.length) {
+            return _buildSectionCard(sections[index], context);
+          }
+          return _buildRaplaFooter(model, context);
+        },
+        separatorBuilder: (context, index) => const SizedBox(height: 12),
+        itemCount: itemCount,
+      ),
     );
+  }
+
+  void _scheduleRaplaAutoload(DateManagementViewModel model) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (!_raplaScrollController.hasClients) return;
+      if (model.isLoadingNextRaplaPage ||
+          model.nextRaplaPageFailed ||
+          !model.hasMoreRaplaPages) {
+        return;
+      }
+
+      final position = _raplaScrollController.position;
+      if (position.maxScrollExtent <= 0 ||
+          position.pixels >= position.maxScrollExtent - 200) {
+        model.loadNextRaplaPage();
+      }
+    });
+  }
+
+  Widget _buildRaplaFooter(
+    DateManagementViewModel model,
+    BuildContext context,
+  ) {
+    if (model.isLoadingNextRaplaPage) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 12),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (model.nextRaplaPageFailed) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        child: Center(
+          child: TextButton(
+            onPressed: model.loadNextRaplaPage,
+            child: const Text("Retry"),
+          ),
+        ),
+      );
+    }
+
+    if (!model.hasMoreRaplaPages) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 12),
+        child: Center(child: Text("No more events")),
+      );
+    }
+
+    return const SizedBox(height: 12);
   }
 
   Widget _buildSectionCard(

--- a/lib/date_management/ui/date_management_page.dart
+++ b/lib/date_management/ui/date_management_page.dart
@@ -273,16 +273,16 @@ class _DateManagementPageState extends State<DateManagementPage> {
         child: Center(
           child: TextButton(
             onPressed: model.loadNextRaplaPage,
-            child: const Text("Retry"),
+            child: Text(L.of(context).retry),
           ),
         ),
       );
     }
 
     if (!model.hasMoreRaplaPages) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(vertical: 12),
-        child: Center(child: Text("No more events")),
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        child: Center(child: Text(L.of(context).noMoreEvents)),
       );
     }
 

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -761,10 +761,22 @@ class DateManagementViewModel extends BaseViewModel {
   }
 
   DateTime _addMonths(DateTime dateTime, int monthsToAdd) {
+    var monthIndex = dateTime.month - 1 + monthsToAdd;
+    var targetYear = dateTime.year + (monthIndex ~/ 12);
+    var targetMonth = (monthIndex % 12) + 1;
+    if (targetMonth <= 0) {
+      targetYear -= 1;
+      targetMonth += 12;
+    }
+    var lastDayOfTargetMonth = DateTime(targetYear, targetMonth + 1, 0).day;
+    var targetDay = dateTime.day < lastDayOfTargetMonth
+        ? dateTime.day
+        : lastDayOfTargetMonth;
+
     return DateTime(
-      dateTime.year,
-      dateTime.month + monthsToAdd,
-      dateTime.day,
+      targetYear,
+      targetMonth,
+      targetDay,
       dateTime.hour,
       dateTime.minute,
       dateTime.second,

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -8,13 +8,16 @@ import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/date_management/business/date_entry_provider.dart';
 import 'package:dualmate/date_management/business/important_event_organizer.dart';
 import 'package:dualmate/date_management/business/rapla_important_events_provider.dart';
+import 'package:dualmate/date_management/model/date_range.dart';
 import 'package:dualmate/date_management/model/date_database.dart';
 import 'package:dualmate/date_management/model/date_entry.dart';
 import 'package:dualmate/date_management/model/date_search_parameters.dart';
 import 'package:dualmate/date_management/model/important_event.dart';
 import 'package:dualmate/date_management/model/important_event_section.dart';
+import 'package:dualmate/schedule/ui/viewmodels/schedule_freshness_gate.dart';
 import 'package:dualmate/schedule/service/rapla/rapla_schedule_source.dart';
 import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
 
 class DateManagementViewModel extends BaseViewModel {
   final DateEntryProvider _dateEntryProvider;
@@ -115,6 +118,20 @@ class DateManagementViewModel extends BaseViewModel {
   bool _raplaUrlValid = true;
   bool get raplaUrlValid => _raplaUrlValid;
 
+  final Map<String, ScheduleFreshnessGate> _raplaFreshnessGates = {};
+  final List<DateRange> _loadedRaplaWindows = <DateRange>[];
+  DateRange? _nextRaplaWindow;
+  DateRange? _cachedRaplaWindowEnd;
+  bool _hasMoreRaplaPages = true;
+  bool get hasMoreRaplaPages => _hasMoreRaplaPages;
+  DateTime? _lastRaplaPageRequestAt;
+  final Duration _raplaPageCooldown = const Duration(seconds: 30);
+  DateTime? _lastNonHolidayEventEnd;
+  bool _isLoadingNextRaplaPage = false;
+  bool get isLoadingNextRaplaPage => _isLoadingNextRaplaPage;
+  bool _nextRaplaPageFailed = false;
+  bool get nextRaplaPageFailed => _nextRaplaPageFailed;
+
   late DateDatabase _currentDateDatabase;
   DateDatabase get currentDateDatabase => _currentDateDatabase;
 
@@ -205,12 +222,16 @@ class DateManagementViewModel extends BaseViewModel {
   }
 
   Future<void> _doUpdateRaplaEvents() async {
-    var raplaEvents = await _readRaplaImportantEvents();
+    _resetRaplaPaging();
+    await _applyCachedRaplaWindows();
+    var raplaEvents = await _readRaplaImportantEventsPage();
     _updateMutex.token.throwIfCancelled();
 
     if (raplaEvents != null) {
       _setImportantEvents(raplaEvents);
     }
+
+    await _prefetchRaplaUntilFilled();
 
     _updateFailed = raplaEvents == null;
     if (updateFailed) {
@@ -224,7 +245,7 @@ class DateManagementViewModel extends BaseViewModel {
     }
   }
 
-  Future<List<ImportantEvent>?> _readRaplaImportantEvents() async {
+  Future<List<ImportantEvent>?> _readRaplaImportantEventsPage() async {
     var raplaUrl = await _preferencesProvider.getRaplaUrl();
     _raplaUrlValid = RaplaScheduleSource.isValidUrl(raplaUrl);
     notifyListeners("raplaUrlValid");
@@ -233,28 +254,17 @@ class DateManagementViewModel extends BaseViewModel {
       return null;
     }
 
-    var now = DateTime.now();
-    var start =
-        _showPassedDates ? DateTime(now.year - 3, now.month, now.day) : now;
-    var end =
-        _showFutureDates ? DateTime(now.year + 3, now.month, now.day) : now;
+    _nextRaplaWindow ??= _buildInitialRaplaWindow();
+    var window = _nextRaplaWindow!;
 
-    if (start.isAfter(end)) {
-      return [];
-    }
-
-    try {
-      var events = await _raplaImportantEventsProvider.getImportantEvents(
-        toStartOfDay(start),
-        toStartOfDay(end).add(const Duration(days: 1)),
-        _updateMutex.token,
-      );
-
-      return events;
-    } on OperationCancelledException {
-    } on ScheduleQueryFailedException {}
-
-    return null;
+    var loaded = await _loadRaplaWindow(
+      window,
+      _updateMutex.token,
+      advanceWindow: true,
+      refresh: false,
+    );
+    _refreshRaplaWindowInBackground(window);
+    return loaded;
   }
 
   Future<void> _refreshRaplaEventsInBackground() async {
@@ -268,25 +278,17 @@ class DateManagementViewModel extends BaseViewModel {
         return;
       }
 
-      var now = DateTime.now();
-      var start =
-          _showPassedDates ? DateTime(now.year - 3, now.month, now.day) : now;
-      var end =
-          _showFutureDates ? DateTime(now.year + 3, now.month, now.day) : now;
-
-      if (start.isAfter(end)) {
-        return;
-      }
-
-      var events = await _raplaImportantEventsProvider.getImportantEvents(
-        toStartOfDay(start),
-        toStartOfDay(end).add(const Duration(days: 1)),
-        CancellationToken(),
-        forceRefresh: true,
-      );
-
-      _setImportantEvents(events);
+      await _refreshRaplaWindowsInBackground();
     } catch (_) {}
+  }
+
+  Future<void> _prefetchRaplaUntilFilled() async {
+    for (var i = 0; i < 3; i++) {
+      if (!_hasMoreRaplaPages) return;
+      if (importantEventSections.isNotEmpty) return;
+
+      await loadNextRaplaPage();
+    }
   }
 
   Future<List<DateEntry>?> _readUpdatedDateEntries() async {
@@ -318,8 +320,53 @@ class DateManagementViewModel extends BaseViewModel {
 
   void _setImportantEvents(List<ImportantEvent> events) {
     _importantEvents = events;
+    _updateLastNonHolidayEventEnd(events);
     _setImportantEventSections();
     notifyListeners("importantEvents");
+  }
+
+  void _appendImportantEvents(DateRange window, List<ImportantEvent> events) {
+    _trackRaplaWindow(window);
+    _importantEvents = _mergeImportantEvents(_importantEvents, events);
+    _updateLastNonHolidayEventEnd(_importantEvents);
+    _setImportantEventSections();
+    notifyListeners("importantEvents");
+  }
+
+  void _replaceImportantEvents(DateRange window, List<ImportantEvent> events) {
+    _trackRaplaWindow(window);
+    _importantEvents = _mergeImportantEvents(_importantEvents, events);
+    _updateLastNonHolidayEventEnd(_importantEvents);
+    _setImportantEventSections();
+    notifyListeners("importantEvents");
+  }
+
+  void _trackRaplaWindow(DateRange window) {
+    if (_loadedRaplaWindows.any((existing) =>
+        existing.start == window.start && existing.end == window.end)) {
+      return;
+    }
+    _loadedRaplaWindows.add(window);
+  }
+
+  List<ImportantEvent> _mergeImportantEvents(
+    List<ImportantEvent> existing,
+    List<ImportantEvent> incoming,
+  ) {
+    var combined = <ImportantEvent>[...existing, ...incoming];
+    var seenKeys = <String>{};
+    var deduped = <ImportantEvent>[];
+
+    for (var event in combined) {
+      var key =
+          '${event.title}-${event.type}-${event.start.toIso8601String()}-${event.end.toIso8601String()}';
+      if (seenKeys.add(key)) {
+        deduped.add(event);
+      }
+    }
+
+    deduped.sort((a, b) => a.start.compareTo(b.start));
+    return deduped;
   }
 
   void _setImportantEventSections() {
@@ -347,8 +394,10 @@ class DateManagementViewModel extends BaseViewModel {
     notifyListeners("showPassedDates");
 
     if (!_useDhMineForDates) {
-      updateDates();
+      return;
     }
+
+    updateDates();
   }
 
   void setShowFutureDates(bool value) {
@@ -356,16 +405,20 @@ class DateManagementViewModel extends BaseViewModel {
     notifyListeners("showFutureDates");
 
     if (!_useDhMineForDates) {
-      updateDates();
+      return;
     }
+
+    updateDates();
   }
 
   void setShowOutOfStudyEvents(bool value) {
     _showOutOfStudyEvents = value;
     notifyListeners("showOutOfStudyEvents");
     if (!_useDhMineForDates) {
-      _setImportantEventSections();
+      return;
     }
+
+    _setImportantEventSections();
   }
 
   void setCurrentDateDatabase(DateDatabase database) {
@@ -408,6 +461,313 @@ class DateManagementViewModel extends BaseViewModel {
     }
 
     await updateDates();
+  }
+
+  DateRange _buildInitialRaplaWindow() {
+    var start = toStartOfDay(DateTime.now());
+    return DateRange(start: start, end: _addMonths(start, 3));
+  }
+
+  DateRange _nextRaplaWindowFrom(DateRange current) {
+    var nextStart = current.end;
+    return DateRange(start: nextStart, end: _addMonths(nextStart, 3));
+  }
+
+  DateTime _maxRaplaEndDate() {
+    var now = DateTime.now();
+    var maxEnd = DateTime(
+      now.year + 3,
+      now.month,
+      now.day,
+      now.hour,
+      now.minute,
+      now.second,
+    );
+
+    if (_lastNonHolidayEventEnd == null) {
+      return maxEnd;
+    }
+
+    var nonHolidayCutoff = addDays(
+      toStartOfDay(_lastNonHolidayEventEnd!),
+      365,
+    );
+
+    return nonHolidayCutoff.isBefore(maxEnd) ? nonHolidayCutoff : maxEnd;
+  }
+
+  void _updateLastNonHolidayEventEnd(List<ImportantEvent> events) {
+    DateTime? lastEnd;
+    for (var event in events) {
+      if (event.type == ScheduleEntryType.PublicHoliday) {
+        continue;
+      }
+      if (lastEnd == null || event.end.isAfter(lastEnd)) {
+        lastEnd = event.end;
+      }
+    }
+
+    _lastNonHolidayEventEnd = lastEnd;
+    _syncRaplaPagingLimit();
+  }
+
+  void _syncRaplaPagingLimit() {
+    if (!_hasMoreRaplaPages) return;
+    if (_nextRaplaWindow == null) return;
+    if (!_nextRaplaWindow!.start.isBefore(_maxRaplaEndDate())) {
+      _hasMoreRaplaPages = false;
+      notifyListeners("hasMoreRaplaPages");
+    }
+  }
+
+  void _resetRaplaPaging() {
+    _loadedRaplaWindows.clear();
+    _nextRaplaWindow = _buildInitialRaplaWindow();
+    _nextRaplaPageFailed = false;
+    _isLoadingNextRaplaPage = false;
+    _cachedRaplaWindowEnd = null;
+    _raplaFreshnessGates.clear();
+    _hasMoreRaplaPages = true;
+    _lastRaplaPageRequestAt = null;
+    _lastNonHolidayEventEnd = null;
+    notifyListeners("hasMoreRaplaPages");
+  }
+
+  Future<void> loadNextRaplaPage() async {
+    if (_useDhMineForDates) return;
+    if (_isLoadingNextRaplaPage) return;
+    if (!_hasMoreRaplaPages) return;
+
+    var now = DateTime.now();
+    if (_lastRaplaPageRequestAt != null &&
+        now.difference(_lastRaplaPageRequestAt!) < _raplaPageCooldown) {
+      return;
+    }
+    _lastRaplaPageRequestAt = now;
+    _nextRaplaWindow ??= _buildInitialRaplaWindow();
+    var maxEnd = _maxRaplaEndDate();
+    if (!_nextRaplaWindow!.start.isBefore(maxEnd)) {
+      _hasMoreRaplaPages = false;
+      notifyListeners("hasMoreRaplaPages");
+      return;
+    }
+
+    _isLoadingNextRaplaPage = true;
+    _nextRaplaPageFailed = false;
+    notifyListeners("isLoadingNextRaplaPage");
+    notifyListeners("nextRaplaPageFailed");
+
+    var window = _nextRaplaWindow!;
+
+    try {
+      var beforeCount = importantEvents.length;
+      var windowToLoad = window;
+      if (windowToLoad.end.isAfter(maxEnd)) {
+        windowToLoad = DateRange(start: windowToLoad.start, end: maxEnd);
+      }
+      var loaded = await _loadRaplaWindow(
+        windowToLoad,
+        CancellationToken(),
+        advanceWindow: true,
+        refresh: true,
+      );
+      if (loaded == null) {
+        _nextRaplaPageFailed = true;
+        notifyListeners("nextRaplaPageFailed");
+      } else {
+        var afterCount = importantEvents.length;
+        if (afterCount == beforeCount) {
+          _hasMoreRaplaPages = false;
+          notifyListeners("hasMoreRaplaPages");
+        }
+      }
+    } finally {
+      _isLoadingNextRaplaPage = false;
+      notifyListeners("isLoadingNextRaplaPage");
+    }
+  }
+
+  Future<List<ImportantEvent>?> _loadRaplaWindow(
+    DateRange window,
+    CancellationToken token, {
+    required bool advanceWindow,
+    required bool refresh,
+  }) async {
+    try {
+      var cached = await _raplaImportantEventsProvider.getCachedImportantEvents(
+        toStartOfDay(window.start),
+        toStartOfDay(window.end).add(const Duration(days: 1)),
+      );
+
+      if (cached.isNotEmpty) {
+        _appendImportantEvents(window, cached);
+      }
+
+      if (refresh) {
+        await _refreshRaplaWindow(window, token);
+      }
+
+      if (advanceWindow) {
+        var next = _nextRaplaWindowFrom(window);
+        var maxEnd = _maxRaplaEndDate();
+        if (!next.start.isBefore(maxEnd)) {
+          _hasMoreRaplaPages = false;
+          notifyListeners("hasMoreRaplaPages");
+        } else {
+          _nextRaplaWindow = next;
+        }
+      }
+
+      await _recordRaplaWindowEnd(window);
+
+      return importantEvents;
+    } on OperationCancelledException {
+      return null;
+    } on ScheduleQueryFailedException {
+      return null;
+    }
+  }
+
+  Future<void> _refreshRaplaWindow(
+    DateRange window,
+    CancellationToken token,
+  ) async {
+    if (!_isRaplaWindowStale(window, DateTime.now())) {
+      return;
+    }
+
+    var updated = await _raplaImportantEventsProvider.refreshImportantEvents(
+      toStartOfDay(window.start),
+      toStartOfDay(window.end).add(const Duration(days: 1)),
+      token,
+    );
+
+    if (updated != null) {
+      _markRaplaWindowFetched(window, DateTime.now());
+      var refreshed =
+          await _raplaImportantEventsProvider.getCachedImportantEvents(
+        toStartOfDay(window.start),
+        toStartOfDay(window.end).add(const Duration(days: 1)),
+      );
+      _replaceImportantEvents(window, refreshed);
+    }
+  }
+
+  Future<void> _recordRaplaWindowEnd(DateRange window) async {
+    var cachedEnd =
+        await _preferencesProvider.getRaplaImportantEventsWindowEnd();
+    var currentEnd = cachedEnd == null || cachedEnd.isEmpty
+        ? null
+        : DateTime.tryParse(cachedEnd);
+
+    var maxEnd = _maxRaplaEndDate();
+    var clampedEnd = window.end.isAfter(maxEnd) ? maxEnd : window.end;
+
+    if (currentEnd == null || clampedEnd.isAfter(currentEnd)) {
+      await _preferencesProvider
+          .setRaplaImportantEventsWindowEnd(clampedEnd.toIso8601String());
+      _cachedRaplaWindowEnd = DateRange(
+        start: _buildInitialRaplaWindow().start,
+        end: clampedEnd,
+      );
+    }
+  }
+
+  void _refreshRaplaWindowInBackground(DateRange window) {
+    Future.microtask(() async {
+      await _refreshRaplaWindow(window, CancellationToken());
+    });
+  }
+
+  bool _isRaplaWindowStale(DateRange window, DateTime now) {
+    var gate = _raplaFreshnessGates[_raplaWindowKey(window)];
+    return gate == null || gate.isStale(window.start, window.end, now);
+  }
+
+  void _markRaplaWindowFetched(DateRange window, DateTime now) {
+    var key = _raplaWindowKey(window);
+    var gate = _raplaFreshnessGates[key] ??= ScheduleFreshnessGate();
+    gate.markFetched(window.start, window.end, now);
+  }
+
+  String _raplaWindowKey(DateRange window) {
+    return '${window.start.toIso8601String()}_${window.end.toIso8601String()}';
+  }
+
+  Future<void> _refreshRaplaWindowsInBackground() async {
+    var start = _buildInitialRaplaWindow().start;
+    var end = _cachedRaplaWindowEnd?.end ?? start;
+    var maxEnd = _maxRaplaEndDate();
+    if (end.isAfter(maxEnd)) {
+      end = maxEnd;
+    }
+    if (end.isBefore(start)) {
+      end = start;
+    }
+    var windowStart = start;
+
+    while (windowStart.isBefore(end) || windowStart.isAtSameMomentAs(end)) {
+      var window =
+          DateRange(start: windowStart, end: _addMonths(windowStart, 3));
+      await _refreshRaplaWindow(window, CancellationToken());
+      windowStart = window.end;
+    }
+  }
+
+  Future<void> _applyCachedRaplaWindows() async {
+    var cachedEnd =
+        await _preferencesProvider.getRaplaImportantEventsWindowEnd();
+    if (cachedEnd == null || cachedEnd.isEmpty) {
+      return;
+    }
+
+    var parsed = DateTime.tryParse(cachedEnd);
+    if (parsed == null) {
+      return;
+    }
+
+    var start = _buildInitialRaplaWindow().start;
+    var maxEnd = _maxRaplaEndDate();
+    var end = parsed.isAfter(start) ? parsed : start;
+    if (end.isAfter(maxEnd)) {
+      end = maxEnd;
+    }
+    _cachedRaplaWindowEnd = DateRange(start: start, end: end);
+
+    var windowStart = start;
+    var lastWindowEnd = start;
+    while (windowStart.isBefore(end) || windowStart.isAtSameMomentAs(end)) {
+      var window =
+          DateRange(start: windowStart, end: _addMonths(windowStart, 3));
+      await _loadRaplaWindow(
+        window,
+        _updateMutex.token,
+        advanceWindow: false,
+        refresh: false,
+      );
+      lastWindowEnd = window.end;
+      windowStart = window.end;
+    }
+
+    _nextRaplaWindow = DateRange(
+      start: lastWindowEnd,
+      end: _addMonths(lastWindowEnd, 3),
+    );
+    if (!_nextRaplaWindow!.start.isBefore(maxEnd)) {
+      _hasMoreRaplaPages = false;
+      notifyListeners("hasMoreRaplaPages");
+    }
+  }
+
+  DateTime _addMonths(DateTime dateTime, int monthsToAdd) {
+    return DateTime(
+      dateTime.year,
+      dateTime.month + monthsToAdd,
+      dateTime.day,
+      dateTime.hour,
+      dateTime.minute,
+      dateTime.second,
+    );
   }
 
   void _cancelErrorInFuture() async {

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -335,7 +335,14 @@ class DateManagementViewModel extends BaseViewModel {
 
   void _replaceImportantEvents(DateRange window, List<ImportantEvent> events) {
     _trackRaplaWindow(window);
-    _importantEvents = _mergeImportantEvents(_importantEvents, events);
+    var trimmed = _importantEvents.where((event) {
+      var endsBefore = event.end.isBefore(window.start) ||
+          event.end.isAtSameMomentAs(window.start);
+      var startsAfter = event.start.isAfter(window.end) ||
+          event.start.isAtSameMomentAs(window.end);
+      return endsBefore || startsAfter;
+    }).toList(growable: false);
+    _importantEvents = _mergeImportantEvents(trimmed, events);
     _updateLastNonHolidayEventEnd(_importantEvents);
     _setImportantEventSections();
     notifyListeners("importantEvents");

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -576,7 +576,8 @@ class DateManagementViewModel extends BaseViewModel {
         notifyListeners("nextRaplaPageFailed");
       } else {
         var afterCount = importantEvents.length;
-        if (afterCount == beforeCount) {
+        if (afterCount == beforeCount &&
+            !windowToLoad.end.isBefore(_maxRaplaEndDate())) {
           _hasMoreRaplaPages = false;
           notifyListeners("hasMoreRaplaPages");
         }
@@ -706,7 +707,7 @@ class DateManagementViewModel extends BaseViewModel {
     }
     var windowStart = start;
 
-    while (windowStart.isBefore(end) || windowStart.isAtSameMomentAs(end)) {
+    while (windowStart.isBefore(end)) {
       var window =
           DateRange(start: windowStart, end: _addMonths(windowStart, 3));
       await _refreshRaplaWindow(window, CancellationToken());
@@ -736,7 +737,7 @@ class DateManagementViewModel extends BaseViewModel {
 
     var windowStart = start;
     var lastWindowEnd = start;
-    while (windowStart.isBefore(end) || windowStart.isAtSameMomentAs(end)) {
+    while (windowStart.isBefore(end)) {
       var window =
           DateRange(start: windowStart, end: _addMonths(windowStart, 3));
       await _loadRaplaWindow(

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -421,7 +421,7 @@ class DateManagementViewModel extends BaseViewModel {
   void setShowOutOfStudyEvents(bool value) {
     _showOutOfStudyEvents = value;
     notifyListeners("showOutOfStudyEvents");
-    if (!_useDhMineForDates) {
+    if (_useDhMineForDates) {
       return;
     }
 
@@ -687,7 +687,12 @@ class DateManagementViewModel extends BaseViewModel {
 
   void _refreshRaplaWindowInBackground(DateRange window) {
     Future.microtask(() async {
-      await _refreshRaplaWindow(window, CancellationToken());
+      try {
+        await _refreshRaplaWindow(window, CancellationToken());
+      } catch (error, trace) {
+        print(error);
+        print(trace);
+      }
     });
   }
 

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -287,7 +287,7 @@ class DateManagementViewModel extends BaseViewModel {
       if (!_hasMoreRaplaPages) return;
       if (importantEventSections.isNotEmpty) return;
 
-      await loadNextRaplaPage();
+      await loadNextRaplaPage(bypassCooldown: true);
     }
   }
 
@@ -540,13 +540,14 @@ class DateManagementViewModel extends BaseViewModel {
     notifyListeners("hasMoreRaplaPages");
   }
 
-  Future<void> loadNextRaplaPage() async {
+  Future<void> loadNextRaplaPage({bool bypassCooldown = false}) async {
     if (_useDhMineForDates) return;
     if (_isLoadingNextRaplaPage) return;
     if (!_hasMoreRaplaPages) return;
 
     var now = DateTime.now();
-    if (_lastRaplaPageRequestAt != null &&
+    if (!bypassCooldown &&
+        _lastRaplaPageRequestAt != null &&
         now.difference(_lastRaplaPageRequestAt!) < _raplaPageCooldown) {
       return;
     }
@@ -580,6 +581,9 @@ class DateManagementViewModel extends BaseViewModel {
       );
       if (loaded == null) {
         _nextRaplaPageFailed = true;
+        if (bypassCooldown) {
+          _lastRaplaPageRequestAt = null;
+        }
         notifyListeners("nextRaplaPageFailed");
       } else {
         var afterCount = importantEvents.length;

--- a/lib/schedule/background/background_schedule_update.dart
+++ b/lib/schedule/background/background_schedule_update.dart
@@ -24,7 +24,7 @@ class BackgroundScheduleUpdate extends TaskCallback {
     }
 
     var today = toDayOfWeek(toStartOfDay(DateTime.now()), DateTime.monday);
-    var end = addDays(today, 7 * 3);
+    var end = addDays(today, 14);
 
     var cancellationToken = CancellationToken();
 

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -48,6 +48,8 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       ScheduleUpdateRequestGate();
   final ScheduleFreshnessGate _freshnessGate = ScheduleFreshnessGate();
   Schedule? weekSchedule;
+  final Map<String, ScheduleFreshnessGate> _windowFreshnessGates = {};
+  Timer? _windowRefreshTimer;
 
   String? scheduleUrl;
 
@@ -83,6 +85,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     _setSchedule(cachedSchedule, currentDateStart, currentDateEnd);
     _scheduleInitialRefresh();
     ensureUpdateNowTimerRunning();
+    _ensureWindowRefreshTimer();
 
     scheduleSourceProvider
         .addDidChangeScheduleSourceCallback(_onDidChangeScheduleSource);
@@ -93,6 +96,19 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       if (_isDisposed) return;
       updateSchedule(currentDateStart, currentDateEnd);
     });
+  }
+
+  void _ensureWindowRefreshTimer() {
+    _windowRefreshTimer?.cancel();
+    _windowRefreshTimer = Timer.periodic(
+        const Duration(minutes: 15), (_) => _refreshWidgetRange());
+  }
+
+  Future<void> _refreshWidgetRange() async {
+    if (_isDisposed) return;
+    var start = toStartOfDay(DateTime.now());
+    var end = addDays(start, 14);
+    await updateSchedule(start, end, force: true);
   }
 
   Future<void> _onDidChangeScheduleSource(
@@ -249,7 +265,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     _setSchedule(cachedSchedule, start, end);
 
     final now = DateTime.now();
-    final isStale = _freshnessGate.isStale(start, end, now);
+    final shouldForceFetch = cachedSchedule.entries.isEmpty &&
+        scheduleSourceProvider.currentScheduleSource.canQuery();
+    final isStale = shouldForceFetch ||
+        _freshnessGate.isStale(start, end, now) ||
+        _isWindowStale(start, end, now);
 
     if (!isStale) {
       print("Schedule fresh; skip network fetch");
@@ -264,6 +284,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         cancellationToken,
       );
       _freshnessGate.markFetched(start, end, DateTime.now());
+      _markWindowFetched(start, end, DateTime.now());
     } catch (e) {
       print("Schedule update failed: $e");
     }
@@ -338,6 +359,21 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
   }
 
+  bool _isWindowStale(DateTime start, DateTime end, DateTime now) {
+    var gate = _windowFreshnessGates[_windowKey(start, end)];
+    return gate == null || gate.isStale(start, end, now);
+  }
+
+  void _markWindowFetched(DateTime start, DateTime end, DateTime now) {
+    var key = _windowKey(start, end);
+    var gate = _windowFreshnessGates[key] ??= ScheduleFreshnessGate();
+    gate.markFetched(start, end, now);
+  }
+
+  String _windowKey(DateTime start, DateTime end) {
+    return '${start.toIso8601String()}_${end.toIso8601String()}';
+  }
+
   @override
   void dispose() {
     _isDisposed = true;
@@ -345,6 +381,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     _updateMutex.cancel();
 
     _updateNowTimer?.cancel();
+    _windowRefreshTimer?.cancel();
 
     _errorResetTimer?.cancel();
 

--- a/test/date_management/business/rapla_important_events_provider_test.dart
+++ b/test/date_management/business/rapla_important_events_provider_test.dart
@@ -1,38 +1,7 @@
-import 'package:dualmate/common/data/preferences/preferences_provider.dart';
-import 'package:dualmate/common/data/preferences/preferences_access.dart';
-import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
 import 'package:dualmate/date_management/business/rapla_important_events_provider.dart';
 import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:test/test.dart';
-
-class FakePreferencesAccess extends PreferencesAccess {
-  final Map<String, Object?> _values = {};
-
-  @override
-  Future<void> set<T>(String key, T value) async {
-    _values[key] = value;
-  }
-
-  @override
-  Future<T?> get<T>(String key) async {
-    return _values[key] as T?;
-  }
-}
-
-class FakeSecureStorageAccess extends SecureStorageAccess {
-  final Map<String, String> _values = {};
-
-  @override
-  Future<String?> get(String key) async {
-    return _values[key];
-  }
-
-  @override
-  Future<void> set(String key, String value) async {
-    _values[key] = value;
-  }
-}
 
 void main() {
   test('Filters only important entry types', () {
@@ -204,9 +173,4 @@ void main() {
 
     expect(filtered.length, 1);
   });
-}
-
-PreferencesProvider _buildPreferencesProvider() {
-  return PreferencesProvider(
-      FakePreferencesAccess(), FakeSecureStorageAccess());
 }

--- a/test/date_management/business/rapla_important_events_provider_test.dart
+++ b/test/date_management/business/rapla_important_events_provider_test.dart
@@ -36,7 +36,6 @@ class FakeSecureStorageAccess extends SecureStorageAccess {
 
 void main() {
   test('Filters only important entry types', () {
-    var provider = RaplaImportantEventsProvider(_buildPreferencesProvider());
     var schedule = Schedule.fromList([
       ScheduleEntry(
         start: DateTime(2026, 7, 27, 8),
@@ -76,7 +75,8 @@ void main() {
       ),
     ]);
 
-    var filtered = provider.filterImportantEntries(schedule);
+    var filtered =
+        RaplaImportantEventsProvider.filterImportantEntries(schedule);
 
     expect(filtered.length, 3);
     expect(
@@ -86,7 +86,6 @@ void main() {
   });
 
   test('Merges consecutive same-title events', () {
-    var provider = RaplaImportantEventsProvider(_buildPreferencesProvider());
     var entries = [
       ScheduleEntry(
         start: DateTime(2026, 7, 27, 7),
@@ -117,7 +116,7 @@ void main() {
       ),
     ];
 
-    var merged = provider.mergeImportantEntries(entries);
+    var merged = RaplaImportantEventsProvider.mergeImportantEntries(entries);
 
     expect(merged.length, 1);
     expect(merged.first.start, DateTime(2026, 7, 27, 7));
@@ -125,7 +124,6 @@ void main() {
   });
 
   test('Keeps separate events when there is a gap', () {
-    var provider = RaplaImportantEventsProvider(_buildPreferencesProvider());
     var entries = [
       ScheduleEntry(
         start: DateTime(2026, 7, 27, 7),
@@ -147,13 +145,12 @@ void main() {
       ),
     ];
 
-    var merged = provider.mergeImportantEntries(entries);
+    var merged = RaplaImportantEventsProvider.mergeImportantEntries(entries);
 
     expect(merged.length, 2);
   });
 
   test('Does not merge exams across days', () {
-    var provider = RaplaImportantEventsProvider(_buildPreferencesProvider());
     var entries = [
       ScheduleEntry(
         start: DateTime(2026, 7, 27, 7),
@@ -175,13 +172,12 @@ void main() {
       ),
     ];
 
-    var merged = provider.mergeImportantEntries(entries);
+    var merged = RaplaImportantEventsProvider.mergeImportantEntries(entries);
 
     expect(merged.length, 2);
   });
 
   test('Deduplicates identical entries', () {
-    var provider = RaplaImportantEventsProvider(_buildPreferencesProvider());
     var schedule = Schedule.fromList([
       ScheduleEntry(
         start: DateTime(2026, 7, 27, 9),
@@ -203,12 +199,14 @@ void main() {
       ),
     ]);
 
-    var filtered = provider.filterImportantEntries(schedule);
+    var filtered =
+        RaplaImportantEventsProvider.filterImportantEntries(schedule);
 
     expect(filtered.length, 1);
   });
 }
 
 PreferencesProvider _buildPreferencesProvider() {
-  return PreferencesProvider(FakePreferencesAccess(), FakeSecureStorageAccess());
+  return PreferencesProvider(
+      FakePreferencesAccess(), FakeSecureStorageAccess());
 }


### PR DESCRIPTION
- Refactor DateManagementViewModel to implement pagination for Rapla events, loading data in 3-month windows.
- Replace the custom JSON cache with a shared schedule cache to ensure consistency between schedule and events.
- Introduce a loading footer and retry mechanism for failed pages.
- Optimize the initial load to fetch cached results immediately and prefetch additional pages on first open.
- Enhance the UI to remove nested scrolls, using a single ListView for better performance.
- Implement freshness gates for individual windows to manage data staleness effectively.
- Update tests to reflect changes in the caching and loading behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rapla events now load in 3‑month pages with on‑scroll incremental loading, loading footer, and per‑page retry.

* **Bug Fixes**
  * Fixed Rapla events not loading on first schedule open; date selector hidden and only future events shown.

* **Performance**
  * Rapla now reuses the central schedule cache with freshness gating for fewer duplicate fetches, faster initial render, and background refreshes.

* **Documentation**
  * Added docs detailing Rapla cache, paging, refresh behavior, and UI mitigation.

* **Localization**
  * Added "Retry" and "No more events" strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->