### PR TITLE
Add pull-to-refresh for weekly schedule

### DIFF
--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -323,6 +323,14 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     _debounceVisibleRefresh(weekStart, weekEnd);
   }
 
+  Future<void> refreshVisibleWeek() {
+    return updateSchedule(
+      currentDateStart,
+      currentDateEnd,
+      force: true,
+    );
+  }
+
   Future openWeekContainingFromWidget(DateTime date) async {
     final weekStart = toStartOfDay(toDayOfWeek(date, DateTime.monday));
     final weekEnd = toNextWeek(weekStart);

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -328,6 +328,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       currentDateStart,
       currentDateEnd,
       force: true,
+      awaitRefresh: true,
     );
   }
 
@@ -361,6 +362,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     DateTime end, {
     bool force = false,
     bool applyToVisibleState = true,
+    bool awaitRefresh = false,
   }) async {
     if (_isDisposed) return;
 
@@ -417,6 +419,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         end,
         visibleUpdateRequestId: visibleUpdateRequestId,
         applyToVisibleState: applyToVisibleState,
+        awaitRefresh: awaitRefresh,
         origin: applyToVisibleState
             ? ScheduleRefreshOrigin.userBrowsing
             : ScheduleRefreshOrigin.foregroundMaintenance,
@@ -434,6 +437,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     DateTime end, {
     int? visibleUpdateRequestId,
     bool applyToVisibleState = true,
+    bool awaitRefresh = false,
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
   }) async {
     final task = PerformanceTelemetry.instance.startTask(
@@ -470,8 +474,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
 
     final nowValue = now;
-    final shouldForceFetch = cachedSchedule.entries.isEmpty &&
-        scheduleSourceProvider.currentScheduleSource.canQuery();
+    final shouldForceFetch = awaitRefresh ||
+        (cachedSchedule.entries.isEmpty &&
+            scheduleSourceProvider.currentScheduleSource.canQuery());
     final isStale = shouldForceFetch || _isWindowStale(start, end, nowValue);
 
     if (!isStale) {
@@ -479,17 +484,21 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       return false;
     }
 
-    unawaited(
-      _refreshScheduleInBackground(
-        start,
-        end,
-        cancellationToken,
-        task,
-        visibleUpdateRequestId: visibleUpdateRequestId,
-        applyToVisibleState: applyToVisibleState,
-        origin: origin,
-      ),
+    final refreshFuture = _refreshScheduleInBackground(
+      start,
+      end,
+      cancellationToken,
+      task,
+      visibleUpdateRequestId: visibleUpdateRequestId,
+      applyToVisibleState: applyToVisibleState,
+      origin: origin,
     );
+
+    if (awaitRefresh) {
+      await refreshFuture;
+    } else {
+      unawaited(refreshFuture);
+    }
 
     return true;
   }

--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -181,58 +181,81 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
 
     return PropertyChangeProvider<WeeklyScheduleViewModel, String>(
       value: viewModel,
-      child: Stack(
-        fit: StackFit.passthrough,
-        children: <Widget>[
-          Column(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              _buildNavigationHeader(context),
-              Expanded(
+      child: RefreshIndicator(
+        onRefresh: () => viewModel.refreshVisibleWeek(),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              key: const ValueKey<String>('weekly_schedule_refresh_scroll_view'),
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: SizedBox(
+                height: constraints.maxHeight,
                 child: Stack(
+                  fit: StackFit.passthrough,
                   children: <Widget>[
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-                      child: PropertyChangeConsumer<WeeklyScheduleViewModel,
-                          String>(
-                        properties: const ['weekSchedule', 'now'],
-                        builder: (
-                          BuildContext context,
-                          WeeklyScheduleViewModel? model,
-                          Set<String>? properties,
-                        ) {
-                          if (model == null) return const SizedBox.shrink();
-                          return _buildAnimatedScheduleViewport(context, model);
-                        },
-                      ),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        _buildNavigationHeader(context),
+                        Expanded(
+                          child: Stack(
+                            children: <Widget>[
+                              Padding(
+                                padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+                                child: PropertyChangeConsumer<
+                                    WeeklyScheduleViewModel, String>(
+                                  properties: const ['weekSchedule', 'now'],
+                                  builder: (
+                                    BuildContext context,
+                                    WeeklyScheduleViewModel? model,
+                                    Set<String>? properties,
+                                  ) {
+                                    if (model == null) {
+                                      return const SizedBox.shrink();
+                                    }
+                                    return _buildAnimatedScheduleViewport(
+                                      context,
+                                      model,
+                                    );
+                                  },
+                                ),
+                              ),
+                              PropertyChangeConsumer<WeeklyScheduleViewModel,
+                                  String>(
+                                properties: const ['isUpdating', 'weekSchedule'],
+                                builder: (
+                                  BuildContext context,
+                                  WeeklyScheduleViewModel? model,
+                                  Set<String>? properties,
+                                ) {
+                                  if (model == null) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  return _TopLoadingIndicator(
+                                    isUpdating: model.isUpdating,
+                                    showWithoutDelay:
+                                        model.visibleWeekNeedsInitialFetch,
+                                  );
+                                },
+                              ),
+                              Positioned(
+                                right: 20,
+                                bottom: 16,
+                                child: _buildCurrentWeekButton(context),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
                     ),
-                    PropertyChangeConsumer<WeeklyScheduleViewModel, String>(
-                      properties: const ['isUpdating', 'weekSchedule'],
-                      builder: (
-                        BuildContext context,
-                        WeeklyScheduleViewModel? model,
-                        Set<String>? properties,
-                      ) {
-                        if (model == null) return const SizedBox.shrink();
-                        return _TopLoadingIndicator(
-                          isUpdating: model.isUpdating,
-                          showWithoutDelay: model.visibleWeekNeedsInitialFetch,
-                        );
-                      },
-                    ),
-                    Positioned(
-                      right: 20,
-                      bottom: 16,
-                      child: _buildCurrentWeekButton(context),
-                    ),
+                    buildErrorDisplay(context),
                   ],
                 ),
               ),
-            ],
-          ),
-          buildErrorDisplay(context)
-        ],
+            );
+          },
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -439,10 +439,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mutex:
     dependency: "direct main"
     description:
@@ -828,10 +828,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   timezone:
     dependency: "direct main"
     description:

--- a/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
@@ -183,6 +183,66 @@ void main() {
 
     expect(viewModel.isUpdating, isFalse);
   });
+
+  test(
+    'refreshVisibleWeek awaits network refresh before completing',
+    () async {
+      final provider = _BlockingScheduleProvider();
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+
+      final weekStart = DateTime(2026, 2, 9);
+      final weekEnd = DateTime(2026, 2, 16);
+
+      viewModel.currentDateStart = weekStart;
+      viewModel.currentDateEnd = weekEnd;
+
+      var refreshCompleted = false;
+      final refreshFuture = viewModel.refreshVisibleWeek().then((_) {
+        refreshCompleted = true;
+      });
+
+      // Let microtasks run but the blocking provider hasn't completed yet.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(refreshCompleted, isFalse,
+          reason: 'refreshVisibleWeek should not complete until network '
+              'request finishes');
+
+      // Now complete the network request.
+      provider.complete(
+        ScheduleQueryResult(Schedule(), const []),
+      );
+      await refreshFuture;
+      expect(refreshCompleted, isTrue);
+    },
+  );
+
+  test(
+    'refreshVisibleWeek forces fetch even when cache is fresh',
+    () async {
+      final entries = <ScheduleEntry>[
+        _entry(DateTime(2026, 2, 9), 'Mon'),
+      ];
+      final provider = _CountingScheduleProvider(entries);
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+
+      final weekStart = DateTime(2026, 2, 9);
+      final weekEnd = DateTime(2026, 2, 16);
+
+      // Initial load populates cache and marks window as fresh.
+      await viewModel.updateSchedule(weekStart, weekEnd, force: true);
+      expect(provider.updatedScheduleRequests, 1);
+
+      viewModel.currentDateStart = weekStart;
+      viewModel.currentDateEnd = weekEnd;
+
+      // Pull-to-refresh should fetch again even though cache is fresh.
+      await viewModel.refreshVisibleWeek();
+      expect(provider.updatedScheduleRequests, 2,
+          reason: 'pull-to-refresh must bypass staleness gate');
+    },
+  );
 }
 
 ScheduleEntry _entry(DateTime start, String suffix) {

--- a/test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart
+++ b/test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart
@@ -44,6 +44,42 @@ void main() {
   );
 
   testWidgets(
+    'pull to refresh reloads the visible week',
+    (tester) async {
+      final provider = _TrackingScheduleProvider(const <ScheduleEntry>[]);
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        sourceProvider,
+        nowProvider: () => DateTime(2026, 2, 10, 10, 0),
+      );
+
+      await viewModel.updateSchedule(
+        DateTime(2026, 2, 9),
+        DateTime(2026, 2, 16),
+        force: true,
+      );
+
+      await tester.pumpWidget(_wrapWithApp(viewModel));
+      await tester.pump();
+
+      await tester.drag(find.byType(SingleChildScrollView), const Offset(0, 300));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(
+        provider.updatedOrigins,
+        contains(ScheduleRefreshOrigin.userBrowsing),
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      viewModel.dispose();
+    },
+  );
+
+  testWidgets(
     'resume-triggered background refresh keeps monday lessons visible',
     (tester) async {
       const mondayTitle = 'MONDAY_ANCHOR';


### PR DESCRIPTION
- Wrap schedule content in RefreshIndicator with ScrollView
- Add refreshVisibleWeek to force reload current week
- Add widget test for pull-to-refresh interaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pull-to-refresh on the schedule page to force an immediate reload of the currently visible week (user-initiated refresh).
* **Tests**
  * Added tests verifying pull-to-refresh triggers a fresh fetch and that the UI waits for the background refresh to complete before marking it done.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FarisZR/DualMate/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->