### PR TITLE
fix: keep Dualis logged in and add manual refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,11 @@ Important runtime behavior:
 
 - Navigation entry and page under `lib/dualis/ui`
 - Service stack includes cache decorator + scraper/authentication in `lib/dualis/service`
+- Stored Dualis credentials should restore the session automatically when the
+  Dualis section is shown again; long-idle returns should trigger a refresh
+  instead of dropping the user back to the login form.
+- Logged-in Dualis pages support manual pull-to-refresh, which should force a
+  cache-busting reload of overview and semester data.
 
 ### Schedule (`lib/schedule`)
 

--- a/docs/solutions/ui-bugs/dualis-session-persistence-and-refresh-20260519.md
+++ b/docs/solutions/ui-bugs/dualis-session-persistence-and-refresh-20260519.md
@@ -23,6 +23,7 @@ The Dualis view model supported explicit login only. It never attempted to resto
 
 ## Solution
 - Updated `StudyGradesViewModel` to:
+  - start in an initializing state so Dualis does not render the logged-out UI before the first saved-credential check completes
   - restore the Dualis session from saved credentials when the Dualis section becomes visible
   - refresh stale Dualis data automatically when reopening the section after a long gap
   - expose `refreshData(force: true)` so the UI can trigger a full cache-busting reload
@@ -40,11 +41,12 @@ The Dualis view model supported explicit login only. It never attempted to resto
 - `login falls back to LoginFailed on unexpected service errors`
 - `loadAllModules keeps loading=true for the newest in-flight request`
 - `restores the Dualis session from saved credentials on page open`
+- `does not show login page before restoring saved session`
 - `refreshData(force: true) clears cached Dualis data before reloading`
 - existing Dualis loading animation widget tests
 
 ## Commands run
 ```bash
-flutter test test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/study_overview_loading_animation_test.dart
+flutter test test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/study_overview_loading_animation_test.dart test/dualis/ui/dualis_page_session_restore_test.dart
 flutter analyze lib/dualis lib/common/data/preferences/preferences_provider.dart test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/study_overview_loading_animation_test.dart
 ```

--- a/docs/solutions/ui-bugs/dualis-session-persistence-and-refresh-20260519.md
+++ b/docs/solutions/ui-bugs/dualis-session-persistence-and-refresh-20260519.md
@@ -1,0 +1,50 @@
+---
+module: Dualis UI
+date: 2026-05-19
+problem_type: ui_bug
+component: frontend_flutter
+symptoms:
+  - "Dualis asks the user to log in again after reopening the app"
+  - "There is no manual pull-to-refresh path on the Dualis pages"
+  - "Returning to Dualis after a long time does not automatically refresh stale data"
+root_cause: dualis_view_model_only_supported_explicit_login_and_never_revalidated_on_page_visibility
+resolution_type: code_fix
+severity: medium
+tags: [dualis, login, session, refresh, cache, flutter, android]
+---
+
+# Troubleshooting: Dualis session persistence and refresh
+
+## Problem
+Dualis only stayed usable for the current in-memory session. After reopening the app, the page returned to the login form even when credentials were already stored. The logged-in views also lacked a manual refresh affordance.
+
+## Root Cause
+The Dualis view model supported explicit login only. It never attempted to restore a stored session when the page became visible again, and it had no persisted freshness timestamp to decide when stale data should be reloaded automatically.
+
+## Solution
+- Updated `StudyGradesViewModel` to:
+  - restore the Dualis session from saved credentials when the Dualis section becomes visible
+  - refresh stale Dualis data automatically when reopening the section after a long gap
+  - expose `refreshData(force: true)` so the UI can trigger a full cache-busting reload
+  - track the last successful Dualis refresh in preferences
+- Updated `DualisPage` to:
+  - observe section visibility inside the main `IndexedStack`
+  - trigger the stale-session refresh flow on first show and on app resume while Dualis is active
+  - show a loading state while the session is being restored
+- Added pull-to-refresh to:
+  - `StudyOverviewPage`
+  - `ExamResultsPage`
+- Extended the Dualis service contract with `clearCache()` so forced refreshes bypass cached grade/module data.
+
+## Test Coverage
+- `login falls back to LoginFailed on unexpected service errors`
+- `loadAllModules keeps loading=true for the newest in-flight request`
+- `restores the Dualis session from saved credentials on page open`
+- `refreshData(force: true) clears cached Dualis data before reloading`
+- existing Dualis loading animation widget tests
+
+## Commands run
+```bash
+flutter test test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/study_overview_loading_animation_test.dart
+flutter analyze lib/dualis lib/common/data/preferences/preferences_provider.dart test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/study_overview_loading_animation_test.dart
+```

--- a/lib/common/data/preferences/preferences_provider.dart
+++ b/lib/common/data/preferences/preferences_provider.dart
@@ -18,6 +18,7 @@ class PreferencesProvider {
   static const String DualisStoreCredentials = "StoreDualisCredentials";
   static const String DualisUsername = "DualisUsername";
   static const String DualisPassword = "DualisPassword";
+  static const String DualisLastRefreshAt = "DualisLastRefreshAt";
   static const String LastViewedSemester = "LastViewedSemester";
   static const String LastViewedDateEntryDatabase =
       "LastViewedDateEntryDatabase";
@@ -163,6 +164,21 @@ class PreferencesProvider {
 
   Future<void> setStoreDualisCredentials(bool value) async {
     await _preferencesAccess.set<bool>(DualisStoreCredentials, value);
+  }
+
+  Future<DateTime?> getDualisLastRefreshAt() async {
+    final storedMs = await _preferencesAccess.get<int>(DualisLastRefreshAt);
+    if (storedMs == null || storedMs <= 0) {
+      return null;
+    }
+    return DateTime.fromMillisecondsSinceEpoch(storedMs);
+  }
+
+  Future<void> setDualisLastRefreshAt(DateTime value) async {
+    await _preferencesAccess.set<int>(
+      DualisLastRefreshAt,
+      value.millisecondsSinceEpoch,
+    );
   }
 
   Future<String> getLastViewedSemester() async {

--- a/lib/dualis/service/cache_dualis_service_decorator.dart
+++ b/lib/dualis/service/cache_dualis_service_decorator.dart
@@ -23,7 +23,11 @@ class CacheDualisServiceDecorator extends DualisService {
     String password, [
     CancellationToken? cancellationToken,
   ]) {
-    return _service.login(username, password, cancellationToken ?? CancellationToken());
+    return _service.login(
+      username,
+      password,
+      cancellationToken ?? CancellationToken(),
+    );
   }
 
   @override
@@ -34,7 +38,9 @@ class CacheDualisServiceDecorator extends DualisService {
       return _allModulesCached!;
     }
 
-    var allModules = await _service.queryAllModules(cancellationToken ?? CancellationToken());
+    var allModules = await _service.queryAllModules(
+      cancellationToken ?? CancellationToken(),
+    );
 
     _allModulesCached = allModules;
 
@@ -49,7 +55,10 @@ class CacheDualisServiceDecorator extends DualisService {
     if (_semestersCached.containsKey(name)) {
       return Future.value(_semestersCached[name]);
     }
-    var semester = await _service.querySemester(name, cancellationToken ?? CancellationToken());
+    var semester = await _service.querySemester(
+      name,
+      cancellationToken ?? CancellationToken(),
+    );
 
     _semestersCached[name] = semester;
 
@@ -64,7 +73,9 @@ class CacheDualisServiceDecorator extends DualisService {
       return _allSemesterNamesCached!;
     }
 
-    var allSemesterNames = await _service.querySemesterNames(cancellationToken ?? CancellationToken());
+    var allSemesterNames = await _service.querySemesterNames(
+      cancellationToken ?? CancellationToken(),
+    );
 
     _allSemesterNamesCached = allSemesterNames;
 
@@ -79,7 +90,9 @@ class CacheDualisServiceDecorator extends DualisService {
       return _studyGradesCached!;
     }
 
-    var studyGrades = await _service.queryStudyGrades(cancellationToken ?? CancellationToken());
+    var studyGrades = await _service.queryStudyGrades(
+      cancellationToken ?? CancellationToken(),
+    );
 
     _studyGradesCached = studyGrades;
 
@@ -91,12 +104,14 @@ class CacheDualisServiceDecorator extends DualisService {
     _allSemesterNamesCached = null;
     _semestersCached = {};
     _studyGradesCached = null;
+    _service.clearCache();
   }
 
   @override
   Future<void> logout([
     CancellationToken? cancellationToken,
   ]) async {
-    await _service.logout(cancellationToken ?? CancellationToken());    clearCache();
+    await _service.logout(cancellationToken ?? CancellationToken());
+    clearCache();
   }
 }

--- a/lib/dualis/service/dualis_service.dart
+++ b/lib/dualis/service/dualis_service.dart
@@ -32,6 +32,8 @@ abstract class DualisService {
   Future<void> logout([
     CancellationToken? cancellationToken,
   ]);
+
+  void clearCache();
 }
 
 enum LoginResult {
@@ -155,4 +157,7 @@ class DualisServiceImpl extends DualisService {
   ]) async {
     await _dualisScraper.logout(cancellationToken ?? CancellationToken());
   }
+
+  @override
+  void clearCache() {}
 }

--- a/lib/dualis/ui/dualis_navigation_entry.dart
+++ b/lib/dualis/ui/dualis_navigation_entry.dart
@@ -11,6 +11,8 @@ import 'package:kiwi/kiwi.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 
 class DualisNavigationEntry extends NavigationEntry<StudyGradesViewModel> {
+  static const int sectionIndex = 2;
+
   @override
   Widget icon(BuildContext context) {
     return Icon(Icons.data_usage);
@@ -31,7 +33,7 @@ class DualisNavigationEntry extends NavigationEntry<StudyGradesViewModel> {
 
   @override
   Widget build(BuildContext context) {
-    return DualisPage();
+    return const DualisPage(sectionIndex: sectionIndex);
   }
 
   @override

--- a/lib/dualis/ui/dualis_page.dart
+++ b/lib/dualis/ui/dualis_page.dart
@@ -101,7 +101,8 @@ class _DualisPageState extends State<DualisPage> with WidgetsBindingObserver {
                   ),
                 ],
               ),
-            LoginState.RestoringSession => const _DualisSessionLoadingPage(
+            LoginState.Initializing || LoginState.RestoringSession =>
+              const _DualisSessionLoadingPage(
                 key: ValueKey<String>('dualis_restoring_page'),
               ),
             _ => const DualisLoginPage(

--- a/lib/dualis/ui/dualis_page.dart
+++ b/lib/dualis/ui/dualis_page.dart
@@ -8,7 +8,67 @@ import 'package:flutter/material.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 import 'package:provider/provider.dart';
 
-class DualisPage extends StatelessWidget {
+class DualisPage extends StatefulWidget {
+  final int sectionIndex;
+
+  const DualisPage({super.key, required this.sectionIndex});
+
+  @override
+  State<DualisPage> createState() => _DualisPageState();
+}
+
+class _DualisPageState extends State<DualisPage> with WidgetsBindingObserver {
+  ValueNotifier<int>? _currentEntryIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final notifier = Provider.of<ValueNotifier<int>>(context, listen: false);
+    if (!identical(_currentEntryIndex, notifier)) {
+      _currentEntryIndex?.removeListener(_handleSectionChanged);
+      _currentEntryIndex = notifier;
+      _currentEntryIndex?.addListener(_handleSectionChanged);
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _handleSectionChanged();
+    });
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _currentEntryIndex?.removeListener(_handleSectionChanged);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) {
+      return;
+    }
+
+    _handleSectionChanged();
+  }
+
+  void _handleSectionChanged() {
+    if (!mounted || _currentEntryIndex?.value != widget.sectionIndex) {
+      return;
+    }
+
+    final viewModel = Provider.of<StudyGradesViewModel>(context, listen: false);
+    viewModel.onPageVisible();
+  }
+
   @override
   Widget build(BuildContext context) {
     StudyGradesViewModel viewModel =
@@ -24,26 +84,30 @@ class DualisPage extends StatelessWidget {
           Set<String>? properties,
         ) {
           final current = model ?? viewModel;
-          final child = current.loginState == LoginState.LoggedIn
-              ? PagerWidget(
-                  key: const ValueKey<String>('dualis_logged_in_pager'),
-                  pagesId: "dualis_pager",
-                  pages: <PageDefinition>[
-                    PageDefinition(
-                      text: L.of(context).pageDualisOverview,
-                      icon: const Icon(Icons.dashboard),
-                      builder: (BuildContext context) => StudyOverviewPage(),
-                    ),
-                    PageDefinition(
-                      text: L.of(context).pageDualisExams,
-                      icon: const Icon(Icons.book),
-                      builder: (BuildContext context) => ExamResultsPage(),
-                    ),
-                  ],
-                )
-              : const DualisLoginPage(
-                  key: ValueKey<String>('dualis_login_page'),
-                );
+          final child = switch (current.loginState) {
+            LoginState.LoggedIn => PagerWidget(
+                key: const ValueKey<String>('dualis_logged_in_pager'),
+                pagesId: "dualis_pager",
+                pages: <PageDefinition>[
+                  PageDefinition(
+                    text: L.of(context).pageDualisOverview,
+                    icon: const Icon(Icons.dashboard),
+                    builder: (BuildContext context) => StudyOverviewPage(),
+                  ),
+                  PageDefinition(
+                    text: L.of(context).pageDualisExams,
+                    icon: const Icon(Icons.book),
+                    builder: (BuildContext context) => ExamResultsPage(),
+                  ),
+                ],
+              ),
+            LoginState.RestoringSession => const _DualisSessionLoadingPage(
+                key: ValueKey<String>('dualis_restoring_page'),
+              ),
+            _ => const DualisLoginPage(
+                key: ValueKey<String>('dualis_login_page'),
+              ),
+          };
 
           return AnimatedSwitcher(
             duration: const Duration(milliseconds: 200),
@@ -51,6 +115,17 @@ class DualisPage extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+}
+
+class _DualisSessionLoadingPage extends StatelessWidget {
+  const _DualisSessionLoadingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: CircularProgressIndicator(),
     );
   }
 }

--- a/lib/dualis/ui/exam_results_page/exam_results_page.dart
+++ b/lib/dualis/ui/exam_results_page/exam_results_page.dart
@@ -4,83 +4,90 @@ import 'package:dualmate/dualis/model/exam_grade.dart';
 import 'package:dualmate/dualis/ui/viewmodels/study_grades_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
+import 'package:provider/provider.dart';
 
 class ExamResultsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: double.infinity,
-      child: SingleChildScrollView(
-        scrollDirection: Axis.vertical,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
-              child: Text(
-                L.of(context).dualisExamResultsTitle,
-                style: Theme.of(context).textTheme.titleLarge,
+    final viewModel = Provider.of<StudyGradesViewModel>(context, listen: false);
+
+    return RefreshIndicator(
+      onRefresh: () => viewModel.refreshData(force: true),
+      child: Container(
+        height: double.infinity,
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          scrollDirection: Axis.vertical,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+                child: Text(
+                  L.of(context).dualisExamResultsTitle,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: <Widget>[
-                  Text(L.of(context).dualisExamResultsSemesterSelect),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(24, 0, 0, 0),
-                    child: PropertyChangeConsumer<StudyGradesViewModel, String>(
-                      properties: const [
-                        "currentSemesterName",
-                        "allSemesterNames",
-                      ],
-                      builder: (
-                        BuildContext context,
-                        StudyGradesViewModel? model,
-                        Set<String>? properties,
-                      ) {
-                        if (model == null) return Container();
-                        return DropdownButton<String>(
-                          onChanged: (value) {
-                            if (value != null) {
-                              model.loadSemester(value);
-                            }
-                          },
-                          value: model.currentSemesterName.isEmpty
-                              ? null
-                              : model.currentSemesterName,
-                          items: model.allSemesterNames
-                              .map(
-                                (n) => DropdownMenuItem<String>(
-                                  child: Text(n),
-                                  value: n,
-                                ),
-                              )
-                              .toList(),
-                        );
-                      },
-                    ),
-                  )
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[
+                    Text(L.of(context).dualisExamResultsSemesterSelect),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(24, 0, 0, 0),
+                      child: PropertyChangeConsumer<StudyGradesViewModel, String>(
+                        properties: const [
+                          "currentSemesterName",
+                          "allSemesterNames",
+                        ],
+                        builder: (
+                          BuildContext context,
+                          StudyGradesViewModel? model,
+                          Set<String>? properties,
+                        ) {
+                          if (model == null) return Container();
+                          return DropdownButton<String>(
+                            onChanged: (value) {
+                              if (value != null) {
+                                model.loadSemester(value);
+                              }
+                            },
+                            value: model.currentSemesterName.isEmpty
+                                ? null
+                                : model.currentSemesterName,
+                            items: model.allSemesterNames
+                                .map(
+                                  (n) => DropdownMenuItem<String>(
+                                    child: Text(n),
+                                    value: n,
+                                  ),
+                                )
+                                .toList(),
+                          );
+                        },
+                      ),
+                    )
+                  ],
+                ),
+              ),
+              PropertyChangeConsumer<StudyGradesViewModel, String>(
+                properties: const [
+                  "currentSemester",
+                  "isLoadingCurrentSemester",
                 ],
+                builder: (
+                  BuildContext context,
+                  StudyGradesViewModel? model,
+                  Set<String>? properties,
+                ) =>
+                    model == null
+                        ? Container()
+                        : buildModulesColumn(context, model),
               ),
-            ),
-            PropertyChangeConsumer<StudyGradesViewModel, String>(
-              properties: const [
-                "currentSemester",
-                "isLoadingCurrentSemester",
-              ],
-              builder: (
-                BuildContext context,
-                StudyGradesViewModel? model,
-                Set<String>? properties,
-              ) =>
-                  model == null
-                      ? Container()
-                      : buildModulesColumn(context, model),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/dualis/ui/study_overview/study_overview_page.dart
+++ b/lib/dualis/ui/study_overview/study_overview_page.dart
@@ -3,21 +3,28 @@ import 'package:dualmate/dualis/ui/viewmodels/study_grades_view_model.dart';
 import 'package:dualmate/dualis/ui/widgets/grade_state_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
+import 'package:provider/provider.dart';
 
 class StudyOverviewPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: double.infinity,
-      child: SingleChildScrollView(
-        scrollDirection: Axis.vertical,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            buildGpaCredits(context),
-            buildModules(context),
-          ],
+    final viewModel = Provider.of<StudyGradesViewModel>(context, listen: false);
+
+    return RefreshIndicator(
+      onRefresh: () => viewModel.refreshData(force: true),
+      child: SizedBox(
+        height: double.infinity,
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          scrollDirection: Axis.vertical,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              buildGpaCredits(context),
+              buildModules(context),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/dualis/ui/viewmodels/study_grades_view_model.dart
+++ b/lib/dualis/ui/viewmodels/study_grades_view_model.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/ui/viewmodels/base_view_model.dart';
 import 'package:dualmate/common/util/cancelable_mutex.dart';
@@ -12,12 +14,15 @@ import 'package:dualmate/schedule/model/schedule_source_type.dart';
 enum LoginState {
   LoggedOut,
   LoggingIn,
+  RestoringSession,
   LoggingOut,
   LoggedIn,
   LoginFailed,
 }
 
 class StudyGradesViewModel extends BaseViewModel {
+  static const Duration _staleRefreshDuration = Duration(hours: 6);
+
   final DualisService _dualisService;
 
   final PreferencesProvider _preferencesProvider;
@@ -62,41 +67,62 @@ class StudyGradesViewModel extends BaseViewModel {
   int _allModulesLoadEpoch = 0;
   int _semesterNamesLoadEpoch = 0;
   int _currentSemesterLoadEpoch = 0;
+  bool _pageActivationInFlight = false;
+  bool _refreshInFlight = false;
+  bool _autoRestoreSuppressed = false;
 
   StudyGradesViewModel(this._preferencesProvider, this._dualisService);
 
   Future<bool> login(Credentials credentials) async {
-    _loginState = LoginState.LoggingIn;
-    notifyListeners("loginState");
+    _autoRestoreSuppressed = false;
+    return _loginWithCredentials(
+      credentials,
+      inProgressState: LoginState.LoggingIn,
+      failureState: LoginState.LoginFailed,
+    );
+  }
 
-    bool success;
-
-    try {
-      var result = await _dualisService.login(
-        credentials.username,
-        credentials.password,
-      );
-
-      success = result == LoginResult.LoggedIn;
-    } on OperationCancelledException catch (_) {
-      success = false;
-    } catch (_) {
-      success = false;
+  Future<void> onPageVisible() async {
+    if (_pageActivationInFlight || isDisposed) {
+      return;
     }
 
-    _loginState = success ? LoginState.LoggedIn : LoginState.LoginFailed;
+    _pageActivationInFlight = true;
+    try {
+      if (_loginState == LoginState.LoggedIn) {
+        if (await _isRefreshStale()) {
+          await refreshData(force: true);
+        }
+        return;
+      }
 
-    notifyListeners("loginState");
+      if (_loginState == LoginState.LoggingIn ||
+          _loginState == LoginState.LoggingOut ||
+          _loginState == LoginState.RestoringSession) {
+        return;
+      }
 
-    if (!success) {
+      await restoreSessionIfPossible();
+    } finally {
+      _pageActivationInFlight = false;
+    }
+  }
+
+  Future<bool> restoreSessionIfPossible() async {
+    if (_autoRestoreSuppressed) {
       return false;
     }
 
-    loadStudyGrades();
-    loadSemesterNames();
-    loadAllModules();
+    final credentials = await _preferencesProvider.loadDualisCredentials();
+    if (credentials.username.isEmpty || credentials.password.isEmpty) {
+      return false;
+    }
 
-    return true;
+    return _loginWithCredentials(
+      credentials,
+      inProgressState: LoginState.RestoringSession,
+      failureState: LoginState.LoggedOut,
+    );
   }
 
   Future<void> clearCredentials() async {
@@ -181,7 +207,16 @@ class StudyGradesViewModel extends BaseViewModel {
   }
 
   Future<void> loadSemester(String semesterName) async {
-    if (_currentSemesterName == semesterName) return Future.value();
+    await loadSemesterByName(semesterName);
+  }
+
+  Future<void> loadSemesterByName(
+    String semesterName, {
+    bool force = false,
+  }) async {
+    if (!force && _currentSemesterName == semesterName) {
+      return Future.value();
+    }
 
     if (_currentLoadingSemesterName == semesterName) return Future.value();
 
@@ -222,6 +257,13 @@ class StudyGradesViewModel extends BaseViewModel {
   }
 
   Future<void> loadSemesterNames() async {
+    await loadSemesterNamesForCurrentSelection();
+  }
+
+  Future<void> loadSemesterNamesForCurrentSelection({
+    String? preferredSemesterName,
+    bool forceCurrentSemesterReload = false,
+  }) async {
     final epoch = ++_semesterNamesLoadEpoch;
     _isLoadingSemesterNames = true;
     notifyListeners("isLoadingSemesterNames");
@@ -249,23 +291,63 @@ class StudyGradesViewModel extends BaseViewModel {
     notifyListeners("isLoadingSemesterNames");
 
     if (epoch == _semesterNamesLoadEpoch) {
-      await _loadInitialSemester();
+      await _loadInitialSemester(
+        preferredSemesterName: preferredSemesterName,
+        force: forceCurrentSemesterReload,
+      );
     }
   }
 
-  Future _loadInitialSemester() async {
+  Future<void> refreshData({bool force = false}) async {
+    if (_loginState != LoginState.LoggedIn || _refreshInFlight) {
+      return;
+    }
+
+    _refreshInFlight = true;
+    try {
+      if (force) {
+        _dualisService.clearCache();
+      }
+
+      final preferredSemesterName = _currentSemesterName;
+      await Future.wait<void>([
+        loadStudyGrades(),
+        loadAllModules(),
+        loadSemesterNamesForCurrentSelection(
+          preferredSemesterName: preferredSemesterName,
+          forceCurrentSemesterReload: preferredSemesterName.isNotEmpty,
+        ),
+      ]);
+
+      await _preferencesProvider.setDualisLastRefreshAt(DateTime.now());
+    } finally {
+      _refreshInFlight = false;
+    }
+  }
+
+  Future<void> _loadInitialSemester({
+    String? preferredSemesterName,
+    bool force = false,
+  }) async {
     if (_semesterNames.isEmpty) return;
+
+    var requestedSemester = preferredSemesterName ?? _currentSemesterName;
+    if (requestedSemester.isNotEmpty && _semesterNames.contains(requestedSemester)) {
+      await loadSemesterByName(requestedSemester, force: force);
+      return;
+    }
 
     var lastViewedSemester = await _preferencesProvider.getLastViewedSemester();
 
     if (_semesterNames.contains(lastViewedSemester)) {
-      loadSemester(lastViewedSemester);
+      await loadSemesterByName(lastViewedSemester, force: force);
     } else {
-      loadSemester(_semesterNames.first);
+      await loadSemesterByName(_semesterNames.first, force: force);
     }
   }
 
   Future<void> logout() async {
+    _autoRestoreSuppressed = true;
     _loginState = LoginState.LoggingOut;
     notifyListeners("loginState");
 
@@ -289,5 +371,49 @@ class StudyGradesViewModel extends BaseViewModel {
     _isLoadingCurrentSemester = false;
 
     notifyListeners();
+  }
+
+  Future<bool> _loginWithCredentials(
+    Credentials credentials, {
+    required LoginState inProgressState,
+    required LoginState failureState,
+  }) async {
+    _loginState = inProgressState;
+    notifyListeners("loginState");
+
+    bool success;
+
+    try {
+      var result = await _dualisService.login(
+        credentials.username,
+        credentials.password,
+      );
+
+      success = result == LoginResult.LoggedIn;
+    } on OperationCancelledException catch (_) {
+      success = false;
+    } catch (_) {
+      success = false;
+    }
+
+    _loginState = success ? LoginState.LoggedIn : failureState;
+
+    notifyListeners("loginState");
+
+    if (!success) {
+      return false;
+    }
+
+    unawaited(refreshData(force: true));
+    return true;
+  }
+
+  Future<bool> _isRefreshStale() async {
+    final lastRefreshAt = await _preferencesProvider.getDualisLastRefreshAt();
+    if (lastRefreshAt == null) {
+      return true;
+    }
+
+    return DateTime.now().difference(lastRefreshAt) >= _staleRefreshDuration;
   }
 }

--- a/lib/dualis/ui/viewmodels/study_grades_view_model.dart
+++ b/lib/dualis/ui/viewmodels/study_grades_view_model.dart
@@ -12,6 +12,7 @@ import 'package:dualmate/dualis/service/dualis_service.dart';
 import 'package:dualmate/schedule/model/schedule_source_type.dart';
 
 enum LoginState {
+  Initializing,
   LoggedOut,
   LoggingIn,
   RestoringSession,
@@ -27,7 +28,7 @@ class StudyGradesViewModel extends BaseViewModel {
 
   final PreferencesProvider _preferencesProvider;
 
-  LoginState _loginState = LoginState.LoggedOut;
+  LoginState _loginState = LoginState.Initializing;
   LoginState get loginState => _loginState;
 
   StudyGrades _studyGrades = StudyGrades(0, 0, 0, 0);
@@ -110,11 +111,15 @@ class StudyGradesViewModel extends BaseViewModel {
 
   Future<bool> restoreSessionIfPossible() async {
     if (_autoRestoreSuppressed) {
+      _loginState = LoginState.LoggedOut;
+      notifyListeners("loginState");
       return false;
     }
 
     final credentials = await _preferencesProvider.loadDualisCredentials();
     if (credentials.username.isEmpty || credentials.password.isEmpty) {
+      _loginState = LoginState.LoggedOut;
+      notifyListeners("loginState");
       return false;
     }
 

--- a/test/dualis/ui/dualis_page_session_restore_test.dart
+++ b/test/dualis/ui/dualis_page_session_restore_test.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+
+import 'package:dualmate/common/data/preferences/preferences_access.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/dualis/model/credentials.dart';
+import 'package:dualmate/dualis/model/module.dart';
+import 'package:dualmate/dualis/model/semester.dart';
+import 'package:dualmate/dualis/model/study_grades.dart';
+import 'package:dualmate/dualis/service/dualis_service.dart';
+import 'package:dualmate/dualis/ui/dualis_page.dart';
+import 'package:dualmate/dualis/ui/login/dualis_login_page.dart';
+import 'package:dualmate/dualis/ui/viewmodels/study_grades_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kiwi/kiwi.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    KiwiContainer().clear();
+  });
+
+  tearDown(() {
+    KiwiContainer().clear();
+  });
+
+  testWidgets('does not show login page before restoring saved session', (
+    tester,
+  ) async {
+    final preferences = PreferencesProvider(
+      _FakePreferencesAccess(),
+      _FakeSecureStorageAccess(),
+    );
+    KiwiContainer().registerInstance<PreferencesProvider>(preferences);
+    await preferences.storeDualisCredentials(Credentials('saved-user', 'saved-pass'));
+
+    final dualisService = _DelayedLoginDualisService();
+    final viewModel = StudyGradesViewModel(preferences, dualisService);
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await tester.pump();
+
+    expect(find.byType(DualisLoginPage), findsNothing);
+    expect(
+      find.byKey(const ValueKey<String>('dualis_restoring_page')),
+      findsOneWidget,
+    );
+
+    dualisService.completeLogin();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DualisLoginPage), findsNothing);
+    expect(
+      find.byKey(const ValueKey<String>('dualis_logged_in_pager')),
+      findsOneWidget,
+    );
+  });
+}
+
+Widget _wrapWithApp(StudyGradesViewModel viewModel) {
+  final sectionIndex = ValueNotifier<int>(2);
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<StudyGradesViewModel>.value(value: viewModel),
+      ChangeNotifierProvider<ValueNotifier<int>>.value(value: sectionIndex),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: const [
+        LocalizationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('de')],
+      home: const Scaffold(body: DualisPage(sectionIndex: 2)),
+    ),
+  );
+}
+
+class _DelayedLoginDualisService extends DualisService {
+  final Completer<void> _loginCompleter = Completer<void>();
+
+  @override
+  Future<LoginResult> login(
+    String username,
+    String password, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    await _loginCompleter.future;
+    return LoginResult.LoggedIn;
+  }
+
+  @override
+  Future<List<Module>> queryAllModules([
+    CancellationToken? cancellationToken,
+  ]) async {
+    return const <Module>[];
+  }
+
+  @override
+  Future<Semester> querySemester(
+    String name, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    return Semester(name, const <Module>[]);
+  }
+
+  @override
+  Future<List<String>> querySemesterNames([
+    CancellationToken? cancellationToken,
+  ]) async {
+    return const <String>[];
+  }
+
+  @override
+  Future<StudyGrades> queryStudyGrades([
+    CancellationToken? cancellationToken,
+  ]) async {
+    return StudyGrades(0, 0, 0, 0);
+  }
+
+  @override
+  Future<void> logout([
+    CancellationToken? cancellationToken,
+  ]) async {}
+
+  @override
+  void clearCache() {}
+
+  void completeLogin() {
+    if (_loginCompleter.isCompleted) {
+      return;
+    }
+    _loginCompleter.complete();
+  }
+}
+
+class _FakePreferencesAccess extends PreferencesAccess {
+  final Map<String, Object?> _store = <String, Object?>{};
+
+  @override
+  Future<void> set<T>(String key, T value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<T?> get<T>(String key) async {
+    return _store[key] as T?;
+  }
+}
+
+class _FakeSecureStorageAccess extends SecureStorageAccess {
+  final Map<String, String?> _store = <String, String?>{};
+
+  @override
+  Future<void> set(String key, String value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<String?> get(String key) async {
+    return _store[key];
+  }
+}

--- a/test/dualis/ui/study_overview_loading_animation_test.dart
+++ b/test/dualis/ui/study_overview_loading_animation_test.dart
@@ -258,6 +258,9 @@ class _BlockingDualisService extends DualisService {
     CancellationToken? cancellationToken,
   ]) async {}
 
+  @override
+  void clearCache() {}
+
   void completeModules(List<Module> modules) {
     if (_allModulesCompleter.isCompleted) {
       return;

--- a/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
+++ b/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
@@ -17,7 +17,10 @@ void main() {
 
   test('login falls back to LoginFailed on unexpected service errors',
       () async {
-    final service = _StudyGradesTestService(loginThrows: true);
+    final service = _StudyGradesTestService(
+      loginThrows: true,
+      blockFirstModulesRequest: false,
+    );
     final viewModel = StudyGradesViewModel(_buildPreferences(), service);
     addTearDown(viewModel.dispose);
 
@@ -48,6 +51,49 @@ void main() {
 
     expect(viewModel.isLoadingAllModules, isFalse);
   });
+
+  test('restores the Dualis session from saved credentials on page open',
+      () async {
+    final preferences = _buildPreferences();
+    await preferences.storeDualisCredentials(Credentials('saved-user', 'saved-pass'));
+    final service = _StudyGradesTestService(blockFirstModulesRequest: false);
+    final viewModel = StudyGradesViewModel(preferences, service);
+    addTearDown(viewModel.dispose);
+
+    final success = await viewModel.restoreSessionIfPossible();
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(success, isTrue);
+    expect(service.loginCalls, 1);
+    expect(service.lastLoginUsername, 'saved-user');
+    expect(service.lastLoginPassword, 'saved-pass');
+    expect(viewModel.loginState, LoginState.LoggedIn);
+    expect(service.clearCacheCalls, 1);
+  });
+
+  test('refreshData(force: true) clears cached Dualis data before reloading',
+      () async {
+    final preferences = _buildPreferences();
+    final service = _StudyGradesTestService(blockFirstModulesRequest: false);
+    final viewModel = StudyGradesViewModel(preferences, service);
+    addTearDown(viewModel.dispose);
+
+    final success = await viewModel.login(Credentials('u', 'p'));
+    expect(success, isTrue);
+
+    while (await preferences.getDualisLastRefreshAt() == null) {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+
+    service.resetCallCounters();
+
+    await viewModel.refreshData(force: true);
+
+    expect(service.clearCacheCalls, 1);
+    expect(service.queryStudyGradesCalls, 1);
+    expect(service.queryAllModulesCalls, 1);
+    expect(service.querySemesterNamesCalls, 1);
+  });
 }
 
 PreferencesProvider _buildPreferences() {
@@ -59,11 +105,23 @@ PreferencesProvider _buildPreferences() {
 
 class _StudyGradesTestService extends DualisService {
   final bool loginThrows;
+  final bool blockFirstModulesRequest;
   int _allModulesCallCount = 0;
+  int loginCalls = 0;
+  int clearCacheCalls = 0;
+  int queryStudyGradesCalls = 0;
+  int queryAllModulesCalls = 0;
+  int querySemesterNamesCalls = 0;
+  int querySemesterCalls = 0;
+  String? lastLoginUsername;
+  String? lastLoginPassword;
   final Completer<void> secondModulesRequestStarted = Completer<void>();
   final Completer<void> _releaseSecondModulesRequest = Completer<void>();
 
-  _StudyGradesTestService({this.loginThrows = false});
+  _StudyGradesTestService({
+    this.loginThrows = false,
+    this.blockFirstModulesRequest = true,
+  });
 
   @override
   Future<LoginResult> login(
@@ -71,6 +129,9 @@ class _StudyGradesTestService extends DualisService {
     String password, [
     CancellationToken? cancellationToken,
   ]) async {
+    loginCalls += 1;
+    lastLoginUsername = username;
+    lastLoginPassword = password;
     if (loginThrows) {
       throw Exception('login exploded');
     }
@@ -81,20 +142,24 @@ class _StudyGradesTestService extends DualisService {
   Future<List<Module>> queryAllModules([
     CancellationToken? cancellationToken,
   ]) async {
+    queryAllModulesCalls += 1;
     _allModulesCallCount += 1;
     final token = cancellationToken;
 
-    if (_allModulesCallCount == 1) {
-      while (token != null && !token.isCancelled()) {
-        await Future<void>.delayed(const Duration(milliseconds: 1));
+    if (blockFirstModulesRequest) {
+      if (_allModulesCallCount == 1) {
+        while (token != null && !token.isCancelled()) {
+          await Future<void>.delayed(const Duration(milliseconds: 1));
+        }
+        throw OperationCancelledException();
       }
-      throw OperationCancelledException();
+
+      if (!secondModulesRequestStarted.isCompleted) {
+        secondModulesRequestStarted.complete();
+      }
+      await _releaseSecondModulesRequest.future;
     }
 
-    if (!secondModulesRequestStarted.isCompleted) {
-      secondModulesRequestStarted.complete();
-    }
-    await _releaseSecondModulesRequest.future;
     return const <Module>[];
   }
 
@@ -109,6 +174,7 @@ class _StudyGradesTestService extends DualisService {
   Future<StudyGrades> queryStudyGrades([
     CancellationToken? cancellationToken,
   ]) async {
+    queryStudyGradesCalls += 1;
     return StudyGrades(0, 0, 0, 0);
   }
 
@@ -116,7 +182,8 @@ class _StudyGradesTestService extends DualisService {
   Future<List<String>> querySemesterNames([
     CancellationToken? cancellationToken,
   ]) async {
-    return const <String>[];
+    querySemesterNamesCalls += 1;
+    return const <String>['SoSe2026'];
   }
 
   @override
@@ -124,6 +191,7 @@ class _StudyGradesTestService extends DualisService {
     String name, [
     CancellationToken? cancellationToken,
   ]) async {
+    querySemesterCalls += 1;
     return Semester(name, const <Module>[]);
   }
 
@@ -131,6 +199,19 @@ class _StudyGradesTestService extends DualisService {
   Future<void> logout([
     CancellationToken? cancellationToken,
   ]) async {}
+
+  @override
+  void clearCache() {
+    clearCacheCalls += 1;
+  }
+
+  void resetCallCounters() {
+    clearCacheCalls = 0;
+    queryStudyGradesCalls = 0;
+    queryAllModulesCalls = 0;
+    querySemesterNamesCalls = 0;
+    querySemesterCalls = 0;
+  }
 }
 
 class _FakePreferencesAccess extends PreferencesAccess {


### PR DESCRIPTION
## Summary\n- restore the Dualis session from saved credentials when the Dualis section becomes visible again\n- refresh stale Dualis data automatically on long-idle reopen instead of dropping back to the login form\n- add pull-to-refresh on the Dualis overview and exams pages with cache-busting reloads\n\n## Testing\n- flutter test test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/study_overview_loading_animation_test.dart\n- flutter analyze lib/dualis lib/common/data/preferences/preferences_provider.dart test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/study_overview_loading_animation_test.dart\n\nCloses #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pull-to-refresh gesture on exam results and study overview pages for manual data refresh
  * Automatic session restoration on app launch with loading indicator during initialization
  * Improved page visibility detection to trigger timely data updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FarisZR/DualMate/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->