### PR TITLE
fix(schedule): clarify weekly current-time indicator

### DIFF
--- a/docs/solutions/ui-bugs/current-time-indicator-clarity-weekly-calendar-20260225.md
+++ b/docs/solutions/ui-bugs/current-time-indicator-clarity-weekly-calendar-20260225.md
@@ -1,0 +1,61 @@
+---
+module: Schedule UI
+date: 2026-02-25
+problem_type: ui_bug
+component: frontend_flutter
+symptoms:
+  - "Current time in weekly calendar is hard to identify"
+  - "Current-time cue is mostly perceived as background shade"
+  - "No explicit current-time line in the visible schedule grid"
+root_cause: missing_explicit_now_indicator
+resolution_type: code_fix
+severity: medium
+tags: [schedule, weekly-calendar, ui, material3, accessibility]
+---
+
+# Troubleshooting: Current-time indicator is unclear in weekly calendar
+
+## Problem
+
+Weekly calendar used only the past-time shading overlay as the visual cue for now. This made the current time hard to locate, especially in sparse schedules or when shading blended with lesson blocks.
+
+## Root Cause
+
+- `ScheduleWidget` rendered `SchedulePastOverlay` but had no explicit "now" line.
+- Existing `colorCurrentTimeIndicator(...)` token was available but only used in daily-list indicator UI.
+- Without a dedicated overlay line, users had to infer the current time from broad background tint.
+
+## Solution
+
+- Added a dedicated weekly overlay widget:
+  - `lib/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart`
+- Wired it into `ScheduleWidget` with minute-precise vertical positioning:
+  - `lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart`
+- Indicator behavior:
+  - show only for the today column
+  - show only when now is within `displayStartHour <= now < displayEndHour`
+  - hide when now is outside visible hours
+  - ignore hit testing so lesson taps are not blocked
+- Updated current-time indicator color token to use Material 3 theme role (`onSurface` with alpha):
+  - `lib/common/ui/colors.dart`
+
+## Test Coverage
+
+- Added `test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart`:
+  - `shows weekly current-time indicator when now is in range`
+  - `hides weekly current-time indicator before visible hours`
+  - `hides weekly current-time indicator after visible hours`
+  - `weekly current-time indicator does not block entry taps`
+
+## Verification Commands
+
+```bash
+flutter test test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart
+flutter test test/schedule/ui/weeklyschedule/schedule_widget_layout_profile_test.dart test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+flutter test test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
+flutter analyze lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart lib/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart lib/common/ui/colors.dart test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart
+```
+
+## Notes
+
+- Analyzer output includes an existing informational deprecation notice for `useMaterial3` in `lib/common/ui/colors.dart` that predates this fix and does not block the feature behavior.

--- a/lib/common/ui/colors.dart
+++ b/lib/common/ui/colors.dart
@@ -44,9 +44,7 @@ Color colorScheduleInPastOverlay(BuildContext context) =>
         : const Color(0x2B000000);
 
 Color colorCurrentTimeIndicator(BuildContext context) =>
-    Theme.of(context).brightness == Brightness.light
-        ? const Color(0xffffa500)
-        : const Color(0xffb37300);
+    Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.88);
 
 Color colorOnboardingDecorationForeground(BuildContext context) =>
     Theme.of(context).brightness == Brightness.light

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+class ScheduleCurrentTimeIndicator extends StatelessWidget {
+  static const Key lineKey = ValueKey('schedule-current-time-line');
+  static const Key markerKey = ValueKey('schedule-current-time-marker');
+
+  final int dayIndex;
+  final int columns;
+  final double yOffset;
+  final Color color;
+  final double strokeWidth;
+  final double markerDiameter;
+
+  const ScheduleCurrentTimeIndicator({
+    super.key,
+    required this.dayIndex,
+    required this.columns,
+    required this.yOffset,
+    required this.color,
+    this.strokeWidth = 2,
+    this.markerDiameter = 8,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (columns <= 0) return const SizedBox.shrink();
+
+    return IgnorePointer(
+      child: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          final columnWidth = constraints.maxWidth / columns;
+          final top = yOffset - (strokeWidth / 2);
+          final markerTop = yOffset - (markerDiameter / 2);
+          final left = dayIndex * columnWidth;
+
+          return Stack(
+            clipBehavior: Clip.hardEdge,
+            children: <Widget>[
+              Positioned(
+                left: left,
+                top: top,
+                width: columnWidth,
+                height: strokeWidth,
+                child: DecoratedBox(
+                  key: lineKey,
+                  decoration: BoxDecoration(color: color),
+                ),
+              ),
+              Positioned(
+                left: left,
+                top: markerTop,
+                width: markerDiameter,
+                height: markerDiameter,
+                child: DecoratedBox(
+                  key: markerKey,
+                  decoration: BoxDecoration(
+                    color: color,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart
@@ -6,6 +6,7 @@ import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_entry_alignment.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_grid.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_past_overlay.dart';
 import 'package:flutter/material.dart';
@@ -76,6 +77,10 @@ class ScheduleWidget extends StatelessWidget {
     final visibleHours = (displayEndHour - displayStartHour).clamp(1.0, 24.0);
     var hourHeight = (height - dayLabelsHeight) / visibleHours;
     var minuteHeight = hourHeight / 60;
+    final currentTimeIndicatorGeometry = _resolveCurrentTimeIndicatorGeometry(
+      days,
+      minuteHeight,
+    );
 
     var labelWidgets = buildLabelWidgets(
       context,
@@ -130,8 +135,53 @@ class ScheduleWidget extends StatelessWidget {
             now,
             days,
           ),
-        )
+        ),
+        if (currentTimeIndicatorGeometry != null)
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              timeLabelsWidth,
+              dayLabelsHeight,
+              0,
+              0,
+            ),
+            child: ScheduleCurrentTimeIndicator(
+              dayIndex: currentTimeIndicatorGeometry.dayIndex,
+              columns: days,
+              yOffset: currentTimeIndicatorGeometry.yOffset,
+              color: colorCurrentTimeIndicator(context),
+            ),
+          ),
       ],
+    );
+  }
+
+  _CurrentTimeIndicatorGeometry? _resolveCurrentTimeIndicatorGeometry(
+    int days,
+    double minuteHeight,
+  ) {
+    final visibleStartDay = toStartOfDay(displayStart);
+    final visibleEndDay = toStartOfDay(displayEnd);
+    final currentDay = toStartOfDay(now);
+
+    if (currentDay.isBefore(visibleStartDay) ||
+        currentDay.isAfter(visibleEndDay)) {
+      return null;
+    }
+
+    final dayIndex = currentDay.difference(visibleStartDay).inDays;
+    if (dayIndex < 0 || dayIndex >= days) return null;
+
+    final nowMinutes = (now.hour * 60) + now.minute;
+    final startMinutes = displayStartHour * 60;
+    final endMinutes = displayEndHour * 60;
+    if (nowMinutes < startMinutes || nowMinutes >= endMinutes) {
+      return null;
+    }
+
+    final yOffset = (nowMinutes - startMinutes) * minuteHeight;
+    return _CurrentTimeIndicatorGeometry(
+      dayIndex: dayIndex,
+      yOffset: yOffset,
     );
   }
 
@@ -461,5 +511,15 @@ class _ScheduleWidgetLayoutProfile {
     required this.eventVerticalGap,
     required this.dayLabelHorizontalPadding,
     required this.dayBoundaryInset,
+  });
+}
+
+class _CurrentTimeIndicatorGeometry {
+  final int dayIndex;
+  final double yOffset;
+
+  const _CurrentTimeIndicatorGeometry({
+    required this.dayIndex,
+    required this.yOffset,
   });
 }

--- a/test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart
@@ -32,6 +32,18 @@ void main() {
     expect(find.byType(ScheduleCurrentTimeIndicator), findsNothing);
   });
 
+  testWidgets('shows weekly current-time indicator at visible start hour', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildApp(
+        now: DateTime(2026, 2, 11, 7, 0),
+      ),
+    );
+
+    expect(find.byType(ScheduleCurrentTimeIndicator), findsOneWidget);
+  });
+
   testWidgets('hides weekly current-time indicator after visible hours', (
     tester,
   ) async {

--- a/test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart
@@ -1,0 +1,128 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows weekly current-time indicator when now is in range', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildApp(
+        now: DateTime(2026, 2, 11, 12, 15),
+      ),
+    );
+
+    expect(find.byType(ScheduleCurrentTimeIndicator), findsOneWidget);
+  });
+
+  testWidgets('hides weekly current-time indicator before visible hours', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildApp(
+        now: DateTime(2026, 2, 11, 6, 55),
+      ),
+    );
+
+    expect(find.byType(ScheduleCurrentTimeIndicator), findsNothing);
+  });
+
+  testWidgets('hides weekly current-time indicator after visible hours', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildApp(
+        now: DateTime(2026, 2, 11, 19, 0),
+      ),
+    );
+
+    expect(find.byType(ScheduleCurrentTimeIndicator), findsNothing);
+  });
+
+  testWidgets('hides weekly current-time indicator when today is not visible', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildApp(
+        now: DateTime(2026, 3, 1, 12, 0),
+      ),
+    );
+
+    expect(find.byType(ScheduleCurrentTimeIndicator), findsNothing);
+  });
+
+  testWidgets('weekly current-time indicator does not block entry taps', (
+    tester,
+  ) async {
+    var tapCount = 0;
+
+    await tester.pumpWidget(
+      _buildApp(
+        now: DateTime(2026, 2, 11, 12, 15),
+        schedule: Schedule.fromList([
+          _entry(
+            DateTime(2026, 2, 11, 12, 0),
+            DateTime(2026, 2, 11, 13, 0),
+            'Operating Systems',
+          ),
+        ]),
+        onTap: (_) => tapCount++,
+      ),
+    );
+
+    await tester.tap(find.text('Operating Systems'));
+    await tester.pump();
+
+    expect(tapCount, 1);
+  });
+}
+
+Widget _buildApp({
+  required DateTime now,
+  Schedule? schedule,
+  void Function(ScheduleEntry)? onTap,
+}) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      LocalizationDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('en'), Locale('de')],
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 360,
+          height: 680,
+          child: ScheduleWidget(
+            schedule: schedule ?? Schedule(),
+            displayStart: DateTime(2026, 2, 9),
+            displayEnd: DateTime(2026, 2, 13),
+            onScheduleEntryTap: onTap ?? (_) {},
+            now: now,
+            displayStartHour: 7.0,
+            displayEndHour: 19.0,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+ScheduleEntry _entry(DateTime start, DateTime end, String title) {
+  return ScheduleEntry(
+    start: start,
+    end: end,
+    title: title,
+    details: 'Details',
+    professor: 'Prof',
+    room: 'R1',
+    type: ScheduleEntryType.Class,
+  );
+}

--- a/test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart
@@ -75,6 +75,9 @@ void main() {
       ),
     );
 
+    await tester.pumpAndSettle();
+    expect(find.byType(ScheduleCurrentTimeIndicator), findsOneWidget);
+
     await tester.tap(find.text('Operating Systems'));
     await tester.pump();
 


### PR DESCRIPTION
## Summary
- Add a dedicated weekly calendar current-time indicator overlay (`line + marker`) so "now" is explicit instead of inferred from shading.
- Show the indicator only when today is visible and `displayStartHour <= now < displayEndHour`; hide it outside visible hours.
- Keep lesson interactions intact by rendering the indicator in an `IgnorePointer` overlay and documenting the fix in `docs/solutions/ui-bugs/current-time-indicator-clarity-weekly-calendar-20260225.md`.

## Why
Issue #34 reports that the current-time cue in calendar view is unclear and mostly visible as shade on lesson blocks. This change provides a clear Material 3-aligned indicator while preserving existing schedule refresh and lifecycle behavior.

## Testing
- `flutter test test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart`
- `flutter test test/schedule/ui/weeklyschedule/schedule_widget_layout_profile_test.dart test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart`
- `flutter analyze lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart lib/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart lib/common/ui/colors.dart test/schedule/ui/weeklyschedule/schedule_current_time_indicator_test.dart`

## Notes
- Analyzer output includes an existing info-level deprecation warning for `useMaterial3` in `lib/common/ui/colors.dart`.
- Unrelated local untracked plan files were intentionally left out of this PR.

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a current-time indicator to the weekly schedule: a horizontal line with a circular marker shown only on today's column while within visible hours.

* **Behavior**
  * Indicator is positioned with minute precision, respects display start/end hours, and is hidden outside the visible range.
  * Indicator ignores pointer hits so taps on entries are not blocked.

* **Style**
  * Current-time indicator color updated to use the theme's surface-on color with alpha.

* **Tests**
  * Added tests for visibility rules and non-blocking interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->