### PR TITLE
fix: constrain canteen swipe bounds and add overscroll indicator

### DIFF
--- a/docs/plans/2026-02-10-fix-canteen-swipe-bounds-and-overscroll-plan.md
+++ b/docs/plans/2026-02-10-fix-canteen-swipe-bounds-and-overscroll-plan.md
@@ -1,0 +1,130 @@
+---
+title: fix: canteen swipe bounds and overscroll indicator
+type: fix
+date: 2026-02-10
+---
+
+# fix: canteen swipe bounds and overscroll indicator
+
+## Overview
+🐛 The canteen page currently allows horizontal paging across an effectively unbounded weekday timeline, which exposes many empty days. Because the canteen source removes past menus and some future days/weeks also have no meals, users repeatedly land on empty states that are not actionable.
+
+This plan constrains navigation to days with actual meal content and adds a visible overscroll affordance at both boundaries (past and future) using `StretchingOverscrollIndicator`.
+
+## Problem Statement / Motivation
+- `PageView.builder` in `lib/canteen/ui/canteen_page.dart:131` is unbounded and always resolves a date (`_dateForPage` at `lib/canteen/ui/canteen_page.dart:187`), so users can swipe to dates with no data.
+- The provider intentionally builds five weekday menu buckets even when meal lists are empty (`lib/canteen/business/canteen_provider.dart:124`), which is valid for data normalization but noisy for page navigation.
+- Empty-state rendering in `_CanteenDayView` (`lib/canteen/ui/canteen_page.dart:312`) is currently used both for real errors and for navigation into known-empty dates, conflating UX states.
+- GitHub issue reference: https://github.com/FarisZR/DualMate/issues/18
+
+## Research Summary
+### Internal code references
+- Canteen page paging and date mapping: `lib/canteen/ui/canteen_page.dart:131`, `lib/canteen/ui/canteen_page.dart:187`, `lib/canteen/ui/canteen_page.dart:209`
+- Empty day fallback rendering: `lib/canteen/ui/canteen_page.dart:312`
+- Week cache/load state + per-day meals access: `lib/canteen/ui/viewmodels/canteen_view_model.dart:60`, `lib/canteen/ui/viewmodels/canteen_view_model.dart:103`
+- Provider normalization that emits weekday entries regardless of meal count: `lib/canteen/business/canteen_provider.dart:124`
+
+### Institutional learnings (`docs/solutions/`)
+- Defer initial state changes and keep post-frame loading patterns stable in canteen viewmodel (`docs/solutions/integration-issues/canteen-widget-crashes-and-locking-Canteen-20260124.md`).
+- Keep cache-first UX and avoid regressing loading responsiveness in canteen flows (`docs/solutions/performance-issues/absolute-startup-schedule-optimization-20260207.md`).
+- Prior canteen fixes emphasize deterministic behavior and edge-case handling for date windows (`docs/solutions/ui-bugs/widget-resize-and-canteen-duplication-20260127.md`).
+
+### External research decision
+- Skipped for this issue. The request targets existing in-repo Flutter code paths and directly names the official API class to use (`StretchingOverscrollIndicator`).
+
+## SpecFlow Analysis (Flows + Gaps)
+### Primary user flow
+1. User opens canteen page.
+2. App resolves visible days with actual meals.
+3. User can swipe only within this finite content range.
+4. Swiping beyond left/right boundary does not change day and shows overscroll feedback.
+
+### Edge cases to cover
+- Today has no meals but a future day does: initial page should select the first day with meals.
+- Loaded range has no meals at all (e.g., source empty week): show a stable non-paged empty/error screen instead of infinite empty swiping.
+- Filter hides all meals for a visible date: keep navigation bounds based on raw menu availability, not filter result, so user can still move between real menu days.
+- Widget deep-link target day is outside current visible bounds: clamp to nearest valid visible day.
+- Async loading updates bounds while user is on page: preserve current day when still valid; otherwise snap to nearest valid day once.
+
+## Proposed Solution
+### 1) Build finite, content-backed navigation bounds
+- Introduce visible day computation in `lib/canteen/ui/viewmodels/canteen_view_model.dart`:
+  - derive sorted weekday dates where menu has at least one raw meal (before filter), from loaded weeks.
+  - expose helpers for first/last visible day and nearest visible day.
+- Keep existing cache-first + refresh behavior unchanged.
+
+### 2) Replace unbounded date index mapping in page layer
+- Refactor `lib/canteen/ui/canteen_page.dart` to drive `PageView` from a finite `List<DateTime> visibleDays` instead of `_basePage` arithmetic.
+- Maintain date title and "Back to today" behavior, but update logic:
+  - "today" action should jump to today if visible, else nearest visible day.
+  - widget payload navigation should clamp to visible bounds.
+
+### 3) Add boundary overscroll affordance
+- Wrap the horizontal page list with `StretchingOverscrollIndicator` in `lib/canteen/ui/canteen_page.dart` so attempts to move before first or after last visible day show clear stretch feedback.
+- Keep platform-appropriate physics and ensure indicator appears at both start/end boundaries.
+
+### 4) Preserve meaningful empty/error states
+- Keep `_CanteenDayView` empty UI for genuine "no content loaded at all" and fetch errors.
+- Remove empty-day navigation as a normal state by preventing those pages from being created.
+
+## Technical Considerations
+- Navigation bounds must be computed from unfiltered meals; otherwise changing filter would unexpectedly shrink/expand page count.
+- Bounds are only as good as loaded data; when additional weeks load, page list may extend and should update without jarring jumps.
+- Date normalization remains weekday-only; no weekend pages should be introduced.
+- Ensure no regression in telemetry hooks (`canteen.entry`, `canteen.pageChanged`) in `lib/canteen/ui/canteen_page.dart:37` and `lib/canteen/ui/canteen_page.dart:138`.
+
+## Acceptance Criteria
+- [ ] Users cannot navigate to past/future canteen days that have no menu content.
+- [ ] Swiping before the first visible content day shows overscroll stretch feedback and does not navigate further back.
+- [ ] Swiping after the last visible content day shows overscroll stretch feedback and does not navigate further forward.
+- [ ] If the current week has no meals but later loaded days do, the page opens at the first available day with meals.
+- [ ] If no visible meal day exists in loaded data, the page shows a single stable empty/error state (no infinite horizontal swipe).
+- [ ] Widget payload day targeting still works and clamps to nearest visible day when exact day is unavailable.
+- [ ] Refresh and loading behavior remains functional and free of `notify`-during-build issues.
+
+## Implementation Plan
+1. `lib/canteen/ui/viewmodels/canteen_view_model.dart`
+- Add methods for visible day extraction from `_weeklyMenus` (raw meals, sorted unique weekdays).
+- Add helpers: `firstVisibleDay`, `lastVisibleDay`, `nearestVisibleDay`.
+
+2. `lib/canteen/ui/canteen_page.dart`
+- Replace `_basePage`/`_dateForPage` driven infinite mapping with finite visible-day indexing.
+- Keep header date + FAB behavior consistent with new indexing.
+- Clamp widget payload target to visible range.
+- Wrap page content with `StretchingOverscrollIndicator`.
+
+3. `test/canteen/ui/canteen_page_bounds_test.dart` (new)
+- Add widget tests for: no past empty-day navigation, no beyond-last-day navigation, overscroll indicator presence, nearest-day clamp.
+
+4. `test/canteen/ui/viewmodels/canteen_visible_days_test.dart` (new)
+- Add unit tests for visible day derivation and nearest-day selection.
+
+## Success Metrics
+- Manual QA on Android: no reproducible path to swipe into empty historical days on canteen page.
+- Manual QA on Android: visible stretch indicator appears when swiping beyond first/last content day.
+- Automated tests cover bound calculation and clamping logic for deterministic regressions.
+
+## Dependencies & Risks
+- Risk: bounds may change while loading next week and cause page jumps.
+  - Mitigation: preserve current selected day when still in visible list; otherwise clamp once.
+- Risk: filter interaction could accidentally affect page bounds.
+  - Mitigation: derive bounds from raw meals, apply filters only inside day content.
+- Risk: overscroll visuals vary by platform/theme.
+  - Mitigation: verify behavior on actual Android device via debugger run (`flutter run -d <DEVICE_ID>`).
+
+## Verification Plan
+- Automated:
+  - `flutter test test/canteen/ui/viewmodels/canteen_visible_days_test.dart`
+  - `flutter test test/canteen/ui/canteen_page_bounds_test.dart`
+- Manual (Android device):
+  - Run `flutter run -d <DEVICE_ID>`.
+  - Swipe left at first visible day and right at last visible day; confirm stretch indicator and no day change.
+  - Validate startup on weeks with sparse meals and widget deep-link day navigation.
+
+## References & Related Work
+- Issue: https://github.com/FarisZR/DualMate/issues/18
+- Flutter API: https://api.flutter.dev/flutter/widgets/StretchingOverscrollIndicator-class.html
+- Canteen page: `lib/canteen/ui/canteen_page.dart:131`
+- Canteen viewmodel: `lib/canteen/ui/viewmodels/canteen_view_model.dart:60`
+- Canteen provider normalization: `lib/canteen/business/canteen_provider.dart:124`
+- Related prior plan: `docs/plans/2026-01-27-fix-android-widget-resize-and-canteen-duplication-plan.md`

--- a/lib/canteen/ui/canteen_page.dart
+++ b/lib/canteen/ui/canteen_page.dart
@@ -3,6 +3,7 @@ import 'package:dualmate/canteen/ui/widgets/filter_dropdown.dart';
 import 'package:dualmate/canteen/ui/widgets/meal_card.dart';
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/logging/performance_telemetry.dart';
+import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -15,12 +16,11 @@ class CanteenPage extends StatefulWidget {
 }
 
 class _CanteenPageState extends State<CanteenPage> {
-  static const int _basePage = 10000;
-
   late CanteenViewModel viewModel;
   late PageController pageController;
   late ValueNotifier<int> pageNotifier;
   late DateTime baseDate;
+  DateTime? _selectedDate;
   bool _isApplyingWidgetPayload = false;
 
   @override
@@ -29,13 +29,13 @@ class _CanteenPageState extends State<CanteenPage> {
     viewModel = Provider.of<CanteenViewModel>(context, listen: false);
     viewModel.initialize();
     baseDate = _normalizeToWeekday(DateTime.now());
-    pageController = PageController(initialPage: _basePage);
-    pageNotifier = ValueNotifier<int>(_basePage);
+    pageController = PageController(initialPage: 0);
+    pageNotifier = ValueNotifier<int>(0);
     WidgetNavigationPayloadStore.instance.addListener(_handleWidgetPayload);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       PerformanceTelemetry.instance.markNavEvent(name: "canteen.entry");
-      _loadWeekForDate(baseDate);
+      _loadContextWeeks(baseDate);
       _applyWidgetPayload();
     });
   }
@@ -55,144 +55,136 @@ class _CanteenPageState extends State<CanteenPage> {
 
     return PropertyChangeProvider<CanteenViewModel, String>(
       value: viewModel,
-      child: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-            child: Row(
-              children: [
-                Expanded(
-                  child: ValueListenableBuilder<int>(
-                    valueListenable: pageNotifier,
-                    builder: (context, page, _) {
-                      var date = _dateForPage(page);
-                      return AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 200),
-                        transitionBuilder: (child, animation) {
-                          var offsetAnimation = Tween<Offset>(
-                            begin: const Offset(0, 0.15),
-                            end: Offset.zero,
-                          ).animate(animation);
+      child: PropertyChangeConsumer<CanteenViewModel, String>(
+        properties: const ["weeklyMenus", "loadingWeeks", "weekErrors"],
+        builder: (
+          BuildContext context,
+          CanteenViewModel? model,
+          Set<String>? properties,
+        ) {
+          if (model == null) return const SizedBox();
+          final visibleDays = model.visibleContentDays;
+          _syncPageForVisibleDays(model, visibleDays);
+          _applyWidgetPayload(visibleDays: visibleDays);
 
-                          return FadeTransition(
-                            opacity: animation,
-                            child: SlideTransition(
-                              position: offsetAnimation,
-                              child: child,
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: ValueListenableBuilder<int>(
+                        valueListenable: pageNotifier,
+                        builder: (context, page, _) {
+                          final date =
+                              _displayDateForPage(page, visibleDays, model);
+                          return AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 200),
+                            transitionBuilder: (child, animation) {
+                              var offsetAnimation = Tween<Offset>(
+                                begin: const Offset(0, 0.15),
+                                end: Offset.zero,
+                              ).animate(animation);
+
+                              return FadeTransition(
+                                opacity: animation,
+                                child: SlideTransition(
+                                  position: offsetAnimation,
+                                  child: child,
+                                ),
+                              );
+                            },
+                            child: Text(
+                              dateFormat.format(date),
+                              key: ValueKey(date.toIso8601String()),
+                              style: Theme.of(context).textTheme.titleMedium,
                             ),
                           );
                         },
-                        child: Text(
-                          dateFormat.format(date),
-                          key: ValueKey(date.toIso8601String()),
-                          style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                child: Row(
+                  children: [
+                    Text(
+                      L.of(context).filterTitle,
+                      style: Theme.of(context).textTheme.labelLarge,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: PropertyChangeConsumer<CanteenViewModel, String>(
+                          properties: const ["filter"],
+                          builder: (
+                            BuildContext context,
+                            CanteenViewModel? model,
+                            Set<String>? properties,
+                          ) {
+                            if (model == null) return const SizedBox();
+                            return FilterDropdown(
+                              filter: model.filter,
+                              onChanged: model.setFilter,
+                            );
+                          },
                         ),
-                      );
-                    },
-                  ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-            child: Row(
-              children: [
-                Text(
-                  L.of(context).filterTitle,
-                  style: Theme.of(context).textTheme.labelLarge,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Align(
-                    alignment: Alignment.centerRight,
-                    child: PropertyChangeConsumer<CanteenViewModel, String>(
-                      properties: const ["filter"],
-                      builder: (
-                        BuildContext context,
-                        CanteenViewModel? model,
-                        Set<String>? properties,
-                      ) {
-                        if (model == null) return const SizedBox();
-                        return FilterDropdown(
-                          filter: model.filter,
-                          onChanged: model.setFilter,
+              ),
+              Expanded(
+                child: Stack(
+                  children: [
+                    _buildPageContent(model, visibleDays),
+                    ValueListenableBuilder<int>(
+                      valueListenable: pageNotifier,
+                      builder: (context, page, _) {
+                        final date =
+                            _displayDateForPage(page, visibleDays, model);
+                        var showButton = !_isBaseDate(date);
+
+                        return Positioned(
+                          right: 16,
+                          bottom: 16,
+                          child: AnimatedOpacity(
+                            duration: const Duration(milliseconds: 200),
+                            opacity: showButton ? 1 : 0,
+                            child: IgnorePointer(
+                              ignoring: !showButton,
+                              child: FloatingActionButton.extended(
+                                heroTag: "canteenBackToToday",
+                                onPressed: () {
+                                  final targetDay =
+                                      model.nearestVisibleContentDay(baseDate);
+                                  if (targetDay == null) return;
+                                  _goToVisibleDay(
+                                    targetDay,
+                                    visibleDays,
+                                    animate: true,
+                                  );
+                                },
+                                icon: const Icon(Icons.today),
+                                label: Text(L.of(context).canteenBackToToday),
+                              ),
+                            ),
+                          ),
                         );
                       },
                     ),
-                  ),
+                  ],
                 ),
-              ],
-            ),
-          ),
-          Expanded(
-            child: Stack(
-              children: [
-                PageView.builder(
-                  controller: pageController,
-                  allowImplicitScrolling: true,
-                  onPageChanged: (index) {
-                    pageNotifier.value = index;
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      if (!mounted) return;
-                      PerformanceTelemetry.instance
-                          .markNavEvent(name: "canteen.pageChanged");
-                      _loadWeekForDate(_dateForPage(index));
-                    });
-                  },
-                  itemBuilder: (context, index) {
-                    var date = _dateForPage(index);
-                    return _CanteenDayView(date: date);
-                  },
-                ),
-                ValueListenableBuilder<int>(
-                  valueListenable: pageNotifier,
-                  builder: (context, page, _) {
-                    var date = _dateForPage(page);
-                    var showButton = !_isBaseDate(date);
-
-                    return Positioned(
-                      right: 16,
-                      bottom: 16,
-                      child: AnimatedOpacity(
-                        duration: const Duration(milliseconds: 200),
-                        opacity: showButton ? 1 : 0,
-                        child: IgnorePointer(
-                          ignoring: !showButton,
-                          child: FloatingActionButton.extended(
-                            heroTag: "canteenBackToToday",
-                            onPressed: () {
-                              pageController.animateToPage(
-                                _basePage,
-                                duration: const Duration(milliseconds: 250),
-                                curve: Curves.easeOut,
-                              );
-                            },
-                            icon: const Icon(Icons.today),
-                            label: Text(L.of(context).canteenBackToToday),
-                          ),
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              ],
-            ),
-          ),
-        ],
+              ),
+            ],
+          );
+        },
       ),
     );
-  }
-
-  DateTime _dateForPage(int page) {
-    var offset = page - _basePage;
-    var baseWeekStart = _toMonday(baseDate);
-    var baseIndex = baseDate.weekday - 1;
-    var totalIndex = baseIndex + offset;
-    var weekOffset = _floorDiv(totalIndex, 5);
-    var dayIndex = totalIndex - (weekOffset * 5);
-    var date = baseWeekStart.add(Duration(days: weekOffset * 7 + dayIndex));
-    return _normalizeToWeekday(date);
   }
 
   DateTime _normalizeToWeekday(DateTime date) {
@@ -206,28 +198,60 @@ class _CanteenPageState extends State<CanteenPage> {
     return normalized;
   }
 
-  int _pageForDate(DateTime date) {
-    final normalized = _normalizeToWeekday(date);
-    final baseWeekStart = _toMonday(baseDate);
-    final targetWeekStart = _toMonday(normalized);
-    final weekOffset = targetWeekStart.difference(baseWeekStart).inDays ~/ 7;
-    final baseIndex = baseDate.weekday - 1;
-    final dayIndex = normalized.weekday - 1;
-    final totalIndex = weekOffset * 5 + dayIndex;
-    return _basePage + (totalIndex - baseIndex);
-  }
-
-  DateTime _toMonday(DateTime date) {
-    return date.subtract(Duration(days: date.weekday - 1));
-  }
-
-  int _floorDiv(int value, int divisor) {
-    if (value >= 0) return value ~/ divisor;
-    return -(((-value + divisor - 1) ~/ divisor));
-  }
-
   void _loadWeekForDate(DateTime date) {
     viewModel.ensureWeekLoaded(viewModel.weekStartFor(date));
+  }
+
+  void _loadContextWeeks(DateTime date) {
+    _loadWeekForDate(date);
+    _loadWeekForDate(date.add(const Duration(days: 7)));
+    _loadWeekForDate(date.subtract(const Duration(days: 7)));
+  }
+
+  DateTime _displayDateForPage(
+    int page,
+    List<DateTime> visibleDays,
+    CanteenViewModel model,
+  ) {
+    if (visibleDays.isNotEmpty) {
+      final boundedPage = page.clamp(0, visibleDays.length - 1) as int;
+      return visibleDays[boundedPage];
+    }
+
+    return _selectedDate ??
+        model.nearestVisibleContentDay(baseDate) ??
+        baseDate;
+  }
+
+  Widget _buildPageContent(
+    CanteenViewModel model,
+    List<DateTime> visibleDays,
+  ) {
+    if (visibleDays.isEmpty) {
+      return _CanteenDayView(date: _selectedDate ?? baseDate);
+    }
+
+    return StretchingOverscrollIndicator(
+      axisDirection: AxisDirection.right,
+      child: PageView.builder(
+        controller: pageController,
+        allowImplicitScrolling: true,
+        itemCount: visibleDays.length,
+        onPageChanged: (index) {
+          pageNotifier.value = index;
+          _selectedDate = visibleDays[index];
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            PerformanceTelemetry.instance
+                .markNavEvent(name: "canteen.pageChanged");
+            _loadContextWeeks(visibleDays[index]);
+          });
+        },
+        itemBuilder: (context, index) {
+          return _CanteenDayView(date: visibleDays[index]);
+        },
+      ),
+    );
   }
 
   void _handleWidgetPayload() {
@@ -237,29 +261,82 @@ class _CanteenPageState extends State<CanteenPage> {
     });
   }
 
-  void _applyWidgetPayload() {
+  void _applyWidgetPayload({
+    List<DateTime>? visibleDays,
+  }) {
     if (_isApplyingWidgetPayload) return;
     final payload = WidgetNavigationPayloadStore.instance.peekCanteenPayload();
     if (payload == null || payload.dayStart == null) return;
 
     final targetDate = _normalizeToWeekday(payload.dayStart!);
     print("Widget canteen target date: $targetDate");
-    final targetPage = _pageForDate(targetDate);
+    _loadContextWeeks(targetDate);
+    final currentVisibleDays = visibleDays ?? viewModel.visibleContentDays;
+    if (currentVisibleDays.isEmpty) return;
 
     if (!pageController.hasClients) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
-        _applyWidgetPayload();
+        _applyWidgetPayload(visibleDays: currentVisibleDays);
       });
       return;
     }
 
+    final targetDay = viewModel.nearestVisibleContentDay(targetDate);
+    if (targetDay == null) return;
+
     _isApplyingWidgetPayload = true;
+    _goToVisibleDay(targetDay, currentVisibleDays);
     WidgetNavigationPayloadStore.instance.takeCanteenPayload();
-    pageController.jumpToPage(targetPage);
-    pageNotifier.value = targetPage;
-    _loadWeekForDate(targetDate);
     _isApplyingWidgetPayload = false;
+  }
+
+  void _syncPageForVisibleDays(
+    CanteenViewModel model,
+    List<DateTime> visibleDays,
+  ) {
+    if (visibleDays.isEmpty) return;
+
+    final currentTarget = _selectedDate ?? baseDate;
+    final syncedDate = model.nearestVisibleContentDay(currentTarget);
+    if (syncedDate == null) return;
+
+    final targetIndex =
+        visibleDays.indexWhere((day) => isAtSameDay(day, syncedDate));
+    if (targetIndex < 0) return;
+
+    _selectedDate = syncedDate;
+    if (pageNotifier.value == targetIndex) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !pageController.hasClients) return;
+      pageController.jumpToPage(targetIndex);
+      pageNotifier.value = targetIndex;
+    });
+  }
+
+  void _goToVisibleDay(
+    DateTime targetDay,
+    List<DateTime> visibleDays, {
+    bool animate = false,
+  }) {
+    final targetIndex =
+        visibleDays.indexWhere((day) => isAtSameDay(day, targetDay));
+    if (targetIndex < 0) return;
+    _selectedDate = targetDay;
+
+    if (!pageController.hasClients) return;
+    if (animate) {
+      pageController.animateToPage(
+        targetIndex,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+      );
+    } else {
+      pageController.jumpToPage(targetIndex);
+    }
+
+    pageNotifier.value = targetIndex;
   }
 
   bool _isBaseDate(DateTime date) {

--- a/lib/canteen/ui/canteen_page.dart
+++ b/lib/canteen/ui/canteen_page.dart
@@ -269,21 +269,32 @@ class _CanteenPageState extends State<CanteenPage> {
     if (payload == null || payload.dayStart == null) return;
 
     final targetDate = _normalizeToWeekday(payload.dayStart!);
-    print("Widget canteen target date: $targetDate");
+    final targetWeekStart = viewModel.weekStartFor(targetDate);
     _loadContextWeeks(targetDate);
-    final currentVisibleDays = visibleDays ?? viewModel.visibleContentDays;
-    if (currentVisibleDays.isEmpty) return;
+
+    final hasTargetWeekData = viewModel.hasWeekData(targetWeekStart);
+    final isTargetWeekLoading = viewModel.isLoadingWeek(targetWeekStart);
+    if (!hasTargetWeekData || isTargetWeekLoading) return;
 
     if (!pageController.hasClients) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
-        _applyWidgetPayload(visibleDays: currentVisibleDays);
+        _applyWidgetPayload();
       });
       return;
     }
 
-    final targetDay = viewModel.nearestVisibleContentDay(targetDate);
-    if (targetDay == null) return;
+    final targetWeekVisibleDays = _contentDaysForWeek(targetWeekStart);
+    final currentVisibleDays = visibleDays ?? viewModel.visibleContentDays;
+    final targetDay = _nearestDay(targetDate, targetWeekVisibleDays) ??
+        viewModel.nearestVisibleContentDay(
+          targetDate,
+          precomputedDays: currentVisibleDays,
+        );
+    if (targetDay == null) {
+      WidgetNavigationPayloadStore.instance.takeCanteenPayload();
+      return;
+    }
 
     _isApplyingWidgetPayload = true;
     _goToVisibleDay(targetDay, currentVisibleDays);
@@ -337,6 +348,35 @@ class _CanteenPageState extends State<CanteenPage> {
     }
 
     pageNotifier.value = targetIndex;
+  }
+
+  List<DateTime> _contentDaysForWeek(DateTime weekStart) {
+    final days = <DateTime>[];
+
+    for (final menu in viewModel.weeklyMenusFor(weekStart)) {
+      if (menu.meals.isEmpty) continue;
+      days.add(toStartOfDay(menu.date));
+    }
+
+    days.sort((a, b) => a.compareTo(b));
+    return days;
+  }
+
+  DateTime? _nearestDay(DateTime targetDate, List<DateTime> days) {
+    if (days.isEmpty) return null;
+    final normalizedTarget = toStartOfDay(targetDate);
+    var nearest = days.first;
+    var minDistance = nearest.difference(normalizedTarget).inDays.abs();
+
+    for (final day in days.skip(1)) {
+      final distance = day.difference(normalizedTarget).inDays.abs();
+      if (distance < minDistance) {
+        nearest = day;
+        minDistance = distance;
+      }
+    }
+
+    return nearest;
   }
 
   bool _isBaseDate(DateTime date) {

--- a/lib/canteen/ui/viewmodels/canteen_view_model.dart
+++ b/lib/canteen/ui/viewmodels/canteen_view_model.dart
@@ -85,8 +85,11 @@ class CanteenViewModel extends BaseViewModel {
     return sortedDays;
   }
 
-  DateTime? nearestVisibleContentDay(DateTime targetDate) {
-    final visibleDays = visibleContentDays;
+  DateTime? nearestVisibleContentDay(
+    DateTime targetDate, {
+    List<DateTime>? precomputedDays,
+  }) {
+    final visibleDays = precomputedDays ?? visibleContentDays;
     if (visibleDays.isEmpty) return null;
 
     final normalizedTarget = toStartOfDay(targetDate);

--- a/lib/canteen/ui/viewmodels/canteen_view_model.dart
+++ b/lib/canteen/ui/viewmodels/canteen_view_model.dart
@@ -70,6 +70,40 @@ class CanteenViewModel extends BaseViewModel {
     return mealsForDay(weekStartFor(date), date);
   }
 
+  List<DateTime> get visibleContentDays {
+    final days = <DateTime>{};
+
+    for (final weeklyMenus in _weeklyMenus.values) {
+      for (final menu in weeklyMenus) {
+        if (menu.meals.isEmpty) continue;
+        days.add(toStartOfDay(menu.date));
+      }
+    }
+
+    final sortedDays = days.toList();
+    sortedDays.sort((a, b) => a.compareTo(b));
+    return sortedDays;
+  }
+
+  DateTime? nearestVisibleContentDay(DateTime targetDate) {
+    final visibleDays = visibleContentDays;
+    if (visibleDays.isEmpty) return null;
+
+    final normalizedTarget = toStartOfDay(targetDate);
+    var nearest = visibleDays.first;
+    var minDistance = nearest.difference(normalizedTarget).inDays.abs();
+
+    for (final day in visibleDays.skip(1)) {
+      final distance = day.difference(normalizedTarget).inDays.abs();
+      if (distance < minDistance) {
+        nearest = day;
+        minDistance = distance;
+      }
+    }
+
+    return nearest;
+  }
+
   Future<void> loadWeek(DateTime weekStart) async {
     if (_loadingWeeks.contains(weekStart)) return;
 

--- a/test/canteen/ui/canteen_page_bounds_test.dart
+++ b/test/canteen/ui/canteen_page_bounds_test.dart
@@ -1,0 +1,240 @@
+import 'package:dualmate/canteen/business/canteen_provider.dart';
+import 'package:dualmate/canteen/data/canteen_meal_repository.dart';
+import 'package:dualmate/canteen/model/daily_menu.dart';
+import 'package:dualmate/canteen/model/meal.dart';
+import 'package:dualmate/canteen/service/canteen_scraper.dart';
+import 'package:dualmate/canteen/ui/canteen_page.dart';
+import 'package:dualmate/canteen/ui/viewmodels/canteen_view_model.dart';
+import 'package:dualmate/common/data/database_access.dart';
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/common/util/date_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('limits page count to only days with content', (tester) async {
+    final now = DateTime.now();
+    final today = _normalizeToWeekday(now);
+    final weekStart = toStartOfDay(toMonday(today));
+    final menus = _buildWeekMenusWithSingleDayMeal(weekStart, today);
+
+    final provider = _FakeCanteenProvider({weekStart: menus});
+    final viewModel = CanteenViewModel(provider);
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await tester.pumpAndSettle();
+
+    final pageView = tester.widget<PageView>(find.byType(PageView));
+    final delegate = pageView.childrenDelegate as SliverChildBuilderDelegate;
+    expect(delegate.childCount, 1);
+  });
+
+  testWidgets('shows horizontal stretching overscroll indicator',
+      (tester) async {
+    final now = DateTime.now();
+    final today = _normalizeToWeekday(now);
+    final weekStart = toStartOfDay(toMonday(today));
+    final menus = _buildWeekMenusWithSingleDayMeal(weekStart, today);
+
+    final provider = _FakeCanteenProvider({weekStart: menus});
+    final viewModel = CanteenViewModel(provider);
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is StretchingOverscrollIndicator &&
+            widget.axisDirection == AxisDirection.right,
+      ),
+      findsWidgets,
+    );
+  });
+
+  testWidgets('does not allow paging to empty days before/after content',
+      (tester) async {
+    final now = DateTime.now();
+    final today = _normalizeToWeekday(now);
+    final weekStart = toStartOfDay(toMonday(today));
+    final menus = _buildWeekMenusWithSingleDayMeal(weekStart, today);
+
+    final provider = _FakeCanteenProvider({weekStart: menus});
+    final viewModel = CanteenViewModel(provider);
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_mealNameFor(today)), findsOneWidget);
+
+    await tester.drag(find.byType(PageView), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+    expect(find.text(_mealNameFor(today)), findsOneWidget);
+
+    await tester.drag(find.byType(PageView), const Offset(400, 0));
+    await tester.pumpAndSettle();
+    expect(find.text(_mealNameFor(today)), findsOneWidget);
+  });
+}
+
+Widget _wrapWithApp(CanteenViewModel viewModel) {
+  return ChangeNotifierProvider<CanteenViewModel>.value(
+    value: viewModel,
+    child: MaterialApp(
+      localizationsDelegates: const [
+        LocalizationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('de')],
+      home: Scaffold(
+        body: CanteenPage(),
+      ),
+    ),
+  );
+}
+
+List<DailyMenu> _buildWeekMenusWithSingleDayMeal(
+  DateTime weekStart,
+  DateTime mealDay,
+) {
+  final normalizedMealDay = toStartOfDay(mealDay);
+  final dailyMenus = <DailyMenu>[];
+
+  for (var i = 0; i < 5; i++) {
+    final day = toStartOfDay(weekStart.add(Duration(days: i)));
+    dailyMenus.add(
+      DailyMenu(
+        date: day,
+        meals: day == normalizedMealDay ? [_mealForDay(day)] : <Meal>[],
+      ),
+    );
+  }
+
+  return dailyMenus;
+}
+
+Meal _mealForDay(DateTime day) {
+  return Meal(
+    date: day,
+    name: _mealNameFor(day),
+    category: 'Wahlessen 1',
+    price: 3.9,
+    notes: const <String>[],
+    mealTypes: const [],
+  );
+}
+
+String _mealNameFor(DateTime day) {
+  return 'Meal_${day.year}_${day.month}_${day.day}';
+}
+
+DateTime _normalizeToWeekday(DateTime date) {
+  final normalized = DateTime(date.year, date.month, date.day);
+  if (normalized.weekday == DateTime.saturday) {
+    return normalized.add(const Duration(days: 2));
+  }
+  if (normalized.weekday == DateTime.sunday) {
+    return normalized.add(const Duration(days: 1));
+  }
+  return normalized;
+}
+
+class _FakeCanteenProvider extends CanteenProvider {
+  final Map<DateTime, List<DailyMenu>> _menusByWeek;
+  final List<CanteenMenuUpdatedCallback> _callbacks = [];
+
+  _FakeCanteenProvider(this._menusByWeek)
+      : super(CanteenMealRepository(_FakeDatabaseAccess()), CanteenScraper());
+
+  @override
+  void addMenuUpdatedCallback(CanteenMenuUpdatedCallback callback) {
+    _callbacks.add(callback);
+  }
+
+  @override
+  void removeMenuUpdatedCallback(CanteenMenuUpdatedCallback callback) {
+    _callbacks.remove(callback);
+  }
+
+  @override
+  Future<List<DailyMenu>> getCachedWeek(DateTime date) async {
+    return _menusForWeek(date);
+  }
+
+  @override
+  Future<DateTime?> lastUpdatedForWeek(DateTime date) async {
+    return null;
+  }
+
+  @override
+  Future<List<DailyMenu>> refreshWeek(
+    DateTime date, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    final weekStart = toStartOfDay(toMonday(date));
+    final weekEnd = weekStart.add(const Duration(days: 5));
+    final menus = _menusForWeek(date);
+
+    for (final callback in _callbacks) {
+      await callback(menus, weekStart, weekEnd);
+    }
+
+    return menus;
+  }
+
+  List<DailyMenu> _menusForWeek(DateTime date) {
+    final weekStart = toStartOfDay(toMonday(date));
+    return _menusByWeek[weekStart] ?? _emptyWeek(weekStart);
+  }
+
+  List<DailyMenu> _emptyWeek(DateTime weekStart) {
+    return List.generate(5, (index) {
+      final date = toStartOfDay(weekStart.add(Duration(days: index)));
+      return DailyMenu(date: date, meals: <Meal>[]);
+    });
+  }
+}
+
+class _FakeDatabaseAccess extends DatabaseAccess {
+  @override
+  Future<List<Map<String, dynamic>>> queryRows(String table,
+      {bool? distinct,
+      List<String>? columns,
+      String? where,
+      List<dynamic>? whereArgs,
+      String? groupBy,
+      String? having,
+      String? orderBy,
+      int? limit,
+      int? offset}) async {
+    return <Map<String, dynamic>>[];
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> rawQuery(
+      String sql, List<dynamic> parameters) async {
+    return <Map<String, dynamic>>[];
+  }
+
+  @override
+  Future<void> insertBatch(
+      String table, List<Map<String, dynamic>> rows) async {
+    return;
+  }
+
+  @override
+  Future<int> deleteWhere(
+    String table, {
+    String? where,
+    List<dynamic>? whereArgs,
+  }) async {
+    return 0;
+  }
+}

--- a/test/canteen/ui/canteen_page_bounds_test.dart
+++ b/test/canteen/ui/canteen_page_bounds_test.dart
@@ -25,6 +25,7 @@ void main() {
 
     final provider = _FakeCanteenProvider({weekStart: menus});
     final viewModel = CanteenViewModel(provider);
+    await viewModel.loadWeek(weekStart);
 
     await tester.pumpWidget(_wrapWithApp(viewModel));
     await tester.pumpAndSettle();
@@ -43,6 +44,7 @@ void main() {
 
     final provider = _FakeCanteenProvider({weekStart: menus});
     final viewModel = CanteenViewModel(provider);
+    await viewModel.loadWeek(weekStart);
 
     await tester.pumpWidget(_wrapWithApp(viewModel));
     await tester.pumpAndSettle();
@@ -66,6 +68,7 @@ void main() {
 
     final provider = _FakeCanteenProvider({weekStart: menus});
     final viewModel = CanteenViewModel(provider);
+    await viewModel.loadWeek(weekStart);
 
     await tester.pumpWidget(_wrapWithApp(viewModel));
     await tester.pumpAndSettle();

--- a/test/canteen/ui/viewmodels/canteen_visible_days_test.dart
+++ b/test/canteen/ui/viewmodels/canteen_visible_days_test.dart
@@ -1,0 +1,165 @@
+import 'package:dualmate/canteen/business/canteen_provider.dart';
+import 'package:dualmate/canteen/data/canteen_meal_repository.dart';
+import 'package:dualmate/canteen/model/daily_menu.dart';
+import 'package:dualmate/canteen/model/meal.dart';
+import 'package:dualmate/canteen/service/canteen_scraper.dart';
+import 'package:dualmate/canteen/ui/viewmodels/canteen_view_model.dart';
+import 'package:dualmate/common/data/database_access.dart';
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/common/util/date_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('returns only days with actual meal content as visible days', () async {
+    final monday = DateTime(2026, 2, 9);
+    final weekStart = toStartOfDay(toMonday(monday));
+    final tuesday = weekStart.add(const Duration(days: 1));
+    final thursday = weekStart.add(const Duration(days: 3));
+
+    final provider = _FakeCanteenProvider({
+      weekStart: _buildMenus(weekStart, <DateTime>{tuesday, thursday}),
+    });
+    final model = CanteenViewModel(provider);
+    addTearDown(model.dispose);
+
+    await model.loadWeek(weekStart);
+
+    expect(model.visibleContentDays, <DateTime>[tuesday, thursday]);
+  });
+
+  test('clamps target date to nearest visible content day', () async {
+    final monday = DateTime(2026, 2, 9);
+    final weekStart = toStartOfDay(toMonday(monday));
+    final tuesday = weekStart.add(const Duration(days: 1));
+    final thursday = weekStart.add(const Duration(days: 3));
+
+    final provider = _FakeCanteenProvider({
+      weekStart: _buildMenus(weekStart, <DateTime>{tuesday, thursday}),
+    });
+    final model = CanteenViewModel(provider);
+    addTearDown(model.dispose);
+
+    await model.loadWeek(weekStart);
+
+    expect(model.nearestVisibleContentDay(weekStart), tuesday);
+    expect(
+        model.nearestVisibleContentDay(weekStart.add(const Duration(days: 4))),
+        thursday);
+  });
+}
+
+List<DailyMenu> _buildMenus(DateTime weekStart, Set<DateTime> mealDays) {
+  return List.generate(5, (index) {
+    final day = toStartOfDay(weekStart.add(Duration(days: index)));
+    final hasMeals = mealDays.contains(day);
+
+    return DailyMenu(
+      date: day,
+      meals: hasMeals
+          ? <Meal>[
+              Meal(
+                date: day,
+                name: 'Meal_${day.day}',
+                category: 'Wahlessen 1',
+                price: 3.5,
+                notes: const <String>[],
+                mealTypes: const [],
+              ),
+            ]
+          : <Meal>[],
+    );
+  });
+}
+
+class _FakeCanteenProvider extends CanteenProvider {
+  final Map<DateTime, List<DailyMenu>> _menusByWeek;
+  final List<CanteenMenuUpdatedCallback> _callbacks = [];
+
+  _FakeCanteenProvider(this._menusByWeek)
+      : super(CanteenMealRepository(_FakeDatabaseAccess()), CanteenScraper());
+
+  @override
+  void addMenuUpdatedCallback(CanteenMenuUpdatedCallback callback) {
+    _callbacks.add(callback);
+  }
+
+  @override
+  void removeMenuUpdatedCallback(CanteenMenuUpdatedCallback callback) {
+    _callbacks.remove(callback);
+  }
+
+  @override
+  Future<List<DailyMenu>> getCachedWeek(DateTime date) async {
+    return _menusForWeek(date);
+  }
+
+  @override
+  Future<DateTime?> lastUpdatedForWeek(DateTime date) async {
+    return null;
+  }
+
+  @override
+  Future<List<DailyMenu>> refreshWeek(
+    DateTime date, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    final weekStart = toStartOfDay(toMonday(date));
+    final weekEnd = weekStart.add(const Duration(days: 5));
+    final menus = _menusForWeek(date);
+
+    for (final callback in _callbacks) {
+      await callback(menus, weekStart, weekEnd);
+    }
+
+    return menus;
+  }
+
+  List<DailyMenu> _menusForWeek(DateTime date) {
+    final weekStart = toStartOfDay(toMonday(date));
+    return _menusByWeek[weekStart] ?? _emptyWeek(weekStart);
+  }
+
+  List<DailyMenu> _emptyWeek(DateTime weekStart) {
+    return List.generate(5, (index) {
+      final date = toStartOfDay(weekStart.add(Duration(days: index)));
+      return DailyMenu(date: date, meals: <Meal>[]);
+    });
+  }
+}
+
+class _FakeDatabaseAccess extends DatabaseAccess {
+  @override
+  Future<List<Map<String, dynamic>>> queryRows(String table,
+      {bool? distinct,
+      List<String>? columns,
+      String? where,
+      List<dynamic>? whereArgs,
+      String? groupBy,
+      String? having,
+      String? orderBy,
+      int? limit,
+      int? offset}) async {
+    return <Map<String, dynamic>>[];
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> rawQuery(
+      String sql, List<dynamic> parameters) async {
+    return <Map<String, dynamic>>[];
+  }
+
+  @override
+  Future<void> insertBatch(
+      String table, List<Map<String, dynamic>> rows) async {
+    return;
+  }
+
+  @override
+  Future<int> deleteWhere(
+    String table, {
+    String? where,
+    List<dynamic>? whereArgs,
+  }) async {
+    return 0;
+  }
+}

--- a/test/canteen/ui/viewmodels/canteen_visible_days_test.dart
+++ b/test/canteen/ui/viewmodels/canteen_visible_days_test.dart
@@ -10,6 +10,8 @@ import 'package:dualmate/common/util/date_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('returns only days with actual meal content as visible days', () async {
     final monday = DateTime(2026, 2, 9);
     final weekStart = toStartOfDay(toMonday(monday));


### PR DESCRIPTION
fix #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meal navigation now only pages through days with available meals
  * Visual overscroll feedback added at navigation boundaries
  * "Today" quick-jump preserved and updated to work with content-based navigation

* **Tests**
  * Added UI and unit tests verifying bounded navigation, overscroll behavior, and visible-meal day computation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->