### PR TITLE
fix(schedule): point current-week button toward today

### DIFF
--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -622,6 +622,11 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
 
   Widget _buildCurrentWeekButton(BuildContext context) {
     final label = L.of(context).scheduleBackToCurrentWeek;
+    final currentWeekStart = _normalizeWeekStart(viewModel.currentDateStart);
+    final todayWeekStart = _normalizeWeekStart(viewModel.now);
+    final icon = currentWeekStart.isBefore(todayWeekStart)
+        ? Icons.arrow_forward_rounded
+        : Icons.arrow_back_rounded;
 
     return AnimatedSwitcher(
       duration: _currentWeekButtonFadeDuration,
@@ -650,7 +655,7 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
                 heroTag: null,
                 tooltip: label,
                 onPressed: _goToToday,
-                child: const Icon(Icons.arrow_back_rounded),
+                child: Icon(icon),
               ),
             ),
     );

--- a/test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
+++ b/test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
@@ -212,8 +212,20 @@ void main() {
 
     expect(viewModel.currentDateStart, DateTime(2026, 2, 16));
     expect(currentWeekButton, findsOneWidget);
-    expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
-    expect(find.byIcon(Icons.arrow_forward_rounded), findsNothing);
+    expect(
+      find.descendant(
+        of: currentWeekButton,
+        matching: find.byIcon(Icons.arrow_back_rounded),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: currentWeekButton,
+        matching: find.byIcon(Icons.arrow_forward_rounded),
+      ),
+      findsNothing,
+    );
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
@@ -244,8 +256,23 @@ void main() {
       find.byKey(const ValueKey<String>('weekly_current_week_button')),
       findsOneWidget,
     );
-    expect(find.byIcon(Icons.arrow_forward_rounded), findsOneWidget);
-    expect(find.byIcon(Icons.arrow_back_rounded), findsNothing);
+    final currentWeekButton = find.byKey(
+      const ValueKey<String>('weekly_current_week_button'),
+    );
+    expect(
+      find.descendant(
+        of: currentWeekButton,
+        matching: find.byIcon(Icons.arrow_forward_rounded),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: currentWeekButton,
+        matching: find.byIcon(Icons.arrow_back_rounded),
+      ),
+      findsNothing,
+    );
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();

--- a/test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
+++ b/test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
@@ -212,6 +212,40 @@ void main() {
 
     expect(viewModel.currentDateStart, DateTime(2026, 2, 16));
     expect(currentWeekButton, findsOneWidget);
+    expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
+    expect(find.byIcon(Icons.arrow_forward_rounded), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    viewModel.dispose();
+  });
+
+  testWidgets('current week button points right when browsing past weeks', (
+    tester,
+  ) async {
+    final viewModel = _buildViewModel(
+      now: DateTime(2026, 2, 10, 10),
+      entries: <ScheduleEntry>[
+        _entry(DateTime(2026, 2, 2), 'PAST_WEEK'),
+        _entry(DateTime(2026, 2, 9), 'CURRENT_WEEK'),
+      ],
+    );
+    await viewModel.updateSchedule(
+      DateTime(2026, 2, 2),
+      DateTime(2026, 2, 16),
+      force: true,
+    );
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await tester.pump();
+
+    expect(viewModel.currentDateStart, DateTime(2026, 2, 2));
+    expect(
+      find.byKey(const ValueKey<String>('weekly_current_week_button')),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.arrow_forward_rounded), findsOneWidget);
+    expect(find.byIcon(Icons.arrow_back_rounded), findsNothing);
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();


### PR DESCRIPTION
## Summary
- point the schedule page current-week FAB toward the actual current week instead of always showing a left arrow
- keep the existing jump-to-current-week behavior unchanged while making past-week navigation show a right arrow
- add widget test coverage for both past-week and future-week button directions

## Testing
- flutter test test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced weekly schedule navigation with smart arrow direction indicators. The "back to current week" button now dynamically adjusts the arrow direction based on your current browsing position: displays a forward arrow when viewing past weeks, and a backward arrow when viewing upcoming weeks. This provides improved navigation context awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->