### PR TITLE
fix(schedule): prevent yesterdays lessons from disappearing after app resumes from background

### DIFF
--- a/docs/solutions/ui-bugs/monday-lessons-missing-after-background-resume-20260210.md
+++ b/docs/solutions/ui-bugs/monday-lessons-missing-after-background-resume-20260210.md
@@ -1,0 +1,54 @@
+---
+module: Schedule UI
+date: 2026-02-10
+problem_type: ui_bug
+component: frontend_flutter
+symptoms:
+  - "Monday column is visible but Monday lessons are missing"
+  - "After app resume, Monday appears empty across current, past, and future weeks"
+  - "Issue disappears after a full app restart"
+root_cause: background_refresh_state_leak
+resolution_type: code_fix
+severity: high
+tags: [schedule, weekly-calendar, lifecycle, background-refresh, cache]
+---
+
+# Troubleshooting: Monday lessons disappear after app resumes from background
+
+## Problem
+After the app stays in background and is reopened, weekly schedule keeps the Monday column but Monday entries disappear across multiple weeks.
+
+## Root Cause
+The periodic widget refresh path in `WeeklyScheduleViewModel` refreshed a broad range (`today` to `today + 14 days`) through the same `updateSchedule(...)` flow used by the visible weekly screen.
+
+That flow updates `currentDateStart/currentDateEnd`. If refresh starts on a non-Monday day (for example Tuesday), the visible week state shifted to a Tuesday-based range. Rendering still anchored labels to Monday-Friday, but Monday data was no longer in the loaded range, so Mondays appeared empty in all navigated weeks until restart reinitialized state.
+
+## Solution
+- Added an `applyToVisibleState` parameter to `WeeklyScheduleViewModel.updateSchedule(...)`.
+- Background widget refresh now calls:
+  - `updateSchedule(start, end, force: true, applyToVisibleState: false)`
+- When `applyToVisibleState` is `false`:
+  - do not call `_setSchedule(...)`
+  - do not toggle visible loading/error UI state
+  - still execute network/cache refresh so widget/schedule data stays fresh
+
+This keeps background refresh behavior while preventing visible week-state mutation.
+
+## Test Coverage
+- Added `test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart`:
+  - `background range refresh keeps the currently visible week anchored`
+  - `midweek background refresh keeps previous weekdays in visible schedule`
+  - `visible range updates still replace the current week window`
+- Added `test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart`:
+  - `resume-triggered background refresh keeps monday lessons visible`
+  - Sends a real `AppLifecycleState.resumed` signal in widget tests and verifies the Monday lesson remains rendered.
+
+## Commands run
+```bash
+flutter test test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+flutter test test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart
+flutter test test/schedule/ui/viewmodels/weekly_schedule_display_range_test.dart
+flutter test test/schedule/ui/viewmodels
+flutter analyze lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+flutter run -d 59RYD25806200107 --debug
+```

--- a/docs/solutions/ui-bugs/monday-lessons-missing-after-background-resume-20260210.md
+++ b/docs/solutions/ui-bugs/monday-lessons-missing-after-background-resume-20260210.md
@@ -50,5 +50,5 @@ flutter test test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test
 flutter test test/schedule/ui/viewmodels/weekly_schedule_display_range_test.dart
 flutter test test/schedule/ui/viewmodels
 flutter analyze lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
-flutter run -d 59RYD25806200107 --debug
+flutter run -d <DEVICE_ID> --debug
 ```

--- a/docs/solutions/ui-bugs/swipe-unloaded-week-no-fetch-schedule-ui-20260127.md
+++ b/docs/solutions/ui-bugs/swipe-unloaded-week-no-fetch-schedule-ui-20260127.md
@@ -88,7 +88,7 @@ class ScheduleFreshnessGate {
 **Commands run**:
 ```bash
 flutter test
-flutter run -d 59RYD25806200107
+flutter run -d <DEVICE_ID>
 ```
 
 ## Why This Works

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -17,7 +17,6 @@ import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:dualmate/schedule/ui/viewmodels/schedule_freshness_gate.dart';
 import 'package:dualmate/schedule/ui/viewmodels/schedule_update_request_gate.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 class WeeklyScheduleViewModel extends BaseViewModel {
@@ -25,6 +24,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
   final ScheduleProvider scheduleProvider;
   final ScheduleSourceProvider scheduleSourceProvider;
+  final DateTime Function() _nowProvider;
 
   late DateTime currentDateStart;
   late DateTime currentDateEnd;
@@ -60,7 +60,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
   String? scheduleUrl;
 
-  DateTime get now => DateTime.now();
+  DateTime get now => _nowProvider();
 
   Timer? _errorResetTimer;
   Timer? _updateNowTimer;
@@ -80,8 +80,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
   WeeklyScheduleViewModel(
     this.scheduleProvider,
-    this.scheduleSourceProvider,
-  );
+    this.scheduleSourceProvider, {
+    DateTime Function()? nowProvider,
+  }) : _nowProvider = nowProvider ?? DateTime.now;
 
   Future<void> initialize() async {
     if (_initialized) return;
@@ -118,8 +119,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   }
 
   Future<void> _initViewModel() async {
-    currentDateStart =
-        toStartOfDay(toDayOfWeek(DateTime.now(), DateTime.monday));
+    currentDateStart = toStartOfDay(toDayOfWeek(now, DateTime.monday));
     currentDateEnd = toNextWeek(currentDateStart);
     try {
       if (_lastCachedSchedule != null) {
@@ -166,15 +166,23 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   void _ensureWindowRefreshTimer() {
     _windowRefreshTimer?.cancel();
     _windowRefreshTimer = Timer.periodic(
-        const Duration(minutes: 15), (_) => _refreshWidgetRange());
+      const Duration(minutes: 15),
+      (_) => refreshWidgetRangeInBackground(),
+    );
   }
 
-  Future<void> _refreshWidgetRange() async {
+  Future<void> refreshWidgetRangeInBackground() async {
     if (_isDisposed) return;
-    var start = toStartOfDay(DateTime.now());
+    var start = toStartOfDay(now);
     var end = addDays(start, 14);
     try {
-      await updateSchedule(start, end, force: true);
+      // Keep widget data fresh without changing the currently visible week.
+      await updateSchedule(
+        start,
+        end,
+        force: true,
+        applyToVisibleState: false,
+      );
     } catch (error, trace) {
       print("Weekly schedule widget refresh failed: $error");
       print(trace);
@@ -244,8 +252,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   }
 
   Future goToToday() async {
-    currentDateStart =
-        toStartOfDay(toDayOfWeek(DateTime.now(), DateTime.monday));
+    currentDateStart = toStartOfDay(toDayOfWeek(now, DateTime.monday));
     currentDateEnd = toNextWeek(currentDateStart);
     await _openWeekFromCache(currentDateStart, currentDateEnd);
     await updateSchedule(currentDateStart, currentDateEnd);
@@ -280,20 +287,24 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
   }
 
-  Future updateSchedule(DateTime start, DateTime end,
-      {bool force = false}) async {
+  Future updateSchedule(
+    DateTime start,
+    DateTime end, {
+    bool force = false,
+    bool applyToVisibleState = true,
+  }) async {
     if (_isDisposed) return;
 
     if (_shouldSkipUpdate(start, end)) {
       return;
     }
 
-    var now = DateTime.now();
-    if (!_updateRequestGate.shouldAllow(start, end, now, force: force)) {
+    final nowValue = now;
+    if (!_updateRequestGate.shouldAllow(start, end, nowValue, force: force)) {
       return;
     }
 
-    if (!force && !_entryRefreshGate.isStale(start, end, now)) {
+    if (!force && !_entryRefreshGate.isStale(start, end, nowValue)) {
       return;
     }
 
@@ -313,26 +324,42 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
 
     try {
-      isUpdating = true;
-      notifyIfMounted("isUpdating");
+      if (applyToVisibleState) {
+        isUpdating = true;
+        notifyIfMounted("isUpdating");
+      }
 
       if (!scheduleSourceProvider.didSetupCorrectly()) {
-        updateFailed = true;
-        notifyIfMounted("updateFailed");
-        _cancelErrorInFuture();
+        if (applyToVisibleState) {
+          updateFailed = true;
+          notifyIfMounted("updateFailed");
+          _cancelErrorInFuture();
+        }
         _updateMutex.cancel();
         return;
       }
 
-      await _doUpdateSchedule(start, end);
+      await _doUpdateSchedule(
+        start,
+        end,
+        applyToVisibleState: applyToVisibleState,
+      );
     } finally {
-      isUpdating = false;
+      if (applyToVisibleState) {
+        isUpdating = false;
+      }
       _updateMutex.release();
-      notifyIfMounted("isUpdating");
+      if (applyToVisibleState) {
+        notifyIfMounted("isUpdating");
+      }
     }
   }
 
-  Future _doUpdateSchedule(DateTime start, DateTime end) async {
+  Future _doUpdateSchedule(
+    DateTime start,
+    DateTime end, {
+    bool applyToVisibleState = true,
+  }) async {
     print("Refreshing schedule...");
     final task = PerformanceTelemetry.instance
         .startTask('schedule.refresh.${start.toIso8601String()}');
@@ -349,14 +376,16 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     cancellationToken.throwIfCancelled();
     if (_isDisposed) return;
 
-    _setSchedule(cachedSchedule, start, end);
+    if (applyToVisibleState) {
+      _setSchedule(cachedSchedule, start, end);
+    }
 
-    final now = DateTime.now();
+    final nowValue = now;
     final shouldForceFetch = cachedSchedule.entries.isEmpty &&
         scheduleSourceProvider.currentScheduleSource.canQuery();
     final isStale = shouldForceFetch ||
-        _freshnessGate.isStale(start, end, now) ||
-        _isWindowStale(start, end, now);
+        _freshnessGate.isStale(start, end, nowValue) ||
+        _isWindowStale(start, end, nowValue);
 
     if (!isStale) {
       print("Schedule fresh; skip network fetch");
@@ -365,7 +394,13 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
 
     unawaited(
-      _refreshScheduleInBackground(start, end, cancellationToken, task),
+      _refreshScheduleInBackground(
+        start,
+        end,
+        cancellationToken,
+        task,
+        applyToVisibleState: applyToVisibleState,
+      ),
     );
   }
 
@@ -373,8 +408,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     DateTime start,
     DateTime end,
     CancellationToken cancellationToken,
-    developer.TimelineTask task,
-  ) async {
+    developer.TimelineTask task, {
+    bool applyToVisibleState = true,
+  }) async {
     ScheduleQueryResult? updatedSchedule;
     try {
       updatedSchedule = await _readScheduleFromService(
@@ -382,8 +418,8 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         end,
         cancellationToken,
       );
-      _freshnessGate.markFetched(start, end, DateTime.now());
-      _markWindowFetched(start, end, DateTime.now());
+      _freshnessGate.markFetched(start, end, now);
+      _markWindowFetched(start, end, now);
     } on OperationCancelledException {
       task.finish();
       return;
@@ -399,6 +435,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
 
     if (_isDisposed) {
+      task.finish();
+      return;
+    }
+
+    if (!applyToVisibleState) {
       task.finish();
       return;
     }
@@ -425,7 +466,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       }
 
       if (updatedSchedule != null) {
-        _entryRefreshGate.markFetched(start, end, DateTime.now());
+        _entryRefreshGate.markFetched(start, end, now);
       }
 
       updateFailed = (updatedSchedule == null);
@@ -527,13 +568,13 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   void _lockWidgetWeek(DateTime start, DateTime end) {
     _widgetLockedStart = start;
     _widgetLockedEnd = end;
-    _widgetLockExpiresAt = DateTime.now().add(const Duration(seconds: 6));
+    _widgetLockExpiresAt = now.add(const Duration(seconds: 6));
   }
 
   bool _shouldSkipUpdate(DateTime start, DateTime end) {
     final expiresAt = _widgetLockExpiresAt;
     if (expiresAt == null) return false;
-    if (DateTime.now().isAfter(expiresAt)) {
+    if (now.isAfter(expiresAt)) {
       _widgetLockedStart = null;
       _widgetLockedEnd = null;
       _widgetLockExpiresAt = null;

--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:animations/animations.dart';
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/ui/widgets/error_display.dart';
@@ -17,7 +19,8 @@ class WeeklySchedulePage extends StatefulWidget {
   _WeeklySchedulePageState createState() => _WeeklySchedulePageState();
 }
 
-class _WeeklySchedulePageState extends State<WeeklySchedulePage> {
+class _WeeklySchedulePageState extends State<WeeklySchedulePage>
+    with WidgetsBindingObserver {
   late WeeklyScheduleViewModel viewModel;
   double _dragDelta = 0;
   bool _isApplyingWidgetPayload = false;
@@ -27,6 +30,7 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     WidgetNavigationPayloadStore.instance.addListener(_handleWidgetPayload);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -36,8 +40,16 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     WidgetNavigationPayloadStore.instance.removeListener(_handleWidgetPayload);
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed || !mounted) return;
+    final model = Provider.of<WeeklyScheduleViewModel>(context, listen: false);
+    unawaited(model.refreshWidgetRangeInBackground());
   }
 
   void _showQueryFailedSnackBar() {

--- a/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
@@ -1,0 +1,199 @@
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/schedule/business/schedule_provider.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/model/schedule_query_result.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:dualmate/schedule/ui/viewmodels/weekly_schedule_view_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'background range refresh keeps the currently visible week anchored',
+    () async {
+      final entries = <ScheduleEntry>[
+        _entry(DateTime(2026, 2, 9), 'Mon'),
+        _entry(DateTime(2026, 2, 10), 'Tue'),
+        _entry(DateTime(2026, 2, 16), 'Mon'),
+        _entry(DateTime(2026, 2, 17), 'Tue'),
+        _entry(DateTime(2026, 2, 23), 'Mon'),
+      ];
+      final provider = _FakeScheduleProvider(entries);
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+
+      final visibleWeekStart = DateTime(2026, 2, 9);
+      final visibleWeekEnd = DateTime(2026, 2, 16);
+
+      await viewModel.updateSchedule(
+        visibleWeekStart,
+        visibleWeekEnd,
+        force: true,
+      );
+
+      expect(viewModel.currentDateStart, visibleWeekStart);
+      expect(viewModel.currentDateEnd, visibleWeekEnd);
+
+      final widgetRefreshStart = DateTime(2026, 2, 10);
+      final widgetRefreshEnd = DateTime(2026, 2, 24);
+
+      await viewModel.updateSchedule(
+        widgetRefreshStart,
+        widgetRefreshEnd,
+        force: true,
+        applyToVisibleState: false,
+      );
+
+      expect(viewModel.currentDateStart, visibleWeekStart);
+      expect(viewModel.currentDateEnd, visibleWeekEnd);
+      expect(viewModel.currentDateStart.weekday, DateTime.monday);
+
+      await viewModel.nextWeek();
+      expect(viewModel.currentDateStart.weekday, DateTime.monday);
+    },
+  );
+
+  test(
+    'midweek background refresh keeps previous weekdays in visible schedule',
+    () async {
+      var nowValue = DateTime(2026, 2, 11, 11, 0); // Wednesday
+      final entries = <ScheduleEntry>[
+        _entry(DateTime(2026, 2, 9), 'MONDAY_PREVIOUS'),
+        _entry(DateTime(2026, 2, 10), 'TUESDAY_PREVIOUS'),
+        _entry(DateTime(2026, 2, 11), 'WEDNESDAY_TODAY'),
+      ];
+      final provider = _FakeScheduleProvider(entries);
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        sourceProvider,
+        nowProvider: () => nowValue,
+      );
+
+      final visibleWeekStart = DateTime(2026, 2, 9);
+      final visibleWeekEnd = DateTime(2026, 2, 16);
+      await viewModel.updateSchedule(
+        visibleWeekStart,
+        visibleWeekEnd,
+        force: true,
+      );
+
+      final titlesBefore =
+          viewModel.weekSchedule!.entries.map((entry) => entry.title).toList();
+      expect(titlesBefore, contains('Course_MONDAY_PREVIOUS'));
+      expect(titlesBefore, contains('Course_TUESDAY_PREVIOUS'));
+
+      await viewModel.refreshWidgetRangeInBackground();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(viewModel.currentDateStart, visibleWeekStart);
+      expect(viewModel.currentDateEnd, visibleWeekEnd);
+      expect(viewModel.currentDateStart.weekday, DateTime.monday);
+
+      final titlesAfter =
+          viewModel.weekSchedule!.entries.map((entry) => entry.title).toList();
+      expect(titlesAfter, contains('Course_MONDAY_PREVIOUS'));
+      expect(titlesAfter, contains('Course_TUESDAY_PREVIOUS'));
+    },
+  );
+
+  test('visible range updates still replace the current week window', () async {
+    final entries = <ScheduleEntry>[
+      _entry(DateTime(2026, 2, 9), 'Mon'),
+      _entry(DateTime(2026, 2, 10), 'Tue'),
+      _entry(DateTime(2026, 2, 16), 'Mon'),
+    ];
+    final provider = _FakeScheduleProvider(entries);
+    final sourceProvider = _FakeScheduleSourceProvider();
+    final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+
+    final initialStart = DateTime(2026, 2, 9);
+    final initialEnd = DateTime(2026, 2, 16);
+    await viewModel.updateSchedule(initialStart, initialEnd, force: true);
+
+    final updatedStart = DateTime(2026, 2, 10);
+    final updatedEnd = DateTime(2026, 2, 24);
+    await viewModel.updateSchedule(updatedStart, updatedEnd, force: true);
+
+    expect(viewModel.currentDateStart, updatedStart);
+    expect(viewModel.currentDateEnd, updatedEnd);
+  });
+}
+
+ScheduleEntry _entry(DateTime start, String suffix) {
+  return ScheduleEntry(
+    start: DateTime(start.year, start.month, start.day, 9),
+    end: DateTime(start.year, start.month, start.day, 10),
+    title: 'Course_$suffix',
+    details: 'Lecture',
+    professor: 'Prof',
+    room: 'R1',
+    type: ScheduleEntryType.Class,
+  );
+}
+
+class _FakeScheduleProvider implements ScheduleProvider {
+  final List<ScheduleEntry> _entries;
+
+  _FakeScheduleProvider(this._entries);
+
+  @override
+  Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
+    return _trim(start, end);
+  }
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken,
+  ) async {
+    return ScheduleQueryResult(_trim(start, end), const []);
+  }
+
+  Schedule _trim(DateTime start, DateTime end) {
+    final entries = _entries.where((entry) {
+      return start.isBefore(entry.end) && end.isAfter(entry.start);
+    }).toList();
+    return Schedule.fromList(entries);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeScheduleSourceProvider implements ScheduleSourceProvider {
+  final ScheduleSource _source = _FakeScheduleSource();
+
+  @override
+  ScheduleSource get currentScheduleSource => _source;
+
+  @override
+  bool didSetupCorrectly() => true;
+
+  @override
+  void addDidChangeScheduleSourceCallback(OnDidChangeScheduleSource callback) {}
+
+  @override
+  void removeDidChangeScheduleSourceCallback(
+    OnDidChangeScheduleSource callback,
+  ) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeScheduleSource implements ScheduleSource {
+  @override
+  bool canQuery() => true;
+
+  @override
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    return ScheduleQueryResult(Schedule(), const []);
+  }
+}

--- a/test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart
+++ b/test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart
@@ -1,0 +1,177 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/schedule/business/schedule_provider.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/model/schedule_query_result.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:dualmate/schedule/ui/viewmodels/weekly_schedule_view_model.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/weekly_schedule_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'resume-triggered background refresh keeps monday lessons visible',
+    (tester) async {
+      const mondayTitle = 'MONDAY_ANCHOR';
+      final entries = <ScheduleEntry>[
+        _entry(DateTime(2026, 2, 9), mondayTitle),
+        _entry(DateTime(2026, 2, 10), 'TUESDAY_ENTRY'),
+        _entry(DateTime(2026, 2, 16), 'NEXT_MONDAY'),
+      ];
+      final provider = _TrackingScheduleProvider(entries);
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final nowOnTuesday = DateTime(2026, 2, 10, 11, 0);
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        sourceProvider,
+        nowProvider: () => nowOnTuesday,
+      );
+
+      await viewModel.updateSchedule(
+        DateTime(2026, 2, 9),
+        DateTime(2026, 2, 16),
+        force: true,
+      );
+
+      await tester.pumpWidget(_wrapWithApp(viewModel));
+      await tester.pump();
+
+      expect(find.text(mondayTitle), findsOneWidget);
+      expect(viewModel.currentDateStart, DateTime(2026, 2, 9));
+      expect(viewModel.currentDateStart.weekday, DateTime.monday);
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(viewModel.currentDateStart, DateTime(2026, 2, 9));
+      expect(viewModel.currentDateStart.weekday, DateTime.monday);
+      expect(find.text(mondayTitle), findsOneWidget);
+
+      expect(
+        provider.cachedRequests.any(
+          (request) =>
+              request.start == DateTime(2026, 2, 10) &&
+              request.end == DateTime(2026, 2, 24),
+        ),
+        isTrue,
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      viewModel.dispose();
+    },
+  );
+}
+
+Widget _wrapWithApp(WeeklyScheduleViewModel viewModel) {
+  return ChangeNotifierProvider<WeeklyScheduleViewModel>.value(
+    value: viewModel,
+    child: MaterialApp(
+      localizationsDelegates: const [
+        LocalizationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('de')],
+      home: Scaffold(
+        body: WeeklySchedulePage(),
+      ),
+    ),
+  );
+}
+
+ScheduleEntry _entry(DateTime day, String title) {
+  return ScheduleEntry(
+    start: DateTime(day.year, day.month, day.day, 9),
+    end: DateTime(day.year, day.month, day.day, 10),
+    title: title,
+    details: 'Lecture',
+    professor: 'Prof',
+    room: 'R1',
+    type: ScheduleEntryType.Class,
+  );
+}
+
+class _TrackingScheduleProvider implements ScheduleProvider {
+  final List<ScheduleEntry> _entries;
+  final List<_RangeRequest> cachedRequests = <_RangeRequest>[];
+
+  _TrackingScheduleProvider(this._entries);
+
+  @override
+  Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
+    cachedRequests.add(_RangeRequest(start, end));
+    return _trim(start, end);
+  }
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken,
+  ) async {
+    return ScheduleQueryResult(_trim(start, end), const []);
+  }
+
+  Schedule _trim(DateTime start, DateTime end) {
+    final entries = _entries.where((entry) {
+      return start.isBefore(entry.end) && end.isAfter(entry.start);
+    }).toList();
+    return Schedule.fromList(entries);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RangeRequest {
+  final DateTime start;
+  final DateTime end;
+
+  _RangeRequest(this.start, this.end);
+}
+
+class _FakeScheduleSourceProvider implements ScheduleSourceProvider {
+  final ScheduleSource _source = _FakeScheduleSource();
+
+  @override
+  ScheduleSource get currentScheduleSource => _source;
+
+  @override
+  bool didSetupCorrectly() => true;
+
+  @override
+  void addDidChangeScheduleSourceCallback(OnDidChangeScheduleSource callback) {}
+
+  @override
+  void removeDidChangeScheduleSourceCallback(
+    OnDidChangeScheduleSource callback,
+  ) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeScheduleSource implements ScheduleSource {
+  @override
+  bool canQuery() => true;
+
+  @override
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    return ScheduleQueryResult(Schedule(), const []);
+  }
+}


### PR DESCRIPTION
fix #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Monday lessons would disappear when resuming the app from the background. The schedule now properly maintains visibility of all lessons during background synchronization, ensuring that your weekly view remains consistent and complete even after the app is suspended and resumed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->