### PR TITLE
feat(dates): show lecturer names on Rapla exam rows

### DIFF
--- a/docs/plans/2026-03-08-feat-show-lecturer-names-klausur-events-plan.md
+++ b/docs/plans/2026-03-08-feat-show-lecturer-names-klausur-events-plan.md
@@ -1,0 +1,239 @@
+---
+title: "feat: Show lecturer names for Rapla exam events"
+type: feat
+date: 2026-03-08
+priority: medium
+estimated_effort: 0.5-1 day
+tags: [dates, rapla, exams, ui]
+source_issue: 40
+---
+
+# feat: Show lecturer names for Rapla exam events
+
+## Overview
+
+Add lecturer names to individual Rapla exam rows on the Dates page so students can distinguish vague exam titles such as `Klausur`. This should apply to all Rapla events with `ScheduleEntryType.Exam`, while keeping the existing `Klausurwoche` grouping, pagination, and cache behavior unchanged.
+
+## Problem Statement / Motivation
+
+The Dates page currently loses lecturer metadata before rendering Rapla important events. `RaplaParsingUtils` already extracts lecturer names from the Rapla tooltip, but `RaplaImportantEventsProvider` drops that data when it converts `ScheduleEntry` records into `ImportantEvent` models, and `ImportantEventTile` only renders a title and date.
+
+As a result, students can see an exam entry but still be unable to tell which module it belongs to when the title is generic or incomplete.
+
+## Research Summary
+
+### Research Decision
+
+External research is not needed for this plan. The repository already contains the relevant data flow, UI patterns, and solution docs for this feature, and the requested change is a localized UI/data-mapping enhancement rather than a new framework or high-risk integration.
+
+### Key Findings
+
+- `lib/schedule/service/rapla/rapla_parsing_utils.dart:109` already extracts lecturer names into `ScheduleEntry.professor` from Rapla `Personen:` data.
+- `lib/date_management/business/rapla_important_events_provider.dart:108` creates exam `ImportantEvent` objects without preserving lecturer data.
+- `lib/date_management/model/important_event.dart:3` has no lecturer field today.
+- `lib/date_management/ui/widgets/important_event_tile.dart:37` only renders title and formatted date.
+- `lib/date_management/business/important_event_organizer.dart:27` groups exam rows under `Klausurwoche`; this behavior should remain untouched.
+
+### Relevant Learnings
+
+- `docs/solutions/ui-bugs/date-blocks-too-tall-20260202.md`
+  - Keep the Dates list compact and avoid inflating cards unnecessarily.
+- `docs/solutions/ui-bugs/first-load-dates-pagination-stops-3-months-20260202.md`
+  - Avoid incidental changes to Rapla paging or first-load prefetch behavior.
+- `docs/rapla_dates_integration.md`
+  - Rapla dates are already intended to show grouped exam weeks and important-event rows fed from schedule data.
+
+## Stakeholders
+
+- Students using the Dates page to identify upcoming exams.
+- Developers maintaining Rapla-to-Dates data mapping.
+- QA/manual testers verifying Android behavior and locale rendering.
+
+## Proposed Solution
+
+### High-Level Approach
+
+1. Extend `ImportantEvent` with optional lecturer metadata.
+2. Preserve `ScheduleEntry.professor` when `RaplaImportantEventsProvider` maps exam entries.
+3. Render lecturer names as visually secondary text on individual exam rows.
+4. Do not show lecturer names for `Klausurwoche` headers or non-exam events.
+5. If lecturer data is missing, keep the current layout without placeholder text.
+
+### Recommended UX Behavior
+
+- Treat the request as applying to all Rapla `ScheduleEntryType.Exam` events, not only titles that literally contain `Klausur`.
+- Show lecturer text only on child exam rows, never on grouped section headers.
+- Prefer plain secondary text over adding a new labeled field, unless product wants a stronger label later.
+- Keep long lecturer strings constrained so tiles remain readable on narrow Android screens.
+
+## Scope
+
+### In Scope
+
+- Rapla-backed exam rows on the Dates page.
+- Data mapping from `ScheduleEntry.professor` to `ImportantEvent`.
+- Widget and unit test updates for the changed model and rendering.
+- Localization only if a visible label is introduced.
+
+### Out of Scope
+
+- Module inference or auto-renaming vague exam titles.
+- DHmine dates.
+- Room display.
+- Changes to grouping, filtering, caching, pagination, or schedule screens.
+- Reworking the Dates page layout beyond the extra lecturer line.
+
+## Technical Considerations
+
+- `ImportantEvent` serialization should stay backward-tolerant so older cached JSON without lecturer data still parses cleanly.
+- Grouped `Klausurwoche` headers are rebuilt in `lib/date_management/business/important_event_organizer.dart`; they should keep empty lecturer metadata.
+- Merged non-exam events should not inherit lecturer names, because merged rows can span multiple source entries.
+- The tile layout should stay compact to avoid regressing the card-height fix documented in `docs/solutions/ui-bugs/date-blocks-too-tall-20260202.md`.
+- If multiple lecturers are present, the first implementation should render the parsed Rapla string as-is rather than trying to normalize names.
+
+## Acceptance Criteria
+
+- [ ] `lib/date_management/model/important_event.dart` stores optional lecturer text for event rows.
+- [ ] `lib/date_management/business/rapla_important_events_provider.dart` preserves `ScheduleEntry.professor` for all Rapla `ScheduleEntryType.Exam` items.
+- [ ] `lib/date_management/ui/widgets/important_event_tile.dart` shows lecturer names on individual exam rows when lecturer text is non-empty.
+- [ ] `lib/date_management/ui/widgets/important_event_section_card.dart` keeps `Klausurwoche` headers free of lecturer text.
+- [ ] Non-exam Rapla events keep their current appearance.
+- [ ] Exam rows without lecturer data render cleanly without placeholder text or broken spacing.
+- [ ] Existing exam grouping and ordering remain unchanged.
+- [ ] English and German layouts remain readable on narrow mobile screens.
+- [ ] Automated tests cover model serialization/equality, provider mapping, and exam tile rendering.
+
+## Implementation Outline
+
+### Phase 1: Preserve Lecturer Metadata
+
+**Files**
+
+- `lib/date_management/model/important_event.dart`
+- `test/date_management/model/important_event_test.dart`
+
+**Tasks**
+
+- Add an optional lecturer field such as `professor` or `lecturerNames` to `ImportantEvent`.
+- Update constructor, `fromJson`, `toJson`, equality, and `hashCode`.
+- Add test coverage for the new field so cache serialization remains explicit.
+
+### Phase 2: Map Lecturer Data from Rapla
+
+**Files**
+
+- `lib/date_management/business/rapla_important_events_provider.dart`
+- `test/date_management/business/rapla_important_events_provider_test.dart`
+
+**Tasks**
+
+- Pass `entry.professor` into `ImportantEvent` when mapping exam rows.
+- Keep merged non-exam rows free of lecturer metadata.
+- Add regression coverage to prove exam rows preserve lecturer data and still do not merge across days.
+
+### Phase 3: Render Lecturer Names on Exam Tiles
+
+**Files**
+
+- `lib/date_management/ui/widgets/important_event_tile.dart`
+- `lib/date_management/ui/widgets/important_event_section_card.dart`
+
+**Tasks**
+
+- Render lecturer text only when `event.type == ScheduleEntryType.Exam` and lecturer data is present.
+- Keep lecturer text visually secondary to the title.
+- Constrain long lecturer strings to avoid card-height blowups and awkward wrapping.
+- Ensure grouped `Klausurwoche` headers remain unchanged.
+
+### Phase 4: Add Widget Coverage
+
+**Files**
+
+- `test/date_management/ui/widgets/important_event_tile_test.dart`
+- or `test/date_management/ui/date_management_page_test.dart`
+
+**Tasks**
+
+- Cover an exam row with lecturer data.
+- Cover an exam row without lecturer data.
+- Cover a non-exam row to confirm no UI regression.
+- Cover a grouped `Klausurwoche` section to confirm only child exam rows show lecturers.
+
+## SpecFlow Notes
+
+### Primary User Flow
+
+1. Student opens the Dates page.
+2. Rapla important events load.
+3. Student sees a generic exam row under `Klausurwoche` or as a standalone exam entry.
+4. Lecturer names appear directly on the row.
+5. Student uses the lecturer names to infer the correct module.
+
+### Edge Cases
+
+- Rapla exam row has no `Personen:` data.
+- Rapla returns multiple lecturer names in one field.
+- Lecturer string is long enough to wrap or truncate.
+- Grouped `Klausurwoche` headers should not duplicate lecturer text.
+- Non-exam items must remain unchanged.
+
+### Recommended Boundaries
+
+- Keep this as a display-only enhancement.
+- Do not add module inference logic.
+- Do not expand the feature to DHmine or schedule screens.
+- Do not modify pagination, grouping, or caching logic unless tests prove it is necessary.
+
+## Success Metrics
+
+- Students can distinguish otherwise ambiguous Rapla exam rows on the Dates page.
+- Existing Rapla grouping and paging behavior remain stable.
+- New automated tests catch regressions in metadata preservation and tile rendering.
+- Manual Android verification confirms readable layouts in both supported locales.
+
+## Dependencies & Risks
+
+- Lecturer names depend on Rapla providing `Personen:` tooltip data.
+- Some source data may still be missing or inconsistent.
+- Long lecturer strings may reduce scanability if not truncated carefully.
+- Extending `ImportantEvent` changes its serialized shape, so null-safe parsing is required.
+
+## Testing Plan
+
+### Automated
+
+- `test/date_management/model/important_event_test.dart`
+- `test/date_management/business/rapla_important_events_provider_test.dart`
+- `test/date_management/ui/widgets/important_event_tile_test.dart`
+
+### Manual Android Verification
+
+- Configure Rapla and open the Dates page.
+- Verify exam rows show lecturer names when available.
+- Verify rows without lecturer data still render cleanly.
+- Verify holidays and special events are unchanged.
+- Verify grouped `Klausurwoche` headers do not show lecturer text.
+- Verify English and German layouts remain readable.
+
+## References & Research
+
+### Internal References
+
+- `lib/schedule/service/rapla/rapla_parsing_utils.dart:109`
+- `lib/date_management/business/rapla_important_events_provider.dart:108`
+- `lib/date_management/model/important_event.dart:3`
+- `lib/date_management/ui/widgets/important_event_tile.dart:37`
+- `lib/date_management/ui/widgets/important_event_section_card.dart:60`
+- `lib/date_management/business/important_event_organizer.dart:27`
+- `test/date_management/business/rapla_important_events_provider_test.dart:122`
+- `test/date_management/model/important_event_test.dart:6`
+
+### Documentation
+
+- `docs/rapla_dates_integration.md`
+- `docs/solutions/ui-bugs/date-blocks-too-tall-20260202.md`
+- `docs/solutions/ui-bugs/first-load-dates-pagination-stops-3-months-20260202.md`
+
+### Related Work
+
+- Related issue: `#40`

--- a/docs/rapla_dates_integration.md
+++ b/docs/rapla_dates_integration.md
@@ -71,8 +71,10 @@ them via the filter toggle on the Dates page.
     preservation on exam rows.
 
 - `test/date_management/ui/widgets/important_event_tile_test.dart`
-  - Verifies lecturer names render on exam rows but not on non-exam rows or
-    Klausurwoche headers.
+  - Verifies lecturer names render on exam rows but not on non-exam rows.
+
+- `test/date_management/ui/widgets/important_event_section_card_test.dart`
+  - Verifies lecturer names are not shown on Klausurwoche section headers.
 
 ### Manual Testing (Android)
 Run on a device with USB debugging enabled:

--- a/docs/rapla_dates_integration.md
+++ b/docs/rapla_dates_integration.md
@@ -52,6 +52,7 @@ Each Rapla event shows a colored dot:
 - Gray: Holiday
 
 Klausurwoche entries appear as section headers with nested exam rows underneath.
+Exam rows show lecturer names when Rapla provides `Personen:` metadata.
 Events outside of detected study phases are hidden by default; users can enable
 them via the filter toggle on the Dates page.
 
@@ -66,7 +67,12 @@ them via the filter toggle on the Dates page.
   - Verifies `ImportantEvent` range handling and equality.
 
 - `test/date_management/business/rapla_important_events_provider_test.dart`
-  - Verifies filtering, merging, and non-merging rules for exams.
+  - Verifies filtering, merging, non-merging rules for exams, and lecturer
+    preservation on exam rows.
+
+- `test/date_management/ui/widgets/important_event_tile_test.dart`
+  - Verifies lecturer names render on exam rows but not on non-exam rows or
+    Klausurwoche headers.
 
 ### Manual Testing (Android)
 Run on a device with USB debugging enabled:

--- a/docs/solutions/ui-bugs/rapla-exam-lecturer-names-missing-dates-page-20260308.md
+++ b/docs/solutions/ui-bugs/rapla-exam-lecturer-names-missing-dates-page-20260308.md
@@ -31,8 +31,8 @@ that metadata before rendering important events. Generic exam rows such as
 
 - `lib/date_management/ui/widgets/important_event_tile.dart`
   - show lecturer names as a secondary line for exam rows when available.
-  - keep long lecturer strings to one truncated line so the Dates list stays
-    compact.
+  - keep long lecturer strings to a single-line, horizontally scrollable row so
+    the Dates list stays compact.
 
 - `lib/date_management/ui/widgets/important_event_section_card.dart`
   - suppress lecturer rendering on `Klausurwoche` section headers.
@@ -44,7 +44,10 @@ that metadata before rendering important events. Generic exam rows such as
   - cover professor preservation for exam entries.
 
 - `test/date_management/ui/widgets/important_event_tile_test.dart`
-  - cover exam-row rendering, non-exam suppression, and grouped header behavior.
+  - cover exam-row rendering and non-exam suppression.
+
+- `test/date_management/ui/widgets/important_event_section_card_test.dart`
+  - cover grouped header behavior (lecturer names suppressed on Klausurwoche headers).
 
 # Validation
 

--- a/docs/solutions/ui-bugs/rapla-exam-lecturer-names-missing-dates-page-20260308.md
+++ b/docs/solutions/ui-bugs/rapla-exam-lecturer-names-missing-dates-page-20260308.md
@@ -1,0 +1,59 @@
+---
+title: Rapla exam lecturer names missing on Dates page
+date: 2026-03-08
+---
+
+# Summary
+
+Rapla already parsed lecturer names for exam entries, but the Dates page dropped
+that metadata before rendering important events. Generic exam rows such as
+`Klausur` therefore gave students too little context to identify the module.
+
+# Cause
+
+- `lib/schedule/service/rapla/rapla_parsing_utils.dart` extracted `Personen:`
+  into `ScheduleEntry.professor`.
+- `lib/date_management/business/rapla_important_events_provider.dart`
+  converted exam `ScheduleEntry` objects into `ImportantEvent` objects without
+  preserving `professor`.
+- `lib/date_management/ui/widgets/important_event_tile.dart` rendered only the
+  event title and date.
+
+# Fix
+
+- `lib/date_management/model/important_event.dart`
+  - add optional `professor` storage to the important-event model.
+  - include the field in JSON serialization, equality, and hash code.
+
+- `lib/date_management/business/rapla_important_events_provider.dart`
+  - preserve `ScheduleEntry.professor` when mapping exam rows.
+  - keep merged non-exam rows unchanged.
+
+- `lib/date_management/ui/widgets/important_event_tile.dart`
+  - show lecturer names as a secondary line for exam rows when available.
+  - keep long lecturer strings to one truncated line so the Dates list stays
+    compact.
+
+- `lib/date_management/ui/widgets/important_event_section_card.dart`
+  - suppress lecturer rendering on `Klausurwoche` section headers.
+
+- `test/date_management/model/important_event_test.dart`
+  - cover professor serialization and equality.
+
+- `test/date_management/business/rapla_important_events_provider_test.dart`
+  - cover professor preservation for exam entries.
+
+- `test/date_management/ui/widgets/important_event_tile_test.dart`
+  - cover exam-row rendering, non-exam suppression, and grouped header behavior.
+
+# Validation
+
+- `flutter test test/date_management/model/important_event_test.dart test/date_management/business/rapla_important_events_provider_test.dart test/date_management/ui/widgets/important_event_tile_test.dart`
+- `flutter test test/date_management`
+- `flutter test`
+
+# Device check
+
+- Built, installed, and launched on the connected Galaxy S21+ (`RFCR31468LJ`).
+- Confirmed `com.fariszr.dualmate/.MainActivity` was running in the isolated
+  feature worktree build during verification.

--- a/lib/date_management/business/rapla_important_events_provider.dart
+++ b/lib/date_management/business/rapla_important_events_provider.dart
@@ -104,7 +104,13 @@ class RaplaImportantEventsProvider {
 
     var mergedEntries = <ImportantEvent>[];
     grouped.forEach((_, groupEntries) {
-      groupEntries.sort((a, b) => a.start.compareTo(b.start));
+      groupEntries.sort((a, b) {
+        var c = a.start.compareTo(b.start);
+        if (c != 0) return c;
+        c = a.end.compareTo(b.end);
+        if (c != 0) return c;
+        return a.professor.compareTo(b.professor);
+      });
       if (groupEntries.first.type == ScheduleEntryType.Exam) {
         for (var entry in groupEntries) {
           mergedEntries.add(ImportantEvent(
@@ -156,7 +162,13 @@ class RaplaImportantEventsProvider {
       flushCurrent();
     });
 
-    mergedEntries.sort((a, b) => a.start.compareTo(b.start));
+    mergedEntries.sort((a, b) {
+      var c = a.start.compareTo(b.start);
+      if (c != 0) return c;
+      c = a.end.compareTo(b.end);
+      if (c != 0) return c;
+      return a.professor.compareTo(b.professor);
+    });
     return mergedEntries;
   }
 

--- a/lib/date_management/business/rapla_important_events_provider.dart
+++ b/lib/date_management/business/rapla_important_events_provider.dart
@@ -111,6 +111,7 @@ class RaplaImportantEventsProvider {
             title: entry.title,
             start: entry.start,
             end: entry.end,
+            professor: entry.professor,
             type: entry.type,
           ));
         }

--- a/lib/date_management/business/rapla_important_events_provider.dart
+++ b/lib/date_management/business/rapla_important_events_provider.dart
@@ -83,7 +83,7 @@ class RaplaImportantEventsProvider {
 
     for (var entry in entries) {
       var key =
-          '${entry.title}-${entry.type}-${entry.start.toIso8601String()}-${entry.end.toIso8601String()}';
+          '${entry.title}-${entry.type}-${entry.start.toIso8601String()}-${entry.end.toIso8601String()}-${entry.professor}';
       if (seenKeys.add(key)) {
         result.add(entry);
       }

--- a/lib/date_management/model/important_event.dart
+++ b/lib/date_management/model/important_event.dart
@@ -4,12 +4,14 @@ class ImportantEvent {
   final String title;
   final DateTime start;
   final DateTime end;
+  final String professor;
   final ScheduleEntryType type;
 
   ImportantEvent({
     required this.title,
     required this.start,
     required this.end,
+    this.professor = '',
     required this.type,
   });
 
@@ -22,10 +24,7 @@ class ImportantEvent {
   }
 
   bool get hasTime =>
-      start.hour != 0 ||
-      start.minute != 0 ||
-      end.hour != 0 ||
-      end.minute != 0;
+      start.hour != 0 || start.minute != 0 || end.hour != 0 || end.minute != 0;
 
   bool _isSameDay(DateTime first, DateTime second) {
     return first.year == second.year &&
@@ -44,14 +43,15 @@ class ImportantEvent {
 
     var startText = json['start'] as String? ?? '';
     var endText = json['end'] as String? ?? '';
-    var start = DateTime.tryParse(startText) ??
-        DateTime.fromMillisecondsSinceEpoch(0);
+    var start =
+        DateTime.tryParse(startText) ?? DateTime.fromMillisecondsSinceEpoch(0);
     var end = DateTime.tryParse(endText) ?? start;
 
     return ImportantEvent(
       title: json['title'] as String? ?? '',
       start: start,
       end: end,
+      professor: json['professor'] as String? ?? '',
       type: type,
     );
   }
@@ -61,6 +61,7 @@ class ImportantEvent {
       'title': title,
       'start': start.toIso8601String(),
       'end': end.toIso8601String(),
+      'professor': professor,
       'type': type.index,
     };
   }
@@ -73,6 +74,7 @@ class ImportantEvent {
         other.title == title &&
         other.start == start &&
         other.end == end &&
+        other.professor == professor &&
         other.type == type;
   }
 
@@ -81,6 +83,7 @@ class ImportantEvent {
     return title.hashCode ^
         start.hashCode ^
         end.hashCode ^
+        professor.hashCode ^
         type.hashCode;
   }
 }

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -414,8 +414,10 @@ class DateManagementViewModel extends BaseViewModel {
     var deduped = <ImportantEvent>[];
 
     for (var event in combined) {
+      var professorSuffix =
+          event.type == ScheduleEntryType.Exam ? '-${event.professor}' : '';
       var key =
-          '${event.title}-${event.type}-${event.start.toIso8601String()}-${event.end.toIso8601String()}';
+          '${event.title}-${event.type}-${event.start.toIso8601String()}-${event.end.toIso8601String()}$professorSuffix';
       if (seenKeys.add(key)) {
         deduped.add(event);
       }
@@ -440,8 +442,10 @@ class DateManagementViewModel extends BaseViewModel {
     Set<String> seenKeys,
     ImportantEvent event,
   ) {
+    var professorSuffix =
+        event.type == ScheduleEntryType.Exam ? '-${event.professor}' : '';
     var key =
-        '${event.title}-${event.type}-${event.start.toIso8601String()}-${event.end.toIso8601String()}';
+        '${event.title}-${event.type}-${event.start.toIso8601String()}-${event.end.toIso8601String()}$professorSuffix';
     if (seenKeys.add(key)) {
       events.add(event);
     }

--- a/lib/date_management/ui/widgets/important_event_section_card.dart
+++ b/lib/date_management/ui/widgets/important_event_section_card.dart
@@ -65,6 +65,7 @@ class ImportantEventSectionCard extends StatelessWidget {
     return ImportantEventTile(
       event: event,
       contentPadding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+      showProfessor: false,
       titleStyle: (Theme.of(context).textTheme.titleMedium ?? const TextStyle())
           .copyWith(fontWeight: FontWeight.w600),
       dotColor: isExamSection ? const Color(0xffff0000) : null,

--- a/lib/date_management/ui/widgets/important_event_tile.dart
+++ b/lib/date_management/ui/widgets/important_event_tile.dart
@@ -69,11 +69,14 @@ class ImportantEventTile extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(_formatEventDate(context, event)),
-        Text(
-          event.professor,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: professorStyle,
+        SingleChildScrollView(
+          key: const Key('important_event_professor_scroll'),
+          scrollDirection: Axis.horizontal,
+          child: Text(
+            event.professor,
+            softWrap: false,
+            style: professorStyle,
+          ),
         ),
       ],
     );

--- a/lib/date_management/ui/widgets/important_event_tile.dart
+++ b/lib/date_management/ui/widgets/important_event_tile.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/date_management/model/important_event.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
@@ -69,14 +71,9 @@ class ImportantEventTile extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(_formatEventDate(context, event)),
-        SingleChildScrollView(
-          key: const Key('important_event_professor_scroll'),
-          scrollDirection: Axis.horizontal,
-          child: Text(
-            event.professor,
-            softWrap: false,
-            style: professorStyle,
-          ),
+        _AutoScrollingProfessorText(
+          text: event.professor,
+          style: professorStyle,
         ),
       ],
     );
@@ -115,6 +112,131 @@ class ImportantEventTile extends StatelessWidget {
     final startDate = dateFormat.format(event.start);
     final endDate = dateFormat.format(event.end);
     return "$startDate - $endDate";
+  }
+}
+
+class _AutoScrollingProfessorText extends StatefulWidget {
+  final String text;
+  final TextStyle? style;
+
+  const _AutoScrollingProfessorText({required this.text, this.style});
+
+  @override
+  State<_AutoScrollingProfessorText> createState() =>
+      _AutoScrollingProfessorTextState();
+}
+
+class _AutoScrollingProfessorTextState
+    extends State<_AutoScrollingProfessorText> {
+  static const _initialPause = Duration(milliseconds: 900);
+  static const _edgePause = Duration(milliseconds: 700);
+  static const _resumePause = Duration(milliseconds: 1400);
+
+  final ScrollController _scrollController = ScrollController();
+  int _animationToken = 0;
+  Timer? _pendingTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scheduleAutoScroll();
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant _AutoScrollingProfessorText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text) {
+      _scrollController.jumpTo(0);
+      _scheduleAutoScroll();
+    }
+  }
+
+  @override
+  void dispose() {
+    _animationToken++;
+    _pendingTimer?.cancel();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollStartNotification) {
+      _animationToken++;
+    } else if (notification is ScrollEndNotification) {
+      _scheduleAutoScroll(delay: _resumePause);
+    }
+    return false;
+  }
+
+  void _scheduleAutoScroll({Duration delay = _initialPause}) {
+    final token = ++_animationToken;
+    _pendingTimer?.cancel();
+    _pendingTimer = Timer(delay, () {
+      _autoScrollLoop(token, forward: true);
+    });
+  }
+
+  Future<void> _autoScrollLoop(int token, {required bool forward}) async {
+    if (!mounted || token != _animationToken || !_scrollController.hasClients) {
+      return;
+    }
+
+    final maxExtent = _scrollController.position.maxScrollExtent;
+    if (maxExtent <= 0) {
+      return;
+    }
+
+    final targetOffset = forward ? maxExtent : 0.0;
+    final currentOffset = _scrollController.offset;
+    final distance = (targetOffset - currentOffset).abs();
+    if (distance <= 0.5) {
+      _scheduleNextPass(token, forward: !forward);
+      return;
+    }
+
+    final duration = Duration(
+      milliseconds: (distance * 12).round().clamp(1200, 6000),
+    );
+
+    try {
+      await _scrollController.animateTo(
+        targetOffset,
+        duration: duration,
+        curve: Curves.linear,
+      );
+    } catch (_) {
+      return;
+    }
+
+    if (!mounted || token != _animationToken) return;
+    _scheduleNextPass(token, forward: !forward);
+  }
+
+  void _scheduleNextPass(int token, {required bool forward}) {
+    if (!mounted || token != _animationToken) return;
+    _pendingTimer?.cancel();
+    _pendingTimer = Timer(_edgePause, () {
+      _autoScrollLoop(token, forward: forward);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollNotification>(
+      onNotification: _handleScrollNotification,
+      child: SingleChildScrollView(
+        key: const Key('important_event_professor_scroll'),
+        controller: _scrollController,
+        scrollDirection: Axis.horizontal,
+        child: Text(
+          widget.text,
+          softWrap: false,
+          style: widget.style,
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/date_management/ui/widgets/important_event_tile.dart
+++ b/lib/date_management/ui/widgets/important_event_tile.dart
@@ -14,6 +14,7 @@ class ImportantEventTile extends StatelessWidget {
   final double dotSize;
   final TextStyle? titleStyle;
   final Color? dotColor;
+  final bool showProfessor;
 
   const ImportantEventTile({
     Key? key,
@@ -23,6 +24,7 @@ class ImportantEventTile extends StatelessWidget {
     this.dotSize = 12,
     this.titleStyle,
     this.dotColor,
+    this.showProfessor = true,
   }) : super(key: key);
 
   @override
@@ -41,8 +43,39 @@ class ImportantEventTile extends StatelessWidget {
         color: dotColor ?? _eventColor(context, event),
         size: dotSize,
       ),
+      isThreeLine: _showsProfessor,
       title: Text(event.title, style: resolvedTitleStyle),
-      subtitle: Text(_formatEventDate(context, event)),
+      subtitle: _buildSubtitle(context),
+    );
+  }
+
+  bool get _showsProfessor {
+    return showProfessor &&
+        event.type == ScheduleEntryType.Exam &&
+        event.professor.trim().isNotEmpty;
+  }
+
+  Widget _buildSubtitle(BuildContext context) {
+    if (!_showsProfessor) {
+      return Text(_formatEventDate(context, event));
+    }
+
+    final professorStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(_formatEventDate(context, event)),
+        Text(
+          event.professor,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: professorStyle,
+        ),
+      ],
     );
   }
 

--- a/test/date_management/business/rapla_important_events_provider_test.dart
+++ b/test/date_management/business/rapla_important_events_provider_test.dart
@@ -44,8 +44,9 @@ void main() {
       ),
     ]);
 
-    var filtered =
-        RaplaImportantEventsProvider.filterImportantEntries(schedule);
+    var filtered = RaplaImportantEventsProvider.filterImportantEntries(
+      schedule,
+    );
 
     expect(filtered.length, 3);
     expect(
@@ -126,7 +127,7 @@ void main() {
         end: DateTime(2026, 7, 27, 8),
         title: 'Klausur',
         details: '',
-        professor: '',
+        professor: 'Prof. Schmidt',
         room: '',
         type: ScheduleEntryType.Exam,
       ),
@@ -135,7 +136,7 @@ void main() {
         end: DateTime(2026, 7, 28, 8),
         title: 'Klausur',
         details: '',
-        professor: '',
+        professor: 'Prof. Becker',
         room: '',
         type: ScheduleEntryType.Exam,
       ),
@@ -144,6 +145,35 @@ void main() {
     var merged = RaplaImportantEventsProvider.mergeImportantEntries(entries);
 
     expect(merged.length, 2);
+  });
+
+  test('Preserves professor names for exam entries', () {
+    var entries = [
+      ScheduleEntry(
+        start: DateTime(2026, 7, 27, 7),
+        end: DateTime(2026, 7, 27, 8),
+        title: 'Klausur',
+        details: '',
+        professor: 'Prof. Schmidt',
+        room: '',
+        type: ScheduleEntryType.Exam,
+      ),
+      ScheduleEntry(
+        start: DateTime(2026, 7, 28, 7),
+        end: DateTime(2026, 7, 28, 8),
+        title: 'Klausur',
+        details: '',
+        professor: 'Prof. Becker',
+        room: '',
+        type: ScheduleEntryType.Exam,
+      ),
+    ];
+
+    var merged = RaplaImportantEventsProvider.mergeImportantEntries(entries);
+
+    expect(merged.length, 2);
+    expect(merged[0].professor, 'Prof. Schmidt');
+    expect(merged[1].professor, 'Prof. Becker');
   });
 
   test('Deduplicates identical entries', () {
@@ -168,8 +198,9 @@ void main() {
       ),
     ]);
 
-    var filtered =
-        RaplaImportantEventsProvider.filterImportantEntries(schedule);
+    var filtered = RaplaImportantEventsProvider.filterImportantEntries(
+      schedule,
+    );
 
     expect(filtered.length, 1);
   });

--- a/test/date_management/business/rapla_important_events_provider_test.dart
+++ b/test/date_management/business/rapla_important_events_provider_test.dart
@@ -201,8 +201,8 @@ void main() {
     var merged = RaplaImportantEventsProvider.mergeImportantEntries(entries);
 
     expect(merged.length, 2);
-    expect(merged[0].professor, 'Prof. Schmidt');
-    expect(merged[1].professor, 'Prof. Becker');
+    expect(merged[0].professor, 'Prof. Becker');
+    expect(merged[1].professor, 'Prof. Schmidt');
   });
 
   test('Keeps same-slot important entries with different professors', () {

--- a/test/date_management/business/rapla_important_events_provider_test.dart
+++ b/test/date_management/business/rapla_important_events_provider_test.dart
@@ -176,6 +176,66 @@ void main() {
     expect(merged[1].professor, 'Prof. Becker');
   });
 
+  test('Preserves both professors for same-slot exam collisions', () {
+    var entries = [
+      ScheduleEntry(
+        start: DateTime(2026, 7, 27, 7),
+        end: DateTime(2026, 7, 27, 8),
+        title: 'Klausur',
+        details: '',
+        professor: 'Prof. Schmidt',
+        room: '',
+        type: ScheduleEntryType.Exam,
+      ),
+      ScheduleEntry(
+        start: DateTime(2026, 7, 27, 7),
+        end: DateTime(2026, 7, 27, 8),
+        title: 'Klausur',
+        details: '',
+        professor: 'Prof. Becker',
+        room: '',
+        type: ScheduleEntryType.Exam,
+      ),
+    ];
+
+    var merged = RaplaImportantEventsProvider.mergeImportantEntries(entries);
+
+    expect(merged.length, 2);
+    expect(merged[0].professor, 'Prof. Schmidt');
+    expect(merged[1].professor, 'Prof. Becker');
+  });
+
+  test('Keeps same-slot important entries with different professors', () {
+    var schedule = Schedule.fromList([
+      ScheduleEntry(
+        start: DateTime(2026, 7, 27, 9),
+        end: DateTime(2026, 7, 27, 10),
+        title: 'Klausur',
+        details: '',
+        professor: 'Prof. Schmidt',
+        room: '',
+        type: ScheduleEntryType.Exam,
+      ),
+      ScheduleEntry(
+        start: DateTime(2026, 7, 27, 9),
+        end: DateTime(2026, 7, 27, 10),
+        title: 'Klausur',
+        details: '',
+        professor: 'Prof. Becker',
+        room: '',
+        type: ScheduleEntryType.Exam,
+      ),
+    ]);
+
+    var filtered = RaplaImportantEventsProvider.filterImportantEntries(
+      schedule,
+    );
+
+    expect(filtered.length, 2);
+    expect(filtered[0].professor, 'Prof. Schmidt');
+    expect(filtered[1].professor, 'Prof. Becker');
+  });
+
   test('Deduplicates identical entries', () {
     var schedule = Schedule.fromList([
       ScheduleEntry(

--- a/test/date_management/model/important_event_test.dart
+++ b/test/date_management/model/important_event_test.dart
@@ -32,15 +32,32 @@ void main() {
       title: 'Hl. 3 Koenige',
       start: DateTime(2026, 1, 6),
       end: DateTime(2026, 1, 6),
+      professor: 'Prof. Schmidt',
       type: ScheduleEntryType.PublicHoliday,
     );
     var event2 = ImportantEvent(
       title: 'Hl. 3 Koenige',
       start: DateTime(2026, 1, 6),
       end: DateTime(2026, 1, 6),
+      professor: 'Prof. Schmidt',
       type: ScheduleEntryType.PublicHoliday,
     );
 
     expect(event1, event2);
+  });
+
+  test('ImportantEvent serializes and deserializes professor', () {
+    var event = ImportantEvent(
+      title: 'Klausur',
+      start: DateTime(2026, 7, 31, 8),
+      end: DateTime(2026, 7, 31, 10),
+      professor: 'Prof. Mueller, Prof. Fischer',
+      type: ScheduleEntryType.Exam,
+    );
+
+    var restored = ImportantEvent.fromJson(event.toJson());
+
+    expect(restored, event);
+    expect(restored.professor, 'Prof. Mueller, Prof. Fischer');
   });
 }

--- a/test/date_management/ui/widgets/important_event_section_card_test.dart
+++ b/test/date_management/ui/widgets/important_event_section_card_test.dart
@@ -1,0 +1,55 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/date_management/model/important_event.dart';
+import 'package:dualmate/date_management/model/important_event_section.dart';
+import 'package:dualmate/date_management/ui/widgets/important_event_section_card.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows professor only on grouped exam rows', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrapWithApp(
+        ImportantEventSectionCard(
+          section: ImportantEventSection(
+            header: ImportantEvent(
+              title: 'Klausurwoche',
+              start: DateTime(2026, 7, 27),
+              end: DateTime(2026, 7, 31),
+              professor: 'Header Lecturer',
+              type: ScheduleEntryType.SpecialEvent,
+            ),
+            events: [
+              ImportantEvent(
+                title: 'Klausur',
+                start: DateTime(2026, 7, 29, 8),
+                end: DateTime(2026, 7, 29, 10),
+                professor: 'Prof. Schmidt',
+                type: ScheduleEntryType.Exam,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Header Lecturer'), findsNothing);
+    expect(find.text('Prof. Schmidt'), findsOneWidget);
+  });
+}
+
+Widget _wrapWithApp(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      LocalizationDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('en'), Locale('de')],
+    home: Scaffold(body: child),
+  );
+}

--- a/test/date_management/ui/widgets/important_event_tile_test.dart
+++ b/test/date_management/ui/widgets/important_event_tile_test.dart
@@ -1,7 +1,5 @@
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/date_management/model/important_event.dart';
-import 'package:dualmate/date_management/model/important_event_section.dart';
-import 'package:dualmate/date_management/ui/widgets/important_event_section_card.dart';
 import 'package:dualmate/date_management/ui/widgets/important_event_tile.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:flutter/material.dart';
@@ -27,6 +25,13 @@ void main() {
 
     expect(find.text('Klausur'), findsOneWidget);
     expect(find.text('Prof. Schmidt'), findsOneWidget);
+    expect(find.byKey(const Key('important_event_professor_scroll')),
+        findsOneWidget);
+
+    final scrollView = tester.widget<SingleChildScrollView>(
+      find.byKey(const Key('important_event_professor_scroll')),
+    );
+    expect(scrollView.scrollDirection, Axis.horizontal);
   });
 
   testWidgets('hides professor for non exam events', (
@@ -49,38 +54,6 @@ void main() {
 
     expect(find.text('Feiertag'), findsOneWidget);
     expect(find.text('Prof. Schmidt'), findsNothing);
-  });
-
-  testWidgets('shows professor only on grouped exam rows', (
-    WidgetTester tester,
-  ) async {
-    await tester.pumpWidget(
-      _wrapWithApp(
-        ImportantEventSectionCard(
-          section: ImportantEventSection(
-            header: ImportantEvent(
-              title: 'Klausurwoche',
-              start: DateTime(2026, 7, 27),
-              end: DateTime(2026, 7, 31),
-              professor: 'Header Lecturer',
-              type: ScheduleEntryType.SpecialEvent,
-            ),
-            events: [
-              ImportantEvent(
-                title: 'Klausur',
-                start: DateTime(2026, 7, 29, 8),
-                end: DateTime(2026, 7, 29, 10),
-                professor: 'Prof. Schmidt',
-                type: ScheduleEntryType.Exam,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-
-    expect(find.text('Header Lecturer'), findsNothing);
-    expect(find.text('Prof. Schmidt'), findsOneWidget);
   });
 }
 

--- a/test/date_management/ui/widgets/important_event_tile_test.dart
+++ b/test/date_management/ui/widgets/important_event_tile_test.dart
@@ -1,0 +1,98 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/date_management/model/important_event.dart';
+import 'package:dualmate/date_management/model/important_event_section.dart';
+import 'package:dualmate/date_management/ui/widgets/important_event_section_card.dart';
+import 'package:dualmate/date_management/ui/widgets/important_event_tile.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows professor for exam events', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _wrapWithApp(
+        ImportantEventTile(
+          event: ImportantEvent(
+            title: 'Klausur',
+            start: DateTime(2026, 7, 31, 8),
+            end: DateTime(2026, 7, 31, 10),
+            professor: 'Prof. Schmidt',
+            type: ScheduleEntryType.Exam,
+          ),
+          contentPadding: EdgeInsets.zero,
+        ),
+      ),
+    );
+
+    expect(find.text('Klausur'), findsOneWidget);
+    expect(find.text('Prof. Schmidt'), findsOneWidget);
+  });
+
+  testWidgets('hides professor for non exam events', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrapWithApp(
+        ImportantEventTile(
+          event: ImportantEvent(
+            title: 'Feiertag',
+            start: DateTime(2026, 7, 31),
+            end: DateTime(2026, 7, 31),
+            professor: 'Prof. Schmidt',
+            type: ScheduleEntryType.PublicHoliday,
+          ),
+          contentPadding: EdgeInsets.zero,
+        ),
+      ),
+    );
+
+    expect(find.text('Feiertag'), findsOneWidget);
+    expect(find.text('Prof. Schmidt'), findsNothing);
+  });
+
+  testWidgets('shows professor only on grouped exam rows', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrapWithApp(
+        ImportantEventSectionCard(
+          section: ImportantEventSection(
+            header: ImportantEvent(
+              title: 'Klausurwoche',
+              start: DateTime(2026, 7, 27),
+              end: DateTime(2026, 7, 31),
+              professor: 'Header Lecturer',
+              type: ScheduleEntryType.SpecialEvent,
+            ),
+            events: [
+              ImportantEvent(
+                title: 'Klausur',
+                start: DateTime(2026, 7, 29, 8),
+                end: DateTime(2026, 7, 29, 10),
+                professor: 'Prof. Schmidt',
+                type: ScheduleEntryType.Exam,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Header Lecturer'), findsNothing);
+    expect(find.text('Prof. Schmidt'), findsOneWidget);
+  });
+}
+
+Widget _wrapWithApp(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      LocalizationDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('en'), Locale('de')],
+    home: Scaffold(body: child),
+  );
+}

--- a/test/date_management/ui/widgets/important_event_tile_test.dart
+++ b/test/date_management/ui/widgets/important_event_tile_test.dart
@@ -10,15 +10,18 @@ void main() {
   testWidgets('shows professor for exam events', (WidgetTester tester) async {
     await tester.pumpWidget(
       _wrapWithApp(
-        ImportantEventTile(
-          event: ImportantEvent(
-            title: 'Klausur',
-            start: DateTime(2026, 7, 31, 8),
-            end: DateTime(2026, 7, 31, 10),
-            professor: 'Prof. Schmidt',
-            type: ScheduleEntryType.Exam,
+        SizedBox(
+          width: 180,
+          child: ImportantEventTile(
+            event: ImportantEvent(
+              title: 'Klausur',
+              start: DateTime(2026, 7, 31, 8),
+              end: DateTime(2026, 7, 31, 10),
+              professor: 'Prof. Schmidt',
+              type: ScheduleEntryType.Exam,
+            ),
+            contentPadding: EdgeInsets.zero,
           ),
-          contentPadding: EdgeInsets.zero,
         ),
       ),
     );
@@ -32,6 +35,40 @@ void main() {
       find.byKey(const Key('important_event_professor_scroll')),
     );
     expect(scrollView.scrollDirection, Axis.horizontal);
+    expect(scrollView.controller, isNotNull);
+  });
+
+  testWidgets('auto scrolls long professor names', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _wrapWithApp(
+        SizedBox(
+          width: 180,
+          child: ImportantEventTile(
+            event: ImportantEvent(
+              title: 'Klausur',
+              start: DateTime(2026, 7, 31, 8),
+              end: DateTime(2026, 7, 31, 10),
+              professor:
+                  'Prof. Schmidt, Prof. Becker, Prof. Mueller, Prof. Fischer',
+              type: ScheduleEntryType.Exam,
+            ),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ),
+    );
+
+    final scrollView = tester.widget<SingleChildScrollView>(
+      find.byKey(const Key('important_event_professor_scroll')),
+    );
+
+    expect(scrollView.controller, isNotNull);
+    expect(scrollView.controller!.offset, 0);
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(seconds: 2));
+
+    expect(scrollView.controller!.offset, greaterThan(0));
   });
 
   testWidgets('hides professor for non exam events', (


### PR DESCRIPTION
## Summary
- preserve Rapla lecturer metadata on important exam events so generic `Klausur` rows are easier to identify on the Dates page
- render lecturer names as a secondary line on exam rows while keeping `Klausurwoche` headers and non-exam rows unchanged
- add model, provider, widget, and documentation coverage, including the drafted plan and solution note

## Testing
- flutter test test/date_management/model/important_event_test.dart test/date_management/business/rapla_important_events_provider_test.dart test/date_management/ui/widgets/important_event_tile_test.dart
- flutter test test/date_management
- flutter test
- flutter analyze lib/date_management docs/rapla_dates_integration.md test/date_management
- flutter run -d RFCR31468LJ --debug --target lib/main.dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exam events now include a professor field and display professor names in event tiles (with auto-scrolling for long names).

* **Improvements**
  * Deduplication and merging now treat exams by professor as distinct, preserving multiple same-slot exams by different professors.
  * Section headers omit professor names for a cleaner look; tiles support multi-line subtitles for date + professor.

* **Tests**
  * Added unit and widget tests covering professor preservation, serialization, UI display, and auto-scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->