### PR TITLE
fix: apply schedule filters immediately in weekly calendar

### DIFF
--- a/docs/solutions/ui-bugs/filters-dont-apply-calendar-without-interaction-20260209.md
+++ b/docs/solutions/ui-bugs/filters-dont-apply-calendar-without-interaction-20260209.md
@@ -1,0 +1,51 @@
+---
+module: Schedule UI
+date: 2026-02-09
+problem_type: ui_bug
+component: frontend_flutter
+symptoms:
+  - "Changing schedule filters does not update the weekly calendar immediately"
+  - "Filtered lessons disappear only after swiping weeks or switching pages"
+root_cause: refresh_gate
+resolution_type: code_fix
+severity: medium
+tags: [schedule, filter, refresh, weekly-calendar, flutter]
+---
+
+# Troubleshooting: Schedule filters not applied immediately in weekly calendar
+
+## Problem
+After changing lesson visibility in the filter screen, the weekly calendar did not refresh in place. Users had to trigger another interaction (like swiping to another week) before filtered entries were reflected.
+
+## Environment
+- Module: Schedule UI
+- Rails Version: N/A (Flutter)
+- Affected Component: Weekly schedule refresh flow
+- Date: 2026-02-09
+
+## Symptoms
+- Filter toggles are saved, but the current weekly view still shows now-hidden lessons.
+- Manual navigation then shows the expected filtered result.
+
+## Root Cause
+The weekly view refresh path used throttling intended for repeated same-range requests. Filter-triggered source-change refreshes could be treated like normal repeated requests and skipped before re-reading cached (filtered) entries.
+
+## Solution
+- Added a `force` override to `ScheduleUpdateRequestGate.shouldAllow(...)`.
+- Updated `WeeklyScheduleViewModel.updateSchedule(...)` to pass the `force` flag into the gate.
+- Updated schedule-source-change handling in `WeeklyScheduleViewModel` to call `updateSchedule(..., force: true)`.
+- Made filter apply flow awaitable and awaited it in `WillPopScope` to ensure filter persistence and refresh are triggered in order.
+
+## Test Coverage
+- Added a regression test in `test/schedule/ui/viewmodels/schedule_update_request_gate_test.dart`:
+  - `allows same range within interval when forced`
+
+This verifies forced refresh requests bypass throttle protection, which is required for immediate refresh after filter changes.
+
+## Commands run
+```bash
+flutter test test/schedule/ui/viewmodels/schedule_update_request_gate_test.dart
+```
+
+## Why This Works
+Filter changes should always trigger a refresh of the currently visible week, even if that week was just requested moments before. The forced path preserves normal throttling for regular traffic while guaranteeing a deterministic immediate refresh for filter/source-change events.

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -207,6 +207,7 @@ final de = {
   "filterDescription":
       "Wähle hier die Vorlesungen, die angezeigt werden sollen. Pass auf, dass Du keine ausgeblendete Vorlesung versehentlich verpasst.",
   "filterTitle": "Filter",
+  "filterSaveError": "Filter konnten nicht gespeichert werden",
   "canteenFilterAll": "Alle Gerichte",
   "canteenFilterNoPork": "Ohne Schwein",
   "canteenFilterVegetarian": "Vegetarisch",

--- a/lib/common/i18n/localization_strings_en.dart
+++ b/lib/common/i18n/localization_strings_en.dart
@@ -193,6 +193,7 @@ final en = {
   "filterDescription":
       "Select the classes which sould be displayed. Be careful not to accidentally miss a hidden lecture",
   "filterTitle": "Filter",
+  "filterSaveError": "Could not save filters",
   "canteenFilterAll": "All meals",
   "canteenFilterNoPork": "Without pork",
   "canteenFilterVegetarian": "Vegetarian",

--- a/lib/common/i18n/localizations.dart
+++ b/lib/common/i18n/localizations.dart
@@ -449,6 +449,7 @@ class L {
   String get filterDisplayedClasses => _getValue("filterDisplayedClasses");
   String get filterDescription => _getValue("filterDescription");
   String get filterTitle => _getValue("filterTitle");
+  String get filterSaveError => _getValue("filterSaveError");
 
   String get canteenFilterAll => _getValue("canteenFilterAll");
   String get canteenFilterNoPork => _getValue("canteenFilterNoPork");

--- a/lib/schedule/ui/viewmodels/schedule_update_request_gate.dart
+++ b/lib/schedule/ui/viewmodels/schedule_update_request_gate.dart
@@ -8,7 +8,19 @@ class ScheduleUpdateRequestGate {
     this.minInterval = const Duration(milliseconds: 300),
   });
 
-  bool shouldAllow(DateTime start, DateTime end, DateTime now) {
+  bool shouldAllow(
+    DateTime start,
+    DateTime end,
+    DateTime now, {
+    bool force = false,
+  }) {
+    if (force) {
+      _lastRequestAt = now;
+      _lastStart = start;
+      _lastEnd = end;
+      return true;
+    }
+
     final isSameRange = _lastStart != null &&
         _lastEnd != null &&
         _lastStart == start &&

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -189,7 +189,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       try {
         await Future.delayed(const Duration(milliseconds: 500));
         if (_isDisposed) return;
-        await updateSchedule(currentDateStart, currentDateEnd);
+        await updateSchedule(currentDateStart, currentDateEnd, force: true);
       } catch (error, trace) {
         print("Weekly schedule source refresh failed: $error");
         print(trace);
@@ -289,7 +289,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
 
     var now = DateTime.now();
-    if (!force && !_updateRequestGate.shouldAllow(start, end, now)) {
+    if (!_updateRequestGate.shouldAllow(start, end, now, force: force)) {
       return;
     }
 

--- a/lib/schedule/ui/weeklyschedule/filter/filter_view_model.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/filter_view_model.dart
@@ -37,7 +37,7 @@ class FilterViewModel extends BaseViewModel {
     notifyIfMounted("filterStates");
   }
 
-  void applyFilter() async {
+  Future<void> applyFilter() async {
     var allFilteredNames = filterStates
         .where((element) => !element.isDisplayed)
         .map((e) => e.entryName)

--- a/lib/schedule/ui/weeklyschedule/filter/filter_view_model.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/filter_view_model.dart
@@ -4,6 +4,24 @@ import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
 
+class FilterValidationException implements Exception {
+  final String message;
+
+  FilterValidationException(this.message);
+
+  @override
+  String toString() => 'FilterValidationException: $message';
+}
+
+class FilterSaveException implements Exception {
+  final Object innerException;
+
+  FilterSaveException(this.innerException);
+
+  @override
+  String toString() => 'FilterSaveException: $innerException';
+}
+
 class FilterViewModel extends BaseViewModel {
   final ScheduleEntryRepository _scheduleEntryRepository;
   final ScheduleFilterRepository _scheduleFilterRepository;
@@ -43,10 +61,23 @@ class FilterViewModel extends BaseViewModel {
         .map((e) => e.entryName)
         .toList();
 
-    await _scheduleFilterRepository.saveAllHiddenNames(allFilteredNames);
+    if (allFilteredNames.any((name) => name.trim().isEmpty)) {
+      throw FilterValidationException("Filter entry names must not be empty");
+    }
 
-    _scheduleProvider.invalidateScheduleCache();
-    _scheduleSource.fireScheduleSourceChanged();
+    final uniqueNames = allFilteredNames.toSet();
+    if (uniqueNames.length != allFilteredNames.length) {
+      throw FilterValidationException("Filter entry names must be unique");
+    }
+
+    try {
+      await _scheduleFilterRepository.saveAllHiddenNames(allFilteredNames);
+
+      _scheduleProvider.invalidateScheduleCache();
+      _scheduleSource.fireScheduleSourceChanged();
+    } catch (e) {
+      throw FilterSaveException(e);
+    }
   }
 }
 

--- a/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
@@ -18,12 +18,28 @@ class ScheduleFilterPage extends StatelessWidget {
       onWillPop: () async {
         try {
           await _viewModel.applyFilter();
+        } on FilterValidationException catch (e, trace) {
+          debugPrint('Failed to validate schedule filter: $e');
+          debugPrint('$trace');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(L.of(context).filterSaveError),
+            ),
+          );
+        } on FilterSaveException catch (e, trace) {
+          debugPrint('Failed to persist schedule filter: $e');
+          debugPrint('$trace');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(L.of(context).filterSaveError),
+            ),
+          );
         } catch (e, trace) {
           debugPrint('Failed to apply schedule filter: $e');
           debugPrint('$trace');
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Failed to save filters'),
+            SnackBar(
+              content: Text(L.of(context).filterSaveError),
             ),
           );
         }

--- a/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
@@ -16,7 +16,17 @@ class ScheduleFilterPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {
-        await _viewModel.applyFilter();
+        try {
+          await _viewModel.applyFilter();
+        } catch (e, trace) {
+          debugPrint('Failed to apply schedule filter: $e');
+          debugPrint('$trace');
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Failed to save filters'),
+            ),
+          );
+        }
         return true;
       },
       child: Scaffold(

--- a/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
@@ -16,7 +16,7 @@ class ScheduleFilterPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {
-        _viewModel.applyFilter();
+        await _viewModel.applyFilter();
         return true;
       },
       child: Scaffold(

--- a/test/schedule/ui/viewmodels/schedule_update_request_gate_test.dart
+++ b/test/schedule/ui/viewmodels/schedule_update_request_gate_test.dart
@@ -61,4 +61,24 @@ void main() {
       isTrue,
     );
   });
+
+  test('allows same range within interval when forced', () {
+    final gate = ScheduleUpdateRequestGate(
+      minInterval: const Duration(milliseconds: 300),
+    );
+    final start = DateTime(2026, 1, 27);
+    final end = DateTime(2026, 2, 3);
+    final now = DateTime(2026, 1, 27, 12, 0, 0, 0);
+
+    expect(gate.shouldAllow(start, end, now), isTrue);
+    expect(
+      gate.shouldAllow(
+        start,
+        end,
+        now.add(const Duration(milliseconds: 150)),
+        force: true,
+      ),
+      isTrue,
+    );
+  });
 }


### PR DESCRIPTION
fix #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule filters now apply immediately to the calendar when changed, without requiring extra interaction.
  * Saving filter changes is now awaited; failures surface a visible error message ("Failed to save filters") so users are informed if persistence fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->