### PR TITLE
Refine Rapla marker events in notifications and widgets

### DIFF
--- a/android/app/src/main/kotlin/com/fariszr/dualmate/model/ScheduleEntry.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/model/ScheduleEntry.kt
@@ -10,4 +10,13 @@ class ScheduleEntry(
         val room: String,
         val type: Int,
         val start: LocalDateTime,
-        val end: LocalDateTime)
+        val end: LocalDateTime) {
+    companion object {
+        const val UNKNOWN_TYPE = 0
+        const val CLASS_TYPE = 1
+        const val ONLINE_TYPE = 2
+        const val PUBLIC_HOLIDAY_TYPE = 3
+        const val EXAM_TYPE = 4
+        const val SPECIAL_EVENT_TYPE = 5
+    }
+}

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactory.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactory.kt
@@ -51,6 +51,10 @@ class NowScheduleEntryViewsFactory(
     }
 
     override fun buildItemView(item: ScheduleEntry, state: WidgetItemState): RemoteViews {
+        if (ScheduleWidgetMarkerHelper.isMarkerEntry(item)) {
+            return buildMarkerItemView(item, state)
+        }
+
         val views = RemoteViews(context.packageName, R.layout.widget_schedule_day_item)
         views.setTextViewText(R.id.text_view_item_title, item.title)
 
@@ -58,21 +62,9 @@ class NowScheduleEntryViewsFactory(
         val subtitle = if (item.room.isBlank()) timeRange else "$timeRange • ${item.room}"
         views.setTextViewText(R.id.text_view_item_subtitle, subtitle)
 
-        val textColor = when (state) {
-            WidgetItemState.PAST -> ContextCompat.getColor(context, R.color.widget_schedule_item_text_past)
-            WidgetItemState.CURRENT -> ContextCompat.getColor(context, R.color.widget_schedule_item_text_current)
-            WidgetItemState.FUTURE -> ContextCompat.getColor(context, R.color.widget_schedule_entry_text_color)
-        }
-
-        val accent = when (state) {
-            WidgetItemState.PAST -> R.drawable.widget_schedule_item_accent_past
-            WidgetItemState.CURRENT -> R.drawable.widget_schedule_item_accent_current
-            WidgetItemState.FUTURE -> R.drawable.widget_schedule_item_accent_future
-        }
-        val background = when (state) {
-            WidgetItemState.CURRENT -> R.drawable.widget_schedule_item_current_background
-            else -> R.drawable.widget_schedule_item_past_background
-        }
+        val textColor = resolveTextColor(state)
+        val accent = resolveAccent(state)
+        val background = resolveBackground(state)
 
         views.setInt(R.id.layout_schedule_item, "setBackgroundResource", background)
         views.setInt(R.id.view_item_accent, "setBackgroundResource", accent)
@@ -80,6 +72,44 @@ class NowScheduleEntryViewsFactory(
         views.setTextColor(R.id.text_view_item_subtitle, textColor)
 
         return views
+    }
+
+    private fun buildMarkerItemView(item: ScheduleEntry, state: WidgetItemState): RemoteViews {
+        val views = RemoteViews(context.packageName, R.layout.widget_schedule_day_marker_item)
+        views.setTextViewText(R.id.text_view_item_title, item.title)
+
+        val textColor = resolveTextColor(state)
+        val accent = resolveAccent(state)
+        val background = resolveBackground(state)
+
+        views.setInt(R.id.layout_schedule_item, "setBackgroundResource", background)
+        views.setInt(R.id.view_item_accent, "setBackgroundResource", accent)
+        views.setTextColor(R.id.text_view_item_title, textColor)
+
+        return views
+    }
+
+    private fun resolveTextColor(state: WidgetItemState): Int {
+        return when (state) {
+            WidgetItemState.PAST -> ContextCompat.getColor(context, R.color.widget_schedule_item_text_past)
+            WidgetItemState.CURRENT -> ContextCompat.getColor(context, R.color.widget_schedule_item_text_current)
+            WidgetItemState.FUTURE -> ContextCompat.getColor(context, R.color.widget_schedule_entry_text_color)
+        }
+    }
+
+    private fun resolveAccent(state: WidgetItemState): Int {
+        return when (state) {
+            WidgetItemState.PAST -> R.drawable.widget_schedule_item_accent_past
+            WidgetItemState.CURRENT -> R.drawable.widget_schedule_item_accent_current
+            WidgetItemState.FUTURE -> R.drawable.widget_schedule_item_accent_future
+        }
+    }
+
+    private fun resolveBackground(state: WidgetItemState): Int {
+        return when (state) {
+            WidgetItemState.CURRENT -> R.drawable.widget_schedule_item_current_background
+            else -> R.drawable.widget_schedule_item_past_background
+        }
     }
 
     override fun buildOverflowView(date: LocalDate, overflowCount: Int): RemoteViews {
@@ -99,7 +129,10 @@ class NowScheduleEntryViewsFactory(
     override fun prepareVisibleItems(
         items: List<ScheduleEntry>
     ): MultiDayWidgetHelper.VisibleItems<ScheduleEntry> {
-        return MultiDayWidgetHelper.VisibleItems(items, 0)
+        return MultiDayWidgetHelper.VisibleItems(
+            ScheduleWidgetMarkerHelper.orderEntriesForDisplay(items),
+            0
+        )
     }
 
     override fun buildEmptyView(isToday: Boolean, isDataUnavailable: Boolean): RemoteViews {

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactory.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactory.kt
@@ -20,7 +20,7 @@ import java.util.Locale
 class NowScheduleEntryViewsFactory(
     context: Context,
     appWidgetId: Int
-) : MultiDayViewsFactory<ScheduleEntry>(context, appWidgetId, ROW_METRICS) {
+) : MultiDayViewsFactory<ScheduleWidgetItem>(context, appWidgetId, ROW_METRICS) {
 
     private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm", Locale.getDefault())
     private val dayFormatter = DateTimeFormatter.ofPattern("EEE", Locale.getDefault())
@@ -50,16 +50,16 @@ class NowScheduleEntryViewsFactory(
         )
     }
 
-    override fun buildItemView(item: ScheduleEntry, state: WidgetItemState): RemoteViews {
-        if (ScheduleWidgetMarkerHelper.isMarkerEntry(item)) {
+    override fun buildItemView(item: ScheduleWidgetItem, state: WidgetItemState): RemoteViews {
+        if (ScheduleWidgetMarkerHelper.isMarkerEntry(item.entry)) {
             return buildMarkerItemView(item, state)
         }
 
         val views = RemoteViews(context.packageName, R.layout.widget_schedule_day_item)
-        views.setTextViewText(R.id.text_view_item_title, item.title)
+        views.setTextViewText(R.id.text_view_item_title, item.entry.title)
 
-        val timeRange = "${item.start.format(timeFormatter)} - ${item.end.format(timeFormatter)}"
-        val subtitle = if (item.room.isBlank()) timeRange else "$timeRange • ${item.room}"
+        val timeRange = "${item.entry.start.format(timeFormatter)} - ${item.entry.end.format(timeFormatter)}"
+        val subtitle = if (item.entry.room.isBlank()) timeRange else "$timeRange • ${item.entry.room}"
         views.setTextViewText(R.id.text_view_item_subtitle, subtitle)
 
         val textColor = resolveTextColor(state)
@@ -74,12 +74,12 @@ class NowScheduleEntryViewsFactory(
         return views
     }
 
-    private fun buildMarkerItemView(item: ScheduleEntry, state: WidgetItemState): RemoteViews {
-        val views = RemoteViews(context.packageName, R.layout.widget_schedule_day_marker_item)
-        views.setTextViewText(R.id.text_view_item_title, item.title)
+    private fun buildMarkerItemView(item: ScheduleWidgetItem, state: WidgetItemState): RemoteViews {
+        val views = RemoteViews(context.packageName, markerLayoutId(item))
+        views.setTextViewText(R.id.text_view_item_title, item.entry.title)
 
         val textColor = resolveTextColor(state)
-        val accent = resolveAccent(state)
+        val accent = markerAccentDrawable(item.entry)
         val background = resolveBackground(state)
 
         views.setInt(R.id.layout_schedule_item, "setBackgroundResource", background)
@@ -127,12 +127,9 @@ class NowScheduleEntryViewsFactory(
     }
 
     override fun prepareVisibleItems(
-        items: List<ScheduleEntry>
-    ): MultiDayWidgetHelper.VisibleItems<ScheduleEntry> {
-        return MultiDayWidgetHelper.VisibleItems(
-            ScheduleWidgetMarkerHelper.orderEntriesForDisplay(items),
-            0
-        )
+        items: List<ScheduleWidgetItem>
+    ): MultiDayWidgetHelper.VisibleItems<ScheduleWidgetItem> {
+        return MultiDayWidgetHelper.VisibleItems(items, 0)
     }
 
     override fun buildEmptyView(isToday: Boolean, isDataUnavailable: Boolean): RemoteViews {
@@ -146,21 +143,23 @@ class NowScheduleEntryViewsFactory(
         return views
     }
 
-    override fun getItemState(item: ScheduleEntry, now: LocalDateTime): WidgetItemState {
-        return MultiDayWidgetHelper.resolveItemState(item.start, item.end, now)
+    override fun getItemState(item: ScheduleWidgetItem, now: LocalDateTime): WidgetItemState {
+        return MultiDayWidgetHelper.resolveItemState(item.entry.start, item.entry.end, now)
     }
 
     override fun loadItemsForWeek(
         startDate: LocalDate,
         endDate: LocalDate
-    ): MultiDayWidgetHelper.LoadResult<ScheduleEntry> {
+    ): MultiDayWidgetHelper.LoadResult<ScheduleWidgetItem> {
         val queryResult = ScheduleProvider(context).queryScheduleEntriesBetweenWithStatus(
             startDate.atStartOfDay(),
             endDate.plusDays(1).atStartOfDay()
         )
 
         return MultiDayWidgetHelper.LoadResult(
-            queryResult.entries.groupBy { entry -> entry.start.toLocalDate() },
+            queryResult.entries
+                .groupBy { entry -> entry.start.toLocalDate() }
+                .mapValues { (_, entries) -> prepareDayItems(entries) },
             queryResult.successful
         )
     }
@@ -173,5 +172,32 @@ class NowScheduleEntryViewsFactory(
             itemHeightDp = 20,
             maxItemsPerRow = 4
         )
+
+        internal fun prepareDayItems(entries: List<ScheduleEntry>): List<ScheduleWidgetItem> {
+            val orderedEntries = ScheduleWidgetMarkerHelper.orderEntriesForDisplay(entries)
+            val usesFullHeightMarkerLayout =
+                orderedEntries.size == 1 && ScheduleWidgetMarkerHelper.isMarkerOnlyDay(orderedEntries)
+
+            return orderedEntries.map { entry ->
+                ScheduleWidgetItem(entry, usesFullHeightMarkerLayout)
+            }
+        }
+
+        internal fun markerLayoutId(item: ScheduleWidgetItem): Int {
+            return if (item.usesFullHeightMarkerLayout) {
+                R.layout.widget_schedule_day_marker_full_item
+            } else {
+                R.layout.widget_schedule_day_marker_item
+            }
+        }
+
+        internal fun markerAccentDrawable(entry: ScheduleEntry): Int {
+            return when (entry.type) {
+                ScheduleEntry.PUBLIC_HOLIDAY_TYPE -> R.drawable.widget_schedule_item_accent_marker_holiday
+                ScheduleEntry.EXAM_TYPE -> R.drawable.widget_schedule_item_accent_marker_exam
+                ScheduleEntry.SPECIAL_EVENT_TYPE -> R.drawable.widget_schedule_item_accent_marker_special_event
+                else -> R.drawable.widget_schedule_item_accent_marker_unknown
+            }
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetItem.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetItem.kt
@@ -1,0 +1,8 @@
+package com.fariszr.dualmate.widget.now
+
+import com.fariszr.dualmate.model.ScheduleEntry
+
+data class ScheduleWidgetItem(
+    val entry: ScheduleEntry,
+    val usesFullHeightMarkerLayout: Boolean
+)

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
@@ -1,0 +1,43 @@
+package com.fariszr.dualmate.widget.now
+
+import com.fariszr.dualmate.model.ScheduleEntry
+import java.util.Locale
+
+object ScheduleWidgetMarkerHelper {
+    private const val specialEventType = 5 // Mirrors Dart ScheduleEntryType.SpecialEvent.
+    private const val examWeekKeyword = "klausurwoche"
+    private const val theoryPhaseKeyword = "theoriephase"
+    private const val beginKeyword = "beginn"
+
+    fun isMarkerEntry(entry: ScheduleEntry): Boolean {
+        if (entry.type != specialEventType) {
+            return false
+        }
+
+        return isExamWeekTitle(entry.title) || isTheoryPhaseStartTitle(entry.title)
+    }
+
+    fun orderEntriesForDisplay(entries: List<ScheduleEntry>): List<ScheduleEntry> {
+        return entries.sortedWith(
+            compareByDescending<ScheduleEntry> { isMarkerEntry(it) }
+                .thenBy { it.start }
+                .thenBy { it.end }
+                .thenBy { it.title }
+        )
+    }
+
+    private fun isExamWeekTitle(title: String): Boolean {
+        return normalizeTitle(title).contains(examWeekKeyword)
+    }
+
+    private fun isTheoryPhaseStartTitle(title: String): Boolean {
+        val normalized = normalizeTitle(title)
+        return normalized.contains(beginKeyword) && normalized.contains(theoryPhaseKeyword)
+    }
+
+    private fun normalizeTitle(title: String): String {
+        return title
+            .lowercase(Locale.ROOT)
+            .replace(Regex("[\\s\\.-]"), "")
+    }
+}

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
@@ -4,8 +4,8 @@ import com.fariszr.dualmate.model.ScheduleEntry
 import java.util.Locale
 
 object ScheduleWidgetMarkerHelper {
-    private const val specialEventType = 5 // Mirrors Dart ScheduleEntryType.SpecialEvent.
-    private const val examType = 4 // Mirrors Dart ScheduleEntryType.Exam.
+    private const val specialEventType = ScheduleEntry.SPECIAL_EVENT_TYPE
+    private const val examType = ScheduleEntry.EXAM_TYPE
     private const val examWeekKeyword = "klausurwoche"
     private const val theoryPhaseKeyword = "theoriephase"
     private const val beginKeyword = "beginn"

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
@@ -10,6 +10,7 @@ object ScheduleWidgetMarkerHelper {
     private const val examWeekKeyword = "klausurwoche"
     private const val theoryPhaseKeyword = "theoriephase"
     private const val beginKeyword = "beginn"
+    private val TITLE_NORMALIZATION_REGEX = Regex("[\\s\\.-]")
 
     fun isMarkerEntry(entry: ScheduleEntry): Boolean {
         if (entry.type != specialEventType &&
@@ -51,6 +52,6 @@ object ScheduleWidgetMarkerHelper {
     private fun normalizeTitle(title: String): String {
         return title
             .lowercase(Locale.ROOT)
-            .replace(Regex("[\\s\\.-]"), "")
+            .replace(TITLE_NORMALIZATION_REGEX, "")
     }
 }

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
@@ -6,13 +6,21 @@ import java.util.Locale
 object ScheduleWidgetMarkerHelper {
     private const val specialEventType = ScheduleEntry.SPECIAL_EVENT_TYPE
     private const val examType = ScheduleEntry.EXAM_TYPE
+    private const val publicHolidayType = ScheduleEntry.PUBLIC_HOLIDAY_TYPE
     private const val examWeekKeyword = "klausurwoche"
     private const val theoryPhaseKeyword = "theoriephase"
     private const val beginKeyword = "beginn"
 
     fun isMarkerEntry(entry: ScheduleEntry): Boolean {
-        if (entry.type != specialEventType && entry.type != examType) {
+        if (entry.type != specialEventType &&
+            entry.type != examType &&
+            entry.type != publicHolidayType
+        ) {
             return false
+        }
+
+        if (entry.type == publicHolidayType) {
+            return true
         }
 
         return isExamWeekTitle(entry.title) || isTheoryPhaseStartTitle(entry.title)

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
@@ -35,6 +35,10 @@ object ScheduleWidgetMarkerHelper {
         )
     }
 
+    fun isMarkerOnlyDay(entries: List<ScheduleEntry>): Boolean {
+        return entries.isNotEmpty() && entries.all { isMarkerEntry(it) }
+    }
+
     private fun isExamWeekTitle(title: String): Boolean {
         return normalizeTitle(title).contains(examWeekKeyword)
     }

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt
@@ -5,12 +5,13 @@ import java.util.Locale
 
 object ScheduleWidgetMarkerHelper {
     private const val specialEventType = 5 // Mirrors Dart ScheduleEntryType.SpecialEvent.
+    private const val examType = 4 // Mirrors Dart ScheduleEntryType.Exam.
     private const val examWeekKeyword = "klausurwoche"
     private const val theoryPhaseKeyword = "theoriephase"
     private const val beginKeyword = "beginn"
 
     fun isMarkerEntry(entry: ScheduleEntry): Boolean {
-        if (entry.type != specialEventType) {
+        if (entry.type != specialEventType && entry.type != examType) {
             return false
         }
 

--- a/android/app/src/main/res/drawable/widget_schedule_item_accent_marker_exam.xml
+++ b/android/app/src/main/res/drawable/widget_schedule_item_accent_marker_exam.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/widget_schedule_entry_exam_color" />
+    <corners android:radius="2dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_schedule_item_accent_marker_holiday.xml
+++ b/android/app/src/main/res/drawable/widget_schedule_item_accent_marker_holiday.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/widget_schedule_entry_holiday_color" />
+    <corners android:radius="2dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_schedule_item_accent_marker_special_event.xml
+++ b/android/app/src/main/res/drawable/widget_schedule_item_accent_marker_special_event.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/widget_schedule_entry_special_event_color" />
+    <corners android:radius="2dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_schedule_item_accent_marker_unknown.xml
+++ b/android/app/src/main/res/drawable/widget_schedule_item_accent_marker_unknown.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/widget_schedule_entry_unknown_color" />
+    <corners android:radius="2dp" />
+</shape>

--- a/android/app/src/main/res/layout/widget_schedule_day_marker_full_item.xml
+++ b/android/app/src/main/res/layout/widget_schedule_day_marker_full_item.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/layout_schedule_item"
+    android:layout_width="match_parent"
+    android:layout_height="32dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/view_item_accent"
+        android:layout_width="4dp"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="10dp"
+        android:background="@drawable/widget_schedule_item_accent_marker_unknown" />
+
+    <TextView
+        android:id="@+id/text_view_item_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="15sp"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_schedule_day_marker_full_item.xml
+++ b/android/app/src/main/res/layout/widget_schedule_day_marker_full_item.xml
@@ -13,7 +13,9 @@
         android:layout_width="4dp"
         android:layout_height="match_parent"
         android:layout_marginEnd="10dp"
-        android:background="@drawable/widget_schedule_item_accent_marker_unknown" />
+        android:background="@drawable/widget_schedule_item_accent_marker_unknown"
+        android:importantForAccessibility="no"
+        android:contentDescription="@null" />
 
     <TextView
         android:id="@+id/text_view_item_title"

--- a/android/app/src/main/res/layout/widget_schedule_day_marker_full_item.xml
+++ b/android/app/src/main/res/layout/widget_schedule_day_marker_full_item.xml
@@ -2,9 +2,11 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/layout_schedule_item"
     android:layout_width="match_parent"
-    android:layout_height="32dp"
+    android:layout_height="wrap_content"
     android:gravity="center_vertical"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:paddingVertical="4dp"
+    android:layout_marginBottom="4dp">
 
     <ImageView
         android:id="@+id/view_item_accent"
@@ -20,6 +22,6 @@
         android:layout_weight="1"
         android:ellipsize="end"
         android:maxLines="1"
-        android:textSize="15sp"
+        android:textSize="16sp"
         android:textStyle="bold" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/widget_schedule_day_marker_item.xml
+++ b/android/app/src/main/res/layout/widget_schedule_day_marker_item.xml
@@ -12,7 +12,9 @@
         android:layout_width="4dp"
         android:layout_height="match_parent"
         android:layout_marginEnd="10dp"
-        android:background="@drawable/widget_schedule_item_accent_default" />
+        android:background="@drawable/widget_schedule_item_accent_default"
+        android:contentDescription="@null"
+        android:importantForAccessibility="no" />
 
     <TextView
         android:id="@+id/text_view_item_title"

--- a/android/app/src/main/res/layout/widget_schedule_day_marker_item.xml
+++ b/android/app/src/main/res/layout/widget_schedule_day_marker_item.xml
@@ -5,13 +5,13 @@
     android:layout_height="wrap_content"
     android:layout_marginBottom="2dp"
     android:orientation="horizontal"
-    android:paddingVertical="2dp">
+    android:paddingVertical="3dp">
 
     <ImageView
         android:id="@+id/view_item_accent"
-        android:layout_width="3dp"
+        android:layout_width="4dp"
         android:layout_height="match_parent"
-        android:layout_marginEnd="8dp"
+        android:layout_marginEnd="10dp"
         android:background="@drawable/widget_schedule_item_accent_default" />
 
     <TextView
@@ -21,6 +21,6 @@
         android:layout_weight="1"
         android:ellipsize="end"
         android:maxLines="1"
-        android:textSize="13sp"
+        android:textSize="14sp"
         android:textStyle="bold" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/widget_schedule_day_marker_item.xml
+++ b/android/app/src/main/res/layout/widget_schedule_day_marker_item.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/layout_schedule_item"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="2dp"
+    android:orientation="horizontal"
+    android:paddingVertical="2dp">
+
+    <ImageView
+        android:id="@+id/view_item_accent"
+        android:layout_width="3dp"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="8dp"
+        android:background="@drawable/widget_schedule_item_accent_default" />
+
+    <TextView
+        android:id="@+id/text_view_item_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="13sp"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -14,6 +14,7 @@
     <color name="widget_schedule_entry_exam_color">#815C19</color>
     <color name="widget_schedule_entry_holiday_color">#676767</color>
     <color name="widget_schedule_entry_online_color">#2659A6</color>
+    <color name="widget_schedule_entry_special_event_color">#3D7FD6</color>
     <color name="widget_schedule_entry_unknown_color">#676767</color>
 
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -29,5 +29,6 @@
     <color name="widget_schedule_entry_exam_color">#fffdb531</color>
     <color name="widget_schedule_entry_holiday_color">#B5B5B5</color>
     <color name="widget_schedule_entry_online_color">#ffAFC7EA</color>
+    <color name="widget_schedule_entry_special_event_color">#ffc0e2ff</color>
     <color name="widget_schedule_entry_unknown_color">#B5B5B5</color>
 </resources>

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactoryTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactoryTest.kt
@@ -27,13 +27,13 @@ class NowScheduleEntryViewsFactoryTest {
     fun prepareDayItems_keepsCompactLayoutForMixedDays() {
         val items = NowScheduleEntryViewsFactory.prepareDayItems(
             listOf(
-                entry(title = "Beginn der 1. Theoriephase", type = ScheduleEntry.SPECIAL_EVENT_TYPE),
-                entry(title = "Algorithms", type = ScheduleEntry.CLASS_TYPE)
+                entry(title = "Algorithms", type = ScheduleEntry.CLASS_TYPE),
+                entry(title = "Beginn der 1. Theoriephase", type = ScheduleEntry.SPECIAL_EVENT_TYPE)
             )
         )
 
-        val markerItem = items.first { ScheduleWidgetMarkerHelper.isMarkerEntry(it.entry) }
-
+        val markerItem = items.first()
+        assertTrue(ScheduleWidgetMarkerHelper.isMarkerEntry(markerItem.entry))
         assertFalse(markerItem.usesFullHeightMarkerLayout)
         assertEquals(
             R.layout.widget_schedule_day_marker_item,

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactoryTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactoryTest.kt
@@ -1,0 +1,80 @@
+package com.fariszr.dualmate.widget.now
+
+import com.fariszr.dualmate.R
+import com.fariszr.dualmate.model.ScheduleEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.threeten.bp.LocalDateTime
+
+class NowScheduleEntryViewsFactoryTest {
+    @Test
+    fun prepareDayItems_usesFullHeightLayoutForSingleMarkerDay() {
+        val items = NowScheduleEntryViewsFactory.prepareDayItems(
+            listOf(entry(title = "Karfreitag", type = ScheduleEntry.PUBLIC_HOLIDAY_TYPE))
+        )
+
+        assertEquals(1, items.size)
+        assertTrue(items.single().usesFullHeightMarkerLayout)
+        assertEquals(
+            R.layout.widget_schedule_day_marker_full_item,
+            NowScheduleEntryViewsFactory.markerLayoutId(items.single())
+        )
+    }
+
+    @Test
+    fun prepareDayItems_keepsCompactLayoutForMixedDays() {
+        val items = NowScheduleEntryViewsFactory.prepareDayItems(
+            listOf(
+                entry(title = "Beginn der 1. Theoriephase", type = ScheduleEntry.SPECIAL_EVENT_TYPE),
+                entry(title = "Algorithms", type = ScheduleEntry.CLASS_TYPE)
+            )
+        )
+
+        val markerItem = items.first { ScheduleWidgetMarkerHelper.isMarkerEntry(it.entry) }
+
+        assertFalse(markerItem.usesFullHeightMarkerLayout)
+        assertEquals(
+            R.layout.widget_schedule_day_marker_item,
+            NowScheduleEntryViewsFactory.markerLayoutId(markerItem)
+        )
+    }
+
+    @Test
+    fun markerAccentDrawable_matchesSchedulePageColors() {
+        assertEquals(
+            R.drawable.widget_schedule_item_accent_marker_special_event,
+            NowScheduleEntryViewsFactory.markerAccentDrawable(
+                entry(title = "Beginn der 1. Theoriephase", type = ScheduleEntry.SPECIAL_EVENT_TYPE)
+            )
+        )
+        assertEquals(
+            R.drawable.widget_schedule_item_accent_marker_holiday,
+            NowScheduleEntryViewsFactory.markerAccentDrawable(
+                entry(title = "Karfreitag", type = ScheduleEntry.PUBLIC_HOLIDAY_TYPE)
+            )
+        )
+        assertEquals(
+            R.drawable.widget_schedule_item_accent_marker_exam,
+            NowScheduleEntryViewsFactory.markerAccentDrawable(
+                entry(title = "Exam marker", type = ScheduleEntry.EXAM_TYPE)
+            )
+        )
+    }
+
+    private fun entry(title: String, type: Int): ScheduleEntry {
+        val start = LocalDateTime.of(2026, 4, 1, 7, 0)
+
+        return ScheduleEntry(
+            id = 1,
+            title = title,
+            details = "",
+            professor = "",
+            room = "",
+            type = type,
+            start = start,
+            end = start.plusHours(1)
+        )
+    }
+}

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
@@ -12,7 +12,7 @@ class ScheduleWidgetMarkerHelperTest {
     fun isMarkerEntry_matchesExamWeekMarker() {
         val entry = entry(
             title = "Klausurwoche 2. Semester",
-            type = 5
+            type = ScheduleEntry.SPECIAL_EVENT_TYPE
         )
 
         assertTrue(ScheduleWidgetMarkerHelper.isMarkerEntry(entry))
@@ -22,7 +22,7 @@ class ScheduleWidgetMarkerHelperTest {
     fun isMarkerEntry_ignoresRegularExam() {
         val entry = entry(
             title = "Klausur Informatik 2",
-            type = 4
+            type = ScheduleEntry.EXAM_TYPE
         )
 
         assertFalse(ScheduleWidgetMarkerHelper.isMarkerEntry(entry))
@@ -32,7 +32,7 @@ class ScheduleWidgetMarkerHelperTest {
     fun isMarkerEntry_ignoresUnrelatedType5() {
         val entry = entry(
             title = "Career Fair",
-            type = 5
+            type = ScheduleEntry.SPECIAL_EVENT_TYPE
         )
 
         assertFalse(ScheduleWidgetMarkerHelper.isMarkerEntry(entry))
@@ -42,12 +42,12 @@ class ScheduleWidgetMarkerHelperTest {
     fun orderEntriesForDisplay_movesMarkersToTop() {
         val classEntry = entry(
             title = "Algorithms",
-            type = 1,
+            type = ScheduleEntry.CLASS_TYPE,
             start = LocalDateTime.of(2026, 4, 1, 8, 0)
         )
         val markerEntry = entry(
             title = "Beginn der 1. Theoriephase",
-            type = 5,
+            type = ScheduleEntry.SPECIAL_EVENT_TYPE,
             start = LocalDateTime.of(2026, 4, 1, 10, 0)
         )
 

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
@@ -29,6 +29,16 @@ class ScheduleWidgetMarkerHelperTest {
     }
 
     @Test
+    fun isMarkerEntry_ignoresUnrelatedType5() {
+        val entry = entry(
+            title = "Career Fair",
+            type = 5
+        )
+
+        assertFalse(ScheduleWidgetMarkerHelper.isMarkerEntry(entry))
+    }
+
+    @Test
     fun orderEntriesForDisplay_movesMarkersToTop() {
         val classEntry = entry(
             title = "Algorithms",

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
@@ -1,0 +1,68 @@
+package com.fariszr.dualmate.widget.now
+
+import com.fariszr.dualmate.model.ScheduleEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.threeten.bp.LocalDateTime
+
+class ScheduleWidgetMarkerHelperTest {
+    @Test
+    fun isMarkerEntry_matchesExamWeekMarker() {
+        val entry = entry(
+            title = "Klausurwoche 2. Semester",
+            type = 5
+        )
+
+        assertTrue(ScheduleWidgetMarkerHelper.isMarkerEntry(entry))
+    }
+
+    @Test
+    fun isMarkerEntry_ignoresRegularExam() {
+        val entry = entry(
+            title = "Klausur Informatik 2",
+            type = 4
+        )
+
+        assertFalse(ScheduleWidgetMarkerHelper.isMarkerEntry(entry))
+    }
+
+    @Test
+    fun orderEntriesForDisplay_movesMarkersToTop() {
+        val classEntry = entry(
+            title = "Algorithms",
+            type = 1,
+            start = LocalDateTime.of(2026, 4, 1, 8, 0)
+        )
+        val markerEntry = entry(
+            title = "Beginn der 1. Theoriephase",
+            type = 5,
+            start = LocalDateTime.of(2026, 4, 1, 10, 0)
+        )
+
+        val ordered = ScheduleWidgetMarkerHelper.orderEntriesForDisplay(
+            listOf(classEntry, markerEntry)
+        )
+
+        assertEquals(markerEntry.title, ordered.first().title)
+        assertEquals(classEntry.title, ordered.last().title)
+    }
+
+    private fun entry(
+        title: String,
+        type: Int,
+        start: LocalDateTime = LocalDateTime.of(2026, 4, 1, 7, 0)
+    ): ScheduleEntry {
+        return ScheduleEntry(
+            1,
+            title,
+            "",
+            "",
+            "",
+            type,
+            start,
+            start.plusHours(1)
+        )
+    }
+}

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
@@ -29,7 +29,7 @@ class ScheduleWidgetMarkerHelperTest {
     }
 
     @Test
-    fun isMarkerEntry_ignoresUnrelatedType5() {
+    fun isMarkerEntry_ignoresUnrelatedSpecialEvent() {
         val entry = entry(
             title = "Career Fair",
             type = ScheduleEntry.SPECIAL_EVENT_TYPE

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
@@ -75,14 +75,14 @@ class ScheduleWidgetMarkerHelperTest {
         start: LocalDateTime = LocalDateTime.of(2026, 4, 1, 7, 0)
     ): ScheduleEntry {
         return ScheduleEntry(
-            1,
-            title,
-            "",
-            "",
-            "",
-            type,
-            start,
-            start.plusHours(1)
+            id = 1,
+            title = title,
+            details = "",
+            professor = "",
+            room = "",
+            type = type,
+            start = start,
+            end = start.plusHours(1)
         )
     }
 }

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
@@ -39,6 +39,16 @@ class ScheduleWidgetMarkerHelperTest {
     }
 
     @Test
+    fun isMarkerEntry_matchesPublicHoliday() {
+        val entry = entry(
+            title = "Karfreitag",
+            type = ScheduleEntry.PUBLIC_HOLIDAY_TYPE
+        )
+
+        assertTrue(ScheduleWidgetMarkerHelper.isMarkerEntry(entry))
+    }
+
+    @Test
     fun orderEntriesForDisplay_movesMarkersToTop() {
         val classEntry = entry(
             title = "Algorithms",

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelperTest.kt
@@ -49,6 +49,34 @@ class ScheduleWidgetMarkerHelperTest {
     }
 
     @Test
+    fun isMarkerOnlyDay_trueWhenAllEntriesAreMarkers() {
+        val entries = listOf(
+            entry(
+                title = "Karfreitag",
+                type = ScheduleEntry.PUBLIC_HOLIDAY_TYPE
+            )
+        )
+
+        assertTrue(ScheduleWidgetMarkerHelper.isMarkerOnlyDay(entries))
+    }
+
+    @Test
+    fun isMarkerOnlyDay_falseWhenRegularClassesExist() {
+        val entries = listOf(
+            entry(
+                title = "Beginn der 1. Theoriephase",
+                type = ScheduleEntry.SPECIAL_EVENT_TYPE
+            ),
+            entry(
+                title = "Algorithms",
+                type = ScheduleEntry.CLASS_TYPE
+            )
+        )
+
+        assertFalse(ScheduleWidgetMarkerHelper.isMarkerOnlyDay(entries))
+    }
+
+    @Test
     fun orderEntriesForDisplay_movesMarkersToTop() {
         val classEntry = entry(
             title = "Algorithms",

--- a/docs/multi-day-widgets.md
+++ b/docs/multi-day-widgets.md
@@ -9,7 +9,7 @@ The schedule and canteen Android home screen widgets now display multiple days. 
 - **Week-only lookahead:** The widgets scan a rolling 7-day window (today plus 6 days) to limit database work.
 - **Today always visible:** Today is always shown, even if there are no remaining classes or meals.
 - **Skip empty future days:** Future days without entries are omitted.
-- **Marker events:** Rapla marker events like `Klausurwoche` and theory-phase starts stay visible, but render first in each day as compact title-only rows.
+- **Marker events:** Rapla marker events like `Klausurwoche`, theory-phase starts, and public holidays stay visible, but render first in each day as compact title-only rows.
 - **State styling:** Schedule items are styled as past (grayed), current (brighter gray), or future (normal).
 - **Overflow:** When a day has more items than fit, the row ends with a "+N more" indicator.
 

--- a/docs/multi-day-widgets.md
+++ b/docs/multi-day-widgets.md
@@ -9,6 +9,7 @@ The schedule and canteen Android home screen widgets now display multiple days. 
 - **Week-only lookahead:** The widgets scan a rolling 7-day window (today plus 6 days) to limit database work.
 - **Today always visible:** Today is always shown, even if there are no remaining classes or meals.
 - **Skip empty future days:** Future days without entries are omitted.
+- **Marker events:** Rapla marker events like `Klausurwoche` and theory-phase starts stay visible, but render first in each day as compact title-only rows.
 - **State styling:** Schedule items are styled as past (grayed), current (brighter gray), or future (normal).
 - **Overflow:** When a day has more items than fit, the row ends with a "+N more" indicator.
 

--- a/docs/multi-day-widgets.md
+++ b/docs/multi-day-widgets.md
@@ -9,7 +9,8 @@ The schedule and canteen Android home screen widgets now display multiple days. 
 - **Week-only lookahead:** The widgets scan a rolling 7-day window (today plus 6 days) to limit database work.
 - **Today always visible:** Today is always shown, even if there are no remaining classes or meals.
 - **Skip empty future days:** Future days without entries are omitted.
-- **Marker events:** Rapla marker events like `Klausurwoche`, theory-phase starts, and public holidays stay visible, but render first in each day as compact title-only rows.
+- **Marker events:** Rapla marker events like `Klausurwoche`, theory-phase starts, and public holidays stay visible, render first in each day, and use their schedule-type colors (blue for special events, gray for holidays, yellow for exam markers).
+- **Marker-only days:** A day with only one marker-style entry uses the full minimum day height instead of a compact chip, so the row does not leave empty vertical space.
 - **State styling:** Schedule items are styled as past (grayed), current (brighter gray), or future (normal).
 - **Overflow:** When a day has more items than fit, the row ends with a "+N more" indicator.
 

--- a/docs/solutions/ui-bugs/widget-marker-events-notifications-20260327.md
+++ b/docs/solutions/ui-bugs/widget-marker-events-notifications-20260327.md
@@ -15,8 +15,9 @@ tags: [schedule, notifications, widget, rapla, android]
 
 ## Context
 
-Rapla important events such as exam-week banners and theory-phase start markers
-should remain visible in the app and widget, but they are not actionable lessons.
+Rapla important events such as exam-week banners, theory-phase start markers,
+and public-holiday rows should remain visible in the app and widget, but they
+are not actionable lessons.
 Treating them like regular classes produced noisy schedule-change notifications,
 misleading next-day notifications, and cluttered widget rows.
 
@@ -33,9 +34,10 @@ misleading next-day notifications, and cluttered widget rows.
 ## Solution
 
 - Added a shared Dart helper at `lib/schedule/model/schedule_marker_event.dart`
-  to recognize marker entries by the existing title heuristics:
+  to recognize marker entries by the existing type and title heuristics:
   - `Klausurwoche`
   - `Beginn ... Theoriephase`
+  - all `PublicHoliday` schedule entries
 - Filtered marker entries out of notification delivery in:
   - `lib/schedule/ui/notification/schedule_changed_notification.dart`
   - `lib/schedule/ui/notification/next_day_information_notification.dart`

--- a/docs/solutions/ui-bugs/widget-marker-events-notifications-20260327.md
+++ b/docs/solutions/ui-bugs/widget-marker-events-notifications-20260327.md
@@ -1,0 +1,76 @@
+---
+title: Marker events stay in widgets but stop triggering notifications
+date: 2026-03-27
+problem_type: ui_bug
+module: Schedule notifications + Android widget
+component: ScheduleChangedNotification, NextDayInformationNotification, ScheduleNowWidget
+severity: medium
+symptoms:
+  - Rapla marker entries like `Klausurwoche` triggered schedule notifications
+  - Next-day notifications could announce a marker entry instead of a real class
+  - The schedule widget rendered marker entries like normal classes with subtitle details
+root_cause: Marker events were stored as normal schedule entries, but notification and widget surfaces had no marker-specific presentation or suppression rules
+tags: [schedule, notifications, widget, rapla, android]
+---
+
+## Context
+
+Rapla important events such as exam-week banners and theory-phase start markers
+should remain visible in the app and widget, but they are not actionable lessons.
+Treating them like regular classes produced noisy schedule-change notifications,
+misleading next-day notifications, and cluttered widget rows.
+
+## Investigation
+
+- Rapla marker entries already existed as normal `ScheduleEntry` rows and were
+  intentionally reused by Dates/important-events flows.
+- `ScheduleChangedNotification` notified on any near-term diff entry.
+- `NextDayInformationNotification` chose the next future schedule entry without
+  distinguishing marker rows from real classes.
+- `NowScheduleEntryViewsFactory` rendered every schedule row with the same
+  title + subtitle layout and chronological ordering.
+
+## Solution
+
+- Added a shared Dart helper at `lib/schedule/model/schedule_marker_event.dart`
+  to recognize marker entries by the existing title heuristics:
+  - `Klausurwoche`
+  - `Beginn ... Theoriephase`
+- Filtered marker entries out of notification delivery in:
+  - `lib/schedule/ui/notification/schedule_changed_notification.dart`
+  - `lib/schedule/ui/notification/next_day_information_notification.dart`
+- Added widget-side marker handling in:
+  - `android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt`
+  - `android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactory.kt`
+- Added a compact title-only widget row layout:
+  - `android/app/src/main/res/layout/widget_schedule_day_marker_item.xml`
+- Marker rows now sort ahead of normal classes inside the widget day column.
+
+## Code References
+
+- Marker detection: `lib/schedule/model/schedule_marker_event.dart`
+- Schedule-change notification filtering:
+  `lib/schedule/ui/notification/schedule_changed_notification.dart`
+- Next-day notification filtering:
+  `lib/schedule/ui/notification/next_day_information_notification.dart`
+- Widget ordering + rendering:
+  `android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt`
+  `android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactory.kt`
+  `android/app/src/main/res/layout/widget_schedule_day_marker_item.xml`
+
+## Verification
+
+- `flutter test test/schedule/model/schedule_marker_event_test.dart test/schedule/ui/notification/schedule_changed_notification_test.dart test/schedule/ui/notification/next_day_information_notification_test.dart`
+- `flutter analyze lib/schedule/model/schedule_marker_event.dart lib/schedule/ui/notification/schedule_changed_notification.dart lib/schedule/ui/notification/next_day_information_notification.dart test/schedule/model/schedule_marker_event_test.dart test/schedule/ui/notification/schedule_changed_notification_test.dart test/schedule/ui/notification/next_day_information_notification_test.dart`
+- `flutter build apk --debug`
+
+## Prevention
+
+- Keep marker-event detection in one helper per runtime where sharing is not
+  possible, and keep those rules aligned instead of sprinkling title checks
+  through notification or widget code.
+- Treat notifications and widget presentation as policy layers; do not remove
+  marker entries from shared schedule storage unless product wants to change the
+  Dates page behavior too.
+- When widgets need special rendering for one schedule subtype, prefer a small
+  layout override instead of changing the shared query path.

--- a/docs/solutions/ui-bugs/widget-marker-events-notifications-20260327.md
+++ b/docs/solutions/ui-bugs/widget-marker-events-notifications-20260327.md
@@ -44,9 +44,16 @@ misleading next-day notifications, and cluttered widget rows.
 - Added widget-side marker handling in:
   - `android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/ScheduleWidgetMarkerHelper.kt`
   - `android/app/src/main/kotlin/com/fariszr/dualmate/widget/now/NowScheduleEntryViewsFactory.kt`
-- Added a compact title-only widget row layout:
+- Added compact and full-height title-only widget row layouts:
   - `android/app/src/main/res/layout/widget_schedule_day_marker_item.xml`
+  - `android/app/src/main/res/layout/widget_schedule_day_marker_full_item.xml`
 - Marker rows now sort ahead of normal classes inside the widget day column.
+- Marker accents now follow the same type colors used by the schedule page:
+  - `SpecialEvent` / exam-week markers: blue
+  - `PublicHoliday`: gray
+  - `Exam` markers: yellow
+- Days that contain only a single marker entry now use the full minimum row
+  height instead of leaving empty space below a compact chip.
 
 ## Code References
 

--- a/lib/schedule/model/schedule_marker_event.dart
+++ b/lib/schedule/model/schedule_marker_event.dart
@@ -6,7 +6,8 @@ class ScheduleMarkerEvent {
   static const String beginKeyword = 'beginn';
 
   static bool isMarkerEntry(ScheduleEntry entry) {
-    if (entry.type != ScheduleEntryType.SpecialEvent) {
+    if (entry.type != ScheduleEntryType.SpecialEvent &&
+        entry.type != ScheduleEntryType.Exam) {
       return false;
     }
 

--- a/lib/schedule/model/schedule_marker_event.dart
+++ b/lib/schedule/model/schedule_marker_event.dart
@@ -4,6 +4,7 @@ class ScheduleMarkerEvent {
   static const String examWeekKeyword = 'klausurwoche';
   static const String theoryPhaseKeyword = 'theoriephase';
   static const String beginKeyword = 'beginn';
+  static final RegExp _normalizationPattern = RegExp(r'[\s\.-]');
 
   static bool isMarkerEntry(ScheduleEntry entry) {
     if (entry.type != ScheduleEntryType.SpecialEvent &&
@@ -30,6 +31,6 @@ class ScheduleMarkerEvent {
   }
 
   static String _normalizeTitle(String title) {
-    return title.toLowerCase().replaceAll(RegExp(r'[\s\.-]'), '');
+    return title.toLowerCase().replaceAll(_normalizationPattern, '');
   }
 }

--- a/lib/schedule/model/schedule_marker_event.dart
+++ b/lib/schedule/model/schedule_marker_event.dart
@@ -7,8 +7,13 @@ class ScheduleMarkerEvent {
 
   static bool isMarkerEntry(ScheduleEntry entry) {
     if (entry.type != ScheduleEntryType.SpecialEvent &&
-        entry.type != ScheduleEntryType.Exam) {
+        entry.type != ScheduleEntryType.Exam &&
+        entry.type != ScheduleEntryType.PublicHoliday) {
       return false;
+    }
+
+    if (entry.type == ScheduleEntryType.PublicHoliday) {
+      return true;
     }
 
     return isExamWeekTitle(entry.title) || isTheoryPhaseStartTitle(entry.title);

--- a/lib/schedule/model/schedule_marker_event.dart
+++ b/lib/schedule/model/schedule_marker_event.dart
@@ -1,0 +1,29 @@
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+
+class ScheduleMarkerEvent {
+  static const String examWeekKeyword = 'klausurwoche';
+  static const String theoryPhaseKeyword = 'theoriephase';
+  static const String beginKeyword = 'beginn';
+
+  static bool isMarkerEntry(ScheduleEntry entry) {
+    if (entry.type != ScheduleEntryType.SpecialEvent) {
+      return false;
+    }
+
+    return isExamWeekTitle(entry.title) || isTheoryPhaseStartTitle(entry.title);
+  }
+
+  static bool isExamWeekTitle(String title) {
+    return _normalizeTitle(title).contains(examWeekKeyword);
+  }
+
+  static bool isTheoryPhaseStartTitle(String title) {
+    var normalized = _normalizeTitle(title);
+    return normalized.contains(beginKeyword) &&
+        normalized.contains(theoryPhaseKeyword);
+  }
+
+  static String _normalizeTitle(String title) {
+    return title.toLowerCase().replaceAll(RegExp(r'[\s\.-]'), '');
+  }
+}

--- a/lib/schedule/ui/notification/next_day_information_notification.dart
+++ b/lib/schedule/ui/notification/next_day_information_notification.dart
@@ -9,6 +9,7 @@ import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/common/util/string_utils.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/model/schedule_marker_event.dart';
 import 'package:intl/intl.dart';
 
 class NextDayInformationNotification extends TaskCallback {
@@ -16,13 +17,15 @@ class NextDayInformationNotification extends TaskCallback {
   final NotificationApi _notificationApi;
   final ScheduleEntryRepository _scheduleEntryRepository;
   final WorkSchedulerService _scheduler;
+  final DateTime Function() _now;
 
   NextDayInformationNotification(
     this._notificationApi,
     this._scheduleEntryRepository,
     this._scheduler,
-    this._preferencesProvider,
-  );
+    this._preferencesProvider, {
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
 
   @override
   Future<void> run() async {
@@ -32,10 +35,9 @@ class NextDayInformationNotification extends TaskCallback {
       return;
     }
 
-    var now = DateTime.now();
+    var now = _now();
 
-    var nextScheduleEntry =
-        await _scheduleEntryRepository.queryNextScheduleEntry(now);
+    var nextScheduleEntry = await _findNextNotifiableScheduleEntry(now);
     if (nextScheduleEntry == null) {
       return;
     }
@@ -94,9 +96,28 @@ class NextDayInformationNotification extends TaskCallback {
     return L(Locale(languageCode ?? 'en'));
   }
 
+  Future<ScheduleEntry?> _findNextNotifiableScheduleEntry(DateTime now) async {
+    final schedule = await _scheduleEntryRepository.queryScheduleBetweenDates(
+      now,
+      addDays(toStartOfDay(now), 2),
+    );
+
+    var upcomingEntries = schedule.entries.where((entry) {
+      return entry.start.isAfter(now) &&
+          !ScheduleMarkerEvent.isMarkerEntry(entry);
+    }).toList()
+      ..sort((a, b) => a.start.compareTo(b.start));
+
+    if (upcomingEntries.isEmpty) {
+      return null;
+    }
+
+    return upcomingEntries.first;
+  }
+
   @override
   Future<void> schedule() async {
-    var nextSchedule = toTimeOfDayInFuture(DateTime.now(), 20, 00);
+    var nextSchedule = toTimeOfDayInFuture(_now(), 20, 00);
     await _scheduler.scheduleOneShotTaskAt(
       nextSchedule,
       "NextDayInformationNotification" + DateFormat.yMd().format(nextSchedule),
@@ -106,7 +127,7 @@ class NextDayInformationNotification extends TaskCallback {
 
   @override
   Future<void> cancel() async {
-    var nextSchedule = toTimeOfDayInFuture(DateTime.now(), 20, 00);
+    var nextSchedule = toTimeOfDayInFuture(_now(), 20, 00);
     await _scheduler.cancelTask(
       "NextDayInformationNotification" + DateFormat.yMd().format(nextSchedule),
     );

--- a/lib/schedule/ui/notification/schedule_changed_notification.dart
+++ b/lib/schedule/ui/notification/schedule_changed_notification.dart
@@ -7,6 +7,7 @@ import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/common/util/string_utils.dart';
 import 'package:dualmate/schedule/business/schedule_diff_calculator.dart';
+import 'package:dualmate/schedule/model/schedule_marker_event.dart';
 import 'package:intl/intl.dart';
 
 class ScheduleChangedNotification {
@@ -23,7 +24,9 @@ class ScheduleChangedNotification {
   }) : _now = now ?? DateTime.now;
 
   Future<void> showNotification(ScheduleDiff scheduleDiff) async {
-    final filteredDiff = _filterToNotificationWindow(scheduleDiff);
+    final filteredDiff = _filterMarkerEntries(
+      _filterToNotificationWindow(scheduleDiff),
+    );
     if (!filteredDiff.didSomethingChange()) {
       return;
     }
@@ -44,6 +47,20 @@ class ScheduleChangedNotification {
           .toList(),
       updatedEntries: scheduleDiff.updatedEntries
           .where((entry) => _isWithinNotificationWindow(entry.entry.start))
+          .toList(),
+    );
+  }
+
+  ScheduleDiff _filterMarkerEntries(ScheduleDiff scheduleDiff) {
+    return ScheduleDiff(
+      addedEntries: scheduleDiff.addedEntries
+          .where((entry) => !ScheduleMarkerEvent.isMarkerEntry(entry))
+          .toList(),
+      removedEntries: scheduleDiff.removedEntries
+          .where((entry) => !ScheduleMarkerEvent.isMarkerEntry(entry))
+          .toList(),
+      updatedEntries: scheduleDiff.updatedEntries
+          .where((entry) => !ScheduleMarkerEvent.isMarkerEntry(entry.entry))
           .toList(),
     );
   }

--- a/test/schedule/model/schedule_marker_event_test.dart
+++ b/test/schedule/model/schedule_marker_event_test.dart
@@ -47,6 +47,15 @@ void main() {
 
     expect(ScheduleMarkerEvent.isMarkerEntry(entry), isTrue);
   });
+
+  test('treats public holidays as markers', () {
+    final entry = _entry(
+      title: 'Karfreitag',
+      type: ScheduleEntryType.PublicHoliday,
+    );
+
+    expect(ScheduleMarkerEvent.isMarkerEntry(entry), isTrue);
+  });
 }
 
 ScheduleEntry _entry({required String title, required ScheduleEntryType type}) {

--- a/test/schedule/model/schedule_marker_event_test.dart
+++ b/test/schedule/model/schedule_marker_event_test.dart
@@ -29,6 +29,24 @@ void main() {
 
     expect(ScheduleMarkerEvent.isMarkerEntry(entry), isFalse);
   });
+
+  test('does not treat unrelated special events as markers', () {
+    final entry = _entry(
+      title: 'Career Fair',
+      type: ScheduleEntryType.SpecialEvent,
+    );
+
+    expect(ScheduleMarkerEvent.isMarkerEntry(entry), isFalse);
+  });
+
+  test('recognizes klausurwoche exams as markers', () {
+    final entry = _entry(
+      title: 'Klausurwoche 2. Semester',
+      type: ScheduleEntryType.Exam,
+    );
+
+    expect(ScheduleMarkerEvent.isMarkerEntry(entry), isTrue);
+  });
 }
 
 ScheduleEntry _entry({required String title, required ScheduleEntryType type}) {

--- a/test/schedule/model/schedule_marker_event_test.dart
+++ b/test/schedule/model/schedule_marker_event_test.dart
@@ -1,0 +1,44 @@
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/model/schedule_marker_event.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('recognizes klausurwoche special events as markers', () {
+    final entry = _entry(
+      title: 'Klausurwoche 2. Semester',
+      type: ScheduleEntryType.SpecialEvent,
+    );
+
+    expect(ScheduleMarkerEvent.isMarkerEntry(entry), isTrue);
+  });
+
+  test('recognizes theoriephase start events as markers', () {
+    final entry = _entry(
+      title: 'Beginn der 1. Theoriephase',
+      type: ScheduleEntryType.SpecialEvent,
+    );
+
+    expect(ScheduleMarkerEvent.isMarkerEntry(entry), isTrue);
+  });
+
+  test('does not treat exams as markers', () {
+    final entry = _entry(
+      title: 'Klausur Informatik 2',
+      type: ScheduleEntryType.Exam,
+    );
+
+    expect(ScheduleMarkerEvent.isMarkerEntry(entry), isFalse);
+  });
+}
+
+ScheduleEntry _entry({required String title, required ScheduleEntryType type}) {
+  return ScheduleEntry(
+    start: DateTime(2026, 4, 1, 8),
+    end: DateTime(2026, 4, 1, 9),
+    title: title,
+    details: '',
+    professor: '',
+    room: '',
+    type: type,
+  );
+}

--- a/test/schedule/model/schedule_marker_event_test.dart
+++ b/test/schedule/model/schedule_marker_event_test.dart
@@ -21,6 +21,15 @@ void main() {
     expect(ScheduleMarkerEvent.isMarkerEntry(entry), isTrue);
   });
 
+  test('does not treat theoriephase without beginn as marker', () {
+    final entry = _entry(
+      title: 'Theoriephase 2. Semester',
+      type: ScheduleEntryType.SpecialEvent,
+    );
+
+    expect(ScheduleMarkerEvent.isMarkerEntry(entry), isFalse);
+  });
+
   test('does not treat exams as markers', () {
     final entry = _entry(
       title: 'Klausur Informatik 2',

--- a/test/schedule/ui/notification/next_day_information_notification_test.dart
+++ b/test/schedule/ui/notification/next_day_information_notification_test.dart
@@ -73,6 +73,33 @@ void main() {
     expect(notificationApi.title, isEmpty);
     expect(notificationApi.message, isEmpty);
   });
+
+  test('run stays silent when only future public holidays exist', () async {
+    final now = DateTime(2026, 4, 2, 20);
+    final notificationApi = _RecordingNotificationApi();
+    final notification = NextDayInformationNotification(
+      notificationApi,
+      _FakeScheduleEntryRepository([
+        ScheduleEntry(
+          start: DateTime(2026, 4, 3),
+          end: DateTime(2026, 4, 4),
+          title: 'Karfreitag',
+          details: '',
+          professor: '',
+          room: '',
+          type: ScheduleEntryType.PublicHoliday,
+        ),
+      ]),
+      _FakeWorkSchedulerService(),
+      _FakePreferencesProvider(),
+      now: () => now,
+    );
+
+    await notification.run();
+
+    expect(notificationApi.title, isEmpty);
+    expect(notificationApi.message, isEmpty);
+  });
 }
 
 class _FakePreferencesProvider implements PreferencesProvider {

--- a/test/schedule/ui/notification/next_day_information_notification_test.dart
+++ b/test/schedule/ui/notification/next_day_information_notification_test.dart
@@ -109,7 +109,12 @@ class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
     DateTime start,
     DateTime end,
   ) async {
-    return Schedule()..entries.addAll(entries);
+    final schedule = Schedule();
+    schedule.entries.addAll(
+      entries.where(
+          (entry) => entry.end.isAfter(start) && entry.start.isBefore(end)),
+    );
+    return schedule;
   }
 
   @override

--- a/test/schedule/ui/notification/next_day_information_notification_test.dart
+++ b/test/schedule/ui/notification/next_day_information_notification_test.dart
@@ -2,36 +2,76 @@ import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('run loads localization from preferences without Kiwi registration',
-      () async {
-    final now = DateTime.now();
+  test(
+    'run loads localization from preferences without Kiwi registration',
+    () async {
+      final now = DateTime(2026, 3, 8, 20);
+      final notificationApi = _RecordingNotificationApi();
+      final notification = NextDayInformationNotification(
+        notificationApi,
+        _FakeScheduleEntryRepository([
+          ScheduleEntry(
+            start: DateTime(now.year, now.month, now.day + 1, 7),
+            end: DateTime(now.year, now.month, now.day + 1, 8),
+            title: 'Klausurwoche 2. Semester',
+            details: '',
+            professor: '',
+            room: '',
+            type: ScheduleEntryType.SpecialEvent,
+          ),
+          ScheduleEntry(
+            start: DateTime(now.year, now.month, now.day + 1, 9),
+            end: DateTime(now.year, now.month, now.day + 1, 10),
+            title: 'Mathematics',
+            details: '',
+            professor: '',
+            room: '',
+            type: ScheduleEntryType.Class,
+          ),
+        ]),
+        _FakeWorkSchedulerService(),
+        _FakePreferencesProvider(),
+        now: () => now,
+      );
+
+      await notification.run();
+
+      expect(notificationApi.title, isNotEmpty);
+      expect(notificationApi.message, contains('Mathematics'));
+    },
+  );
+
+  test('run stays silent when only future marker events exist', () async {
+    final now = DateTime(2026, 3, 8, 20);
     final notificationApi = _RecordingNotificationApi();
     final notification = NextDayInformationNotification(
       notificationApi,
-      _FakeScheduleEntryRepository(
+      _FakeScheduleEntryRepository([
         ScheduleEntry(
-          start: DateTime(now.year, now.month, now.day + 1, 9),
-          end: DateTime(now.year, now.month, now.day + 1, 10),
-          title: 'Mathematics',
+          start: DateTime(now.year, now.month, now.day + 1, 7),
+          end: DateTime(now.year, now.month, now.day + 1, 8),
+          title: 'Beginn der 1. Theoriephase',
           details: '',
           professor: '',
           room: '',
-          type: ScheduleEntryType.Class,
+          type: ScheduleEntryType.SpecialEvent,
         ),
-      ),
+      ]),
       _FakeWorkSchedulerService(),
       _FakePreferencesProvider(),
+      now: () => now,
     );
 
     await notification.run();
 
-    expect(notificationApi.title, isNotEmpty);
-    expect(notificationApi.message, contains('Mathematics'));
+    expect(notificationApi.title, isEmpty);
+    expect(notificationApi.message, isEmpty);
   });
 }
 
@@ -60,13 +100,17 @@ class _RecordingNotificationApi extends VoidNotificationApi {
 }
 
 class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
-  final ScheduleEntry? nextEntry;
+  final List<ScheduleEntry> entries;
 
-  _FakeScheduleEntryRepository(this.nextEntry);
+  _FakeScheduleEntryRepository(this.entries);
 
   @override
-  Future<ScheduleEntry?> queryNextScheduleEntry(DateTime now) async =>
-      nextEntry;
+  Future<Schedule> queryScheduleBetweenDates(
+    DateTime start,
+    DateTime end,
+  ) async {
+    return Schedule()..entries.addAll(entries);
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/schedule/ui/notification/next_day_information_notification_test.dart
+++ b/test/schedule/ui/notification/next_day_information_notification_test.dart
@@ -100,6 +100,36 @@ void main() {
     expect(notificationApi.title, isEmpty);
     expect(notificationApi.message, isEmpty);
   });
+
+  test(
+    'run stays silent when only future exam marker klausurwoche exists',
+    () async {
+      final now = DateTime(2026, 3, 8, 20);
+      final notificationApi = _RecordingNotificationApi();
+      final notification = NextDayInformationNotification(
+        notificationApi,
+        _FakeScheduleEntryRepository([
+          ScheduleEntry(
+            start: DateTime(now.year, now.month, now.day + 1, 7),
+            end: DateTime(now.year, now.month, now.day + 1, 8),
+            title: 'Klausurwoche 2. Semester',
+            details: '',
+            professor: '',
+            room: '',
+            type: ScheduleEntryType.Exam,
+          ),
+        ]),
+        _FakeWorkSchedulerService(),
+        _FakePreferencesProvider(),
+        now: () => now,
+      );
+
+      await notification.run();
+
+      expect(notificationApi.title, isEmpty);
+      expect(notificationApi.message, isEmpty);
+    },
+  );
 }
 
 class _FakePreferencesProvider implements PreferencesProvider {

--- a/test/schedule/ui/notification/schedule_changed_notification_test.dart
+++ b/test/schedule/ui/notification/schedule_changed_notification_test.dart
@@ -105,6 +105,65 @@ void main() {
     );
 
     expect(notificationApi.titles, isEmpty);
+    expect(
+      notificationApi.messages.any(
+        (message) => message.contains('Klausurwoche 2. Semester'),
+      ),
+      isFalse,
+    );
+  });
+
+  test('does not notify for removed marker events', () async {
+    final notificationApi = _RecordingNotificationApi();
+    final notification = _buildNotification(notificationApi, fixedNow);
+
+    await notification.showNotification(
+      ScheduleDiff(
+        removedEntries: [
+          _entryAt(
+            DateTime(2026, 3, 10, 7),
+            title: 'Klausurwoche 2. Semester',
+            type: ScheduleEntryType.SpecialEvent,
+          ),
+        ],
+      ),
+    );
+
+    expect(notificationApi.titles, isEmpty);
+    expect(
+      notificationApi.messages.any(
+        (message) => message.contains('Klausurwoche 2. Semester'),
+      ),
+      isFalse,
+    );
+  });
+
+  test('does not notify for updated marker events', () async {
+    final notificationApi = _RecordingNotificationApi();
+    final notification = _buildNotification(notificationApi, fixedNow);
+
+    await notification.showNotification(
+      ScheduleDiff(
+        updatedEntries: [
+          UpdatedEntry(
+            _entryAt(
+              DateTime(2026, 3, 10, 7),
+              title: 'Klausurwoche 2. Semester',
+              type: ScheduleEntryType.SpecialEvent,
+            ),
+            ['start'],
+          ),
+        ],
+      ),
+    );
+
+    expect(notificationApi.titles, isEmpty);
+    expect(
+      notificationApi.messages.any(
+        (message) => message.contains('Klausurwoche 2. Semester'),
+      ),
+      isFalse,
+    );
   });
 
   test(
@@ -122,6 +181,72 @@ void main() {
               type: ScheduleEntryType.SpecialEvent,
             ),
             _entryAt(DateTime(2026, 3, 10, 9), title: 'Algorithms'),
+          ],
+        ),
+      );
+
+      expect(notificationApi.titles, hasLength(1));
+      expect(notificationApi.messages.single, contains('Algorithms'));
+      expect(
+        notificationApi.messages.any(
+          (message) => message.contains('Klausurwoche 2. Semester'),
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'notifies only for real removed classes when marker removals also changed',
+    () async {
+      final notificationApi = _RecordingNotificationApi();
+      final notification = _buildNotification(notificationApi, fixedNow);
+
+      await notification.showNotification(
+        ScheduleDiff(
+          removedEntries: [
+            _entryAt(
+              DateTime(2026, 3, 10, 7),
+              title: 'Klausurwoche 2. Semester',
+              type: ScheduleEntryType.SpecialEvent,
+            ),
+            _entryAt(DateTime(2026, 3, 10, 9), title: 'Algorithms'),
+          ],
+        ),
+      );
+
+      expect(notificationApi.titles, hasLength(1));
+      expect(notificationApi.messages.single, contains('Algorithms'));
+      expect(
+        notificationApi.messages.any(
+          (message) => message.contains('Klausurwoche 2. Semester'),
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'notifies only for real updated classes when marker updates also changed',
+    () async {
+      final notificationApi = _RecordingNotificationApi();
+      final notification = _buildNotification(notificationApi, fixedNow);
+
+      await notification.showNotification(
+        ScheduleDiff(
+          updatedEntries: [
+            UpdatedEntry(
+              _entryAt(
+                DateTime(2026, 3, 10, 7),
+                title: 'Klausurwoche 2. Semester',
+                type: ScheduleEntryType.SpecialEvent,
+              ),
+              ['start'],
+            ),
+            UpdatedEntry(
+              _entryAt(DateTime(2026, 3, 10, 9), title: 'Algorithms'),
+              ['room'],
+            ),
           ],
         ),
       );

--- a/test/schedule/ui/notification/schedule_changed_notification_test.dart
+++ b/test/schedule/ui/notification/schedule_changed_notification_test.dart
@@ -113,6 +113,29 @@ void main() {
     );
   });
 
+  test('does not notify for added public holidays', () async {
+    final notificationApi = _RecordingNotificationApi();
+    final notification = _buildNotification(notificationApi, fixedNow);
+
+    await notification.showNotification(
+      ScheduleDiff(
+        addedEntries: [
+          _entryAt(
+            DateTime(2026, 4, 3),
+            title: 'Karfreitag',
+            type: ScheduleEntryType.PublicHoliday,
+          ),
+        ],
+      ),
+    );
+
+    expect(notificationApi.titles, isEmpty);
+    expect(
+      notificationApi.messages.any((message) => message.contains('Karfreitag')),
+      isFalse,
+    );
+  });
+
   test('does not notify for removed marker events', () async {
     final notificationApi = _RecordingNotificationApi();
     final notification = _buildNotification(notificationApi, fixedNow);

--- a/test/schedule/ui/notification/schedule_changed_notification_test.dart
+++ b/test/schedule/ui/notification/schedule_changed_notification_test.dart
@@ -14,9 +14,7 @@ void main() {
 
     await notification.showNotification(
       ScheduleDiff(
-        addedEntries: [
-          _entryAt(DateTime(2026, 3, 22, 9), title: 'Algorithms'),
-        ],
+        addedEntries: [_entryAt(DateTime(2026, 3, 22, 9), title: 'Algorithms')],
       ),
     );
 
@@ -30,9 +28,7 @@ void main() {
 
     await notification.showNotification(
       ScheduleDiff(
-        addedEntries: [
-          _entryAt(DateTime(2026, 3, 23, 9), title: 'Algorithms'),
-        ],
+        addedEntries: [_entryAt(DateTime(2026, 3, 23, 9), title: 'Algorithms')],
       ),
     );
 
@@ -45,9 +41,7 @@ void main() {
 
     await notification.showNotification(
       ScheduleDiff(
-        removedEntries: [
-          _entryAt(DateTime(2026, 4, 5, 11), title: 'Physics'),
-        ],
+        removedEntries: [_entryAt(DateTime(2026, 4, 5, 11), title: 'Physics')],
       ),
     );
 
@@ -61,9 +55,50 @@ void main() {
     await notification.showNotification(
       ScheduleDiff(
         updatedEntries: [
-          UpdatedEntry(
-            _entryAt(DateTime(2026, 4, 2, 14), title: 'Databases'),
-            ['start'],
+          UpdatedEntry(_entryAt(DateTime(2026, 4, 2, 14), title: 'Databases'), [
+            'start',
+          ]),
+        ],
+      ),
+    );
+
+    expect(notificationApi.titles, isEmpty);
+  });
+
+  test(
+    'filters far-future entries before applying notification count limits',
+    () async {
+      final notificationApi = _RecordingNotificationApi();
+      final notification = _buildNotification(notificationApi, fixedNow);
+
+      await notification.showNotification(
+        ScheduleDiff(
+          addedEntries: [
+            _entryAt(DateTime(2026, 3, 10, 9), title: 'Near term'),
+            _entryAt(DateTime(2026, 4, 10, 9), title: 'Far 1'),
+            _entryAt(DateTime(2026, 4, 11, 9), title: 'Far 2'),
+            _entryAt(DateTime(2026, 4, 12, 9), title: 'Far 3'),
+            _entryAt(DateTime(2026, 4, 13, 9), title: 'Far 4'),
+          ],
+        ),
+      );
+
+      expect(notificationApi.titles, hasLength(1));
+      expect(notificationApi.messages.single, contains('Near term'));
+    },
+  );
+
+  test('does not notify for added marker events', () async {
+    final notificationApi = _RecordingNotificationApi();
+    final notification = _buildNotification(notificationApi, fixedNow);
+
+    await notification.showNotification(
+      ScheduleDiff(
+        addedEntries: [
+          _entryAt(
+            DateTime(2026, 3, 10, 7),
+            title: 'Klausurwoche 2. Semester',
+            type: ScheduleEntryType.SpecialEvent,
           ),
         ],
       ),
@@ -72,26 +107,35 @@ void main() {
     expect(notificationApi.titles, isEmpty);
   });
 
-  test('filters far-future entries before applying notification count limits',
-      () async {
-    final notificationApi = _RecordingNotificationApi();
-    final notification = _buildNotification(notificationApi, fixedNow);
+  test(
+    'notifies only for real classes when marker events also changed',
+    () async {
+      final notificationApi = _RecordingNotificationApi();
+      final notification = _buildNotification(notificationApi, fixedNow);
 
-    await notification.showNotification(
-      ScheduleDiff(
-        addedEntries: [
-          _entryAt(DateTime(2026, 3, 10, 9), title: 'Near term'),
-          _entryAt(DateTime(2026, 4, 10, 9), title: 'Far 1'),
-          _entryAt(DateTime(2026, 4, 11, 9), title: 'Far 2'),
-          _entryAt(DateTime(2026, 4, 12, 9), title: 'Far 3'),
-          _entryAt(DateTime(2026, 4, 13, 9), title: 'Far 4'),
-        ],
-      ),
-    );
+      await notification.showNotification(
+        ScheduleDiff(
+          addedEntries: [
+            _entryAt(
+              DateTime(2026, 3, 10, 7),
+              title: 'Klausurwoche 2. Semester',
+              type: ScheduleEntryType.SpecialEvent,
+            ),
+            _entryAt(DateTime(2026, 3, 10, 9), title: 'Algorithms'),
+          ],
+        ),
+      );
 
-    expect(notificationApi.titles, hasLength(1));
-    expect(notificationApi.messages.single, contains('Near term'));
-  });
+      expect(notificationApi.titles, hasLength(1));
+      expect(notificationApi.messages.single, contains('Algorithms'));
+      expect(
+        notificationApi.messages.any(
+          (message) => message.contains('Klausurwoche 2. Semester'),
+        ),
+        isFalse,
+      );
+    },
+  );
 }
 
 ScheduleChangedNotification _buildNotification(
@@ -105,7 +149,11 @@ ScheduleChangedNotification _buildNotification(
   );
 }
 
-ScheduleEntry _entryAt(DateTime start, {required String title}) {
+ScheduleEntry _entryAt(
+  DateTime start, {
+  required String title,
+  ScheduleEntryType type = ScheduleEntryType.Class,
+}) {
   return ScheduleEntry(
     start: start,
     end: start.add(const Duration(hours: 1)),
@@ -113,7 +161,7 @@ ScheduleEntry _entryAt(DateTime start, {required String title}) {
     details: 'Lecture',
     professor: 'Prof',
     room: 'R1',
-    type: ScheduleEntryType.Class,
+    type: type,
   );
 }
 


### PR DESCRIPTION
## Summary
- suppress Rapla marker events like `Klausurwoche` and theory-phase starts from schedule-change and next-day notifications
- keep marker events visible in the schedule widget, but render them first as compact title-only rows
- add focused tests plus widget behavior docs for the new marker-event rules

## Testing
- flutter test test/schedule/model/schedule_marker_event_test.dart test/schedule/ui/notification/schedule_changed_notification_test.dart test/schedule/ui/notification/next_day_information_notification_test.dart
- flutter analyze lib/schedule/model/schedule_marker_event.dart lib/schedule/ui/notification/schedule_changed_notification.dart lib/schedule/ui/notification/next_day_information_notification.dart test/schedule/model/schedule_marker_event_test.dart test/schedule/ui/notification/schedule_changed_notification_test.dart test/schedule/ui/notification/next_day_information_notification_test.dart
- flutter build apk --debug
- Installed `build/app/outputs/flutter-apk/app-debug.apk` on Galaxy S21+ (`RFCR31468LJ`), launched `com.fariszr.dualmate/.MainActivity`, and verified the widget provider registered without runtime errors in logcat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widget highlights specific schedule items (exam weeks, theory-phase starts, public holidays) with distinct styling and surfaces them first in the list.
* **Bug Fixes / Improvements**
  * Notifications and change-detection now exclude those highlighted marker items; widget item styling and rendering paths were unified for consistency.
* **Tests**
  * Added deterministic tests covering marker detection, ordering, notification filtering, and widget rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->