### PR TITLE
fix: avoid empty schedule filters on first launch

### DIFF
--- a/lib/schedule/ui/schedule_page.dart
+++ b/lib/schedule/ui/schedule_page.dart
@@ -168,7 +168,14 @@ class _SchedulePageState extends State<SchedulePage> {
 
   Future<void> _warmFilterPageState() async {
     try {
-      await Future.delayed(const Duration(milliseconds: 250));
+      final scheduleViewModel =
+          Provider.of<ScheduleViewModel>(context, listen: false);
+      final deadline = DateTime.now().add(const Duration(seconds: 3));
+      while (mounted &&
+          scheduleViewModel.isInitializingScheduleSource &&
+          DateTime.now().isBefore(deadline)) {
+        await Future.delayed(const Duration(milliseconds: 120));
+      }
       if (!mounted) return;
       await FilterViewModel.preloadStates(
         KiwiContainer().resolve<ScheduleEntryRepository>(),

--- a/lib/schedule/ui/schedule_page.dart
+++ b/lib/schedule/ui/schedule_page.dart
@@ -181,9 +181,15 @@ class _SchedulePageState extends State<SchedulePage> {
         KiwiContainer().resolve<ScheduleEntryRepository>(),
         KiwiContainer().resolve<ScheduleFilterRepository>(),
       );
-    } catch (error, trace) {
+    } on ProviderNotFoundException {
+      rethrow;
+    } on FlutterError catch (error, trace) {
       debugPrint('Failed to warm filter state: $error');
       debugPrint('$trace');
+    } catch (error, trace) {
+      debugPrint('Unexpected error while warming filter state: $error');
+      debugPrint('$trace');
+      rethrow;
     }
   }
 }

--- a/lib/schedule/ui/weeklyschedule/filter/filter_view_model.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/filter_view_model.dart
@@ -49,7 +49,13 @@ class FilterViewModel extends BaseViewModel {
     if (_cachedStates != null) return;
     _cachedStatesFuture ??=
         _loadStates(scheduleEntryRepository, scheduleFilterRepository);
-    _cachedStates = _cloneStates(await _cachedStatesFuture!);
+    final loadedStates = await _cachedStatesFuture!;
+    if (loadedStates.isEmpty) {
+      _cachedStates = null;
+      _cachedStatesFuture = null;
+      return;
+    }
+    _cachedStates = _cloneStates(loadedStates);
   }
 
   /// Clears the static cache so the next load reflects latest repository data.
@@ -80,7 +86,12 @@ class FilterViewModel extends BaseViewModel {
     _cachedStatesFuture ??=
         _loadStates(_scheduleEntryRepository, _scheduleFilterRepository);
     final loadedStates = await _cachedStatesFuture!;
-    _cachedStates = _cloneStates(loadedStates);
+    if (loadedStates.isEmpty) {
+      _cachedStates = null;
+      _cachedStatesFuture = null;
+    } else {
+      _cachedStates = _cloneStates(loadedStates);
+    }
     filterStates = _cloneStates(loadedStates);
 
     notifyIfMounted("filterStates");

--- a/test/schedule/ui/viewmodels/filter_view_model_cache_test.dart
+++ b/test/schedule/ui/viewmodels/filter_view_model_cache_test.dart
@@ -1,0 +1,104 @@
+import 'package:dualmate/schedule/business/schedule_provider.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
+import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/filter/filter_view_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() {
+    FilterViewModel.resetCachedStateForTesting();
+  });
+
+  test('preload does not keep empty states as final cache', () async {
+    final entryRepository = _FakeScheduleEntryRepository([]);
+    final filterRepository = _FakeScheduleFilterRepository([]);
+
+    await FilterViewModel.preloadStates(entryRepository, filterRepository);
+
+    entryRepository.names = ['Class B', 'Class A'];
+    final viewModel = FilterViewModel(
+      entryRepository,
+      filterRepository,
+      _FakeScheduleSourceProvider(),
+      _FakeScheduleProvider(),
+    );
+
+    await viewModel.initialize();
+
+    expect(
+        viewModel.filterStates.map((e) => e.entryName), ['Class A', 'Class B']);
+    expect(entryRepository.queryAllNamesCallCount, 2);
+  });
+
+  test('preload keeps non-empty states for fast open', () async {
+    final entryRepository = _FakeScheduleEntryRepository(['Class A']);
+    final filterRepository = _FakeScheduleFilterRepository([]);
+
+    await FilterViewModel.preloadStates(entryRepository, filterRepository);
+
+    entryRepository.names = ['Class B'];
+    final viewModel = FilterViewModel(
+      entryRepository,
+      filterRepository,
+      _FakeScheduleSourceProvider(),
+      _FakeScheduleProvider(),
+    );
+
+    await viewModel.initialize();
+
+    expect(viewModel.filterStates.map((e) => e.entryName), ['Class A']);
+    expect(entryRepository.queryAllNamesCallCount, 1);
+  });
+}
+
+class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
+  List<String> names;
+  int queryAllNamesCallCount = 0;
+
+  _FakeScheduleEntryRepository(this.names);
+
+  @override
+  Future<List<String>> queryAllNamesOfScheduleEntries() async {
+    queryAllNamesCallCount += 1;
+    return List<String>.from(names);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+        'Unexpected ScheduleEntryRepository call: $invocation');
+  }
+}
+
+class _FakeScheduleFilterRepository implements ScheduleFilterRepository {
+  final List<String> hiddenNames;
+
+  _FakeScheduleFilterRepository(this.hiddenNames);
+
+  @override
+  Future<List<String>> queryAllHiddenNames() async {
+    return List<String>.from(hiddenNames);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+        'Unexpected ScheduleFilterRepository call: $invocation');
+  }
+}
+
+class _FakeScheduleSourceProvider implements ScheduleSourceProvider {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+        'Unexpected ScheduleSourceProvider call: $invocation');
+  }
+}
+
+class _FakeScheduleProvider implements ScheduleProvider {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError('Unexpected ScheduleProvider call: $invocation');
+  }
+}

--- a/test/schedule/ui/weeklyschedule/filter/filter_view_model_cache_test.dart
+++ b/test/schedule/ui/weeklyschedule/filter/filter_view_model_cache_test.dart
@@ -10,6 +10,10 @@ void main() {
     FilterViewModel.resetCachedStateForTesting();
   });
 
+  tearDown(() {
+    FilterViewModel.resetCachedStateForTesting();
+  });
+
   test('preload does not keep empty states as final cache', () async {
     final entryRepository = _FakeScheduleEntryRepository([]);
     final filterRepository = _FakeScheduleFilterRepository([]);
@@ -27,7 +31,9 @@ void main() {
     await viewModel.initialize();
 
     expect(
-        viewModel.filterStates.map((e) => e.entryName), ['Class A', 'Class B']);
+      viewModel.filterStates.map((e) => e.entryName),
+      ['Class A', 'Class B'],
+    );
     expect(entryRepository.queryAllNamesCallCount, 2);
   });
 
@@ -50,6 +56,23 @@ void main() {
     expect(viewModel.filterStates.map((e) => e.entryName), ['Class A']);
     expect(entryRepository.queryAllNamesCallCount, 1);
   });
+
+  test('loadFilterStates handles empty results without preload', () async {
+    final entryRepository = _FakeScheduleEntryRepository([]);
+    final filterRepository = _FakeScheduleFilterRepository([]);
+
+    final viewModel = FilterViewModel(
+      entryRepository,
+      filterRepository,
+      _FakeScheduleSourceProvider(),
+      _FakeScheduleProvider(),
+    );
+
+    await viewModel.initialize();
+
+    expect(viewModel.filterStates, isEmpty);
+    expect(entryRepository.queryAllNamesCallCount, 1);
+  });
 }
 
 class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
@@ -67,7 +90,8 @@ class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
   @override
   dynamic noSuchMethod(Invocation invocation) {
     throw UnsupportedError(
-        'Unexpected ScheduleEntryRepository call: $invocation');
+      'Unexpected ScheduleEntryRepository call: $invocation',
+    );
   }
 }
 
@@ -84,7 +108,8 @@ class _FakeScheduleFilterRepository implements ScheduleFilterRepository {
   @override
   dynamic noSuchMethod(Invocation invocation) {
     throw UnsupportedError(
-        'Unexpected ScheduleFilterRepository call: $invocation');
+      'Unexpected ScheduleFilterRepository call: $invocation',
+    );
   }
 }
 
@@ -92,7 +117,8 @@ class _FakeScheduleSourceProvider implements ScheduleSourceProvider {
   @override
   dynamic noSuchMethod(Invocation invocation) {
     throw UnsupportedError(
-        'Unexpected ScheduleSourceProvider call: $invocation');
+      'Unexpected ScheduleSourceProvider call: $invocation',
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent first-launch filter prewarm from freezing an empty filter cache
- wait for schedule source initialization before preloading filter states
- add regression tests for empty-cache vs non-empty-cache preload behavior

## Testing
- `flutter test test/schedule/ui/viewmodels/filter_view_model_cache_test.dart test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart`
- `flutter analyze` *(fails on existing third_party/path_provider_android pigeon dependency issues unrelated to this change)*

## Notes
- keeps warm-path behavior for non-empty preload results
- fixes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule initialization handling with conditional waiting and enhanced error handling
  * Fixed filter state caching to prevent stale or empty data from persisting

* **Tests**
  * Added comprehensive unit test coverage for filter state caching behavior and preload functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->