### PR TITLE
[codex] Add Dualis demo review account

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ Important runtime behavior:
   instead of dropping the user back to the login form.
 - Logged-in Dualis pages support manual pull-to-refresh, which should force a
   cache-busting reload of overview and semester data.
+- Google Play review credentials are handled by
+  `FakeAccountDualisScraperDecorator`; keep mock data local and covered by
+  automated tests.
 
 ### Schedule (`lib/schedule`)
 

--- a/docs/solutions/integration-issues/dualis-google-play-demo-account-20260604.md
+++ b/docs/solutions/integration-issues/dualis-google-play-demo-account-20260604.md
@@ -1,0 +1,54 @@
+---
+module: Dualis Integration
+date: 2026-06-04
+problem_type: integration_issue
+component: frontend_flutter
+symptoms:
+  - "Google Play review needs access to the restricted Dualis integration"
+root_cause: review_build_had_no_documented_reusable_dualis_demo_credentials
+resolution_type: code_fix
+severity: medium
+tags: [dualis, google-play, review, demo-account, mock-data]
+---
+
+# Troubleshooting: Dualis Google Play demo account
+
+## Problem
+Google Play reviewers need reusable credentials to inspect the Dualis section,
+but a real DHBW Dualis account should not be shared for review.
+
+## Solution
+The Dualis scraper is wrapped by `FakeAccountDualisScraperDecorator`. In normal
+app builds, the following credentials select a local mock Dualis scraper instead
+of the real Dualis network scraper:
+
+- Username: `review@dualmate.app`
+- Password: `DualisDemo2026!`
+
+These credentials are intended for Play Console App Access instructions only.
+They load deterministic local data and do not require a real DHBW/Dualis
+account.
+
+## Play Console text
+```text
+The Dualis section requires credentials.
+
+Open the app, go to Dualis, and enter:
+Username: review@dualmate.app
+Password: DualisDemo2026!
+
+These credentials load local demo Dualis data for review. No external DHBW/Dualis account is required.
+```
+
+## Test Coverage
+- Demo credentials log in and route Dualis reads to fake data.
+- Demo credential matching tolerates leading and trailing whitespace.
+- Non-demo credentials stay on the original Dualis scraper.
+- Stored demo credentials work with previous-credentials login.
+- Logout clears the fake login state.
+
+## Commands run
+```bash
+flutter test test/dualis/service/fake_account_dualis_scraper_decorator_test.dart test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/dualis_page_session_restore_test.dart test/dualis/ui/study_overview_loading_animation_test.dart
+flutter analyze lib/dualis lib/common/appstart/service_injector.dart test/dualis
+```

--- a/lib/dualis/service/fake_account_dualis_scraper_decorator.dart
+++ b/lib/dualis/service/fake_account_dualis_scraper_decorator.dart
@@ -10,21 +10,19 @@ import 'package:dualmate/schedule/model/schedule.dart';
 /// This DualisScraper decorator allows to enter specific fake account
 /// information in order to get beyond the Dualis login without having a
 /// dualis account.
-/// Background: The AppStore review process needs login credentials to every
-/// area of the app.
+/// Background: The Google Play review process needs login credentials to every
+/// restricted area of the app.
 ///
 class FakeAccountDualisScraperDecorator implements DualisScraper {
-  final fakeUsername = "fakeAccount@domain.de";
-  final fakePassword = "Passw0rd";
+  static const String demoUsername = "review@dualmate.app";
+  static const String demoPassword = "DualisDemo2026!";
 
   final DualisScraper _fakeDualisScraper = FakeDataDualisScraper();
   final DualisScraper _originalDualisScraper;
 
   late DualisScraper _currentDualisScraper;
 
-  FakeAccountDualisScraperDecorator(
-    this._originalDualisScraper,
-  ) {
+  FakeAccountDualisScraperDecorator(this._originalDualisScraper) {
     _currentDualisScraper = _originalDualisScraper;
   }
 
@@ -34,10 +32,12 @@ class FakeAccountDualisScraperDecorator implements DualisScraper {
   }
 
   @override
-  Future<List<DualisModule>> loadAllModules(
-      [CancellationToken? cancellationToken]) {
-    return _currentDualisScraper
-        .loadAllModules(cancellationToken ?? CancellationToken());
+  Future<List<DualisModule>> loadAllModules([
+    CancellationToken? cancellationToken,
+  ]) {
+    return _currentDualisScraper.loadAllModules(
+      cancellationToken ?? CancellationToken(),
+    );
   }
 
   @override
@@ -74,16 +74,19 @@ class FakeAccountDualisScraperDecorator implements DualisScraper {
   }
 
   @override
-  Future<List<DualisSemester>> loadSemesters(
-      [CancellationToken? cancellationToken]) {
-    return _currentDualisScraper
-        .loadSemesters(cancellationToken ?? CancellationToken());
+  Future<List<DualisSemester>> loadSemesters([
+    CancellationToken? cancellationToken,
+  ]) {
+    return _currentDualisScraper.loadSemesters(
+      cancellationToken ?? CancellationToken(),
+    );
   }
 
   @override
   Future<StudyGrades> loadStudyGrades(CancellationToken? cancellationToken) {
-    return _currentDualisScraper
-        .loadStudyGrades(cancellationToken ?? CancellationToken());
+    return _currentDualisScraper.loadStudyGrades(
+      cancellationToken ?? CancellationToken(),
+    );
   }
 
   @override
@@ -92,7 +95,7 @@ class FakeAccountDualisScraperDecorator implements DualisScraper {
     String password,
     CancellationToken? cancellationToken,
   ) {
-    if (username == fakeUsername && password == fakePassword) {
+    if (_isDemoAccount(username, password)) {
       _currentDualisScraper = _fakeDualisScraper;
     } else {
       _currentDualisScraper = _originalDualisScraper;
@@ -106,7 +109,8 @@ class FakeAccountDualisScraperDecorator implements DualisScraper {
 
   @override
   Future<LoginResult> loginWithPreviousCredentials(
-      CancellationToken? cancellationToken) {
+    CancellationToken? cancellationToken,
+  ) {
     return _currentDualisScraper.loginWithPreviousCredentials(
       cancellationToken ?? CancellationToken(),
     );
@@ -121,15 +125,16 @@ class FakeAccountDualisScraperDecorator implements DualisScraper {
 
   @override
   void setLoginCredentials(String username, String password) {
-    if (username == fakeUsername && password == fakePassword) {
+    if (_isDemoAccount(username, password)) {
       _currentDualisScraper = _fakeDualisScraper;
     } else {
       _currentDualisScraper = _originalDualisScraper;
     }
 
-    return _currentDualisScraper.setLoginCredentials(
-      username,
-      password,
-    );
+    return _currentDualisScraper.setLoginCredentials(username, password);
+  }
+
+  bool _isDemoAccount(String username, String password) {
+    return username.trim() == demoUsername && password.trim() == demoPassword;
   }
 }

--- a/lib/dualis/service/fake_account_dualis_scraper_decorator.dart
+++ b/lib/dualis/service/fake_account_dualis_scraper_decorator.dart
@@ -117,10 +117,14 @@ class FakeAccountDualisScraperDecorator implements DualisScraper {
   }
 
   @override
-  Future<void> logout(CancellationToken? cancellationToken) {
-    return _currentDualisScraper.logout(
-      cancellationToken ?? CancellationToken(),
-    );
+  Future<void> logout(CancellationToken? cancellationToken) async {
+    try {
+      await _currentDualisScraper.logout(
+        cancellationToken ?? CancellationToken(),
+      );
+    } finally {
+      _currentDualisScraper = _originalDualisScraper;
+    }
   }
 
   @override

--- a/lib/dualis/service/fake_data_dualis_scraper.dart
+++ b/lib/dualis/service/fake_data_dualis_scraper.dart
@@ -19,18 +19,35 @@ class FakeDataDualisScraper implements DualisScraper {
   }
 
   @override
-  Future<List<DualisModule>> loadAllModules(
-      [CancellationToken? cancellationToken]) async {
+  Future<List<DualisModule>> loadAllModules([
+    CancellationToken? cancellationToken,
+  ]) async {
     await Future.delayed(Duration(milliseconds: 200));
 
     return Future.value([
       DualisModule(
-        "Module1",
-        "Informatik",
-        "1.0",
-        "10",
+        "T3INF1001",
+        "Software Engineering",
+        "1.7",
+        "5",
         ExamState.Passed,
+        "demo://software-engineering",
+      ),
+      DualisModule(
+        "T3INF1002",
+        "Datenbanken",
+        "2.0",
+        "5",
+        ExamState.Passed,
+        "demo://databases",
+      ),
+      DualisModule(
+        "T3INF1003",
+        "Mathematik",
         "",
+        "5",
+        ExamState.Pending,
+        "demo://mathematics",
       ),
     ]);
   }
@@ -44,10 +61,17 @@ class FakeDataDualisScraper implements DualisScraper {
     return Future.value([
       DualisExam(
         "Klausur",
-        "Module1",
-        ExamGrade.graded("1.0"),
+        "Software Engineering",
+        ExamGrade.graded("1.7"),
         "1",
-        "SoSe2020",
+        "SoSe 2026",
+      ),
+      DualisExam(
+        "Projektarbeit",
+        "Software Engineering",
+        ExamGrade.passed(),
+        "1",
+        "SoSe 2026",
       ),
     ]);
   }
@@ -69,35 +93,40 @@ class FakeDataDualisScraper implements DualisScraper {
     await Future.delayed(Duration(milliseconds: 200));
     return Future.value([
       DualisModule(
-        "Module1",
-        "Informatik",
-        "1.0",
-        "10",
+        "T3INF1001",
+        "Software Engineering",
+        "1.7",
+        "5",
         ExamState.Passed,
-        "",
+        "demo://software-engineering",
+      ),
+      DualisModule(
+        "T3INF1002",
+        "Datenbanken",
+        "2.0",
+        "5",
+        ExamState.Passed,
+        "demo://databases",
       ),
     ]);
   }
 
   @override
-  Future<List<DualisSemester>> loadSemesters(
-      [CancellationToken? cancellationToken]) async {
+  Future<List<DualisSemester>> loadSemesters([
+    CancellationToken? cancellationToken,
+  ]) async {
     await Future.delayed(Duration(milliseconds: 200));
-    return Future.value([DualisSemester("SoSe2020", "", [])]);
+    return Future.value([
+      DualisSemester("SoSe 2026", "demo://semester/sose-2026", []),
+    ]);
   }
 
   @override
   Future<StudyGrades> loadStudyGrades(
-      CancellationToken? cancellationToken) async {
+    CancellationToken? cancellationToken,
+  ) async {
     await Future.delayed(Duration(milliseconds: 200));
-    return Future.value(
-      StudyGrades(
-        1.5,
-        1.5,
-        210,
-        10,
-      ),
-    );
+    return Future.value(StudyGrades(1.7, 1.8, 210, 96));
   }
 
   @override
@@ -113,7 +142,8 @@ class FakeDataDualisScraper implements DualisScraper {
 
   @override
   Future<LoginResult> loginWithPreviousCredentials(
-      CancellationToken? cancellationToken) async {
+    CancellationToken? cancellationToken,
+  ) async {
     await Future.delayed(Duration(milliseconds: 200));
     _isLoggedIn = true;
     return Future.value(LoginResult.LoggedIn);
@@ -126,7 +156,5 @@ class FakeDataDualisScraper implements DualisScraper {
   }
 
   @override
-  void setLoginCredentials(String username, String password) {
-    // TODO: implement setLoginCredentials
-  }
+  void setLoginCredentials(String username, String password) {}
 }

--- a/test/dualis/service/fake_account_dualis_scraper_decorator_test.dart
+++ b/test/dualis/service/fake_account_dualis_scraper_decorator_test.dart
@@ -129,6 +129,28 @@ void main() {
 
     expect(scraper.isLoggedIn(), isFalse);
   });
+
+  test('logout prevents demo restore through previous credentials', () async {
+    final originalScraper = _RecordingDualisScraper();
+    final scraper = FakeAccountDualisScraperDecorator(originalScraper);
+
+    scraper.setLoginCredentials(
+      FakeAccountDualisScraperDecorator.demoUsername,
+      FakeAccountDualisScraperDecorator.demoPassword,
+    );
+    expect(
+      await scraper.loginWithPreviousCredentials(CancellationToken()),
+      LoginResult.LoggedIn,
+    );
+
+    await scraper.logout(CancellationToken());
+
+    expect(
+      await scraper.loginWithPreviousCredentials(CancellationToken()),
+      LoginResult.LoginFailed,
+    );
+    expect(originalScraper.loginWithPreviousCredentialsCalls, 1);
+  });
 }
 
 class _RecordingDualisScraper implements DualisScraper {

--- a/test/dualis/service/fake_account_dualis_scraper_decorator_test.dart
+++ b/test/dualis/service/fake_account_dualis_scraper_decorator_test.dart
@@ -1,0 +1,222 @@
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/dualis/model/study_grades.dart';
+import 'package:dualmate/dualis/service/dualis_scraper.dart';
+import 'package:dualmate/dualis/service/dualis_service.dart';
+import 'package:dualmate/dualis/service/dualis_website_model.dart';
+import 'package:dualmate/dualis/service/fake_account_dualis_scraper_decorator.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('demo credentials log in and route Dualis reads to fake data', () async {
+    final originalScraper = _RecordingDualisScraper();
+    final scraper = FakeAccountDualisScraperDecorator(originalScraper);
+
+    final loginResult = await scraper.login(
+      FakeAccountDualisScraperDecorator.demoUsername,
+      FakeAccountDualisScraperDecorator.demoPassword,
+      CancellationToken(),
+    );
+
+    expect(loginResult, LoginResult.LoggedIn);
+    expect(originalScraper.loginCalls, 0);
+
+    final studyGrades = await scraper.loadStudyGrades(CancellationToken());
+    final semesters = await scraper.loadSemesters(CancellationToken());
+    final modules = await scraper.loadAllModules(CancellationToken());
+    final semesterModules = await scraper.loadSemesterModules(
+      'SoSe 2026',
+      CancellationToken(),
+    );
+    final exams = await scraper.loadModuleExams(
+      'demo://software-engineering',
+      CancellationToken(),
+    );
+
+    expect(studyGrades.gpaTotal, 1.7);
+    expect(studyGrades.gpaMainModules, 1.8);
+    expect(studyGrades.creditsGained, 96);
+    expect(semesters.single.semesterName, 'SoSe 2026');
+    expect(
+      modules.map((module) => module.name),
+      contains('Software Engineering'),
+    );
+    expect(
+      semesterModules.map((module) => module.name),
+      contains('Datenbanken'),
+    );
+    expect(exams.map((exam) => exam.name), contains('Klausur'));
+    expect(originalScraper.loadStudyGradesCalls, 0);
+    expect(originalScraper.loadSemestersCalls, 0);
+    expect(originalScraper.loadAllModulesCalls, 0);
+    expect(originalScraper.loadSemesterModulesCalls, 0);
+    expect(originalScraper.loadModuleExamsCalls, 0);
+  });
+
+  test(
+    'demo credential matching tolerates leading and trailing whitespace',
+    () async {
+      final originalScraper = _RecordingDualisScraper();
+      final scraper = FakeAccountDualisScraperDecorator(originalScraper);
+
+      final result = await scraper.login(
+        ' ${FakeAccountDualisScraperDecorator.demoUsername} ',
+        ' ${FakeAccountDualisScraperDecorator.demoPassword} ',
+        CancellationToken(),
+      );
+
+      expect(result, LoginResult.LoggedIn);
+      expect(originalScraper.loginCalls, 0);
+    },
+  );
+
+  test('non-demo credentials stay on the original Dualis scraper', () async {
+    final originalScraper = _RecordingDualisScraper();
+    final scraper = FakeAccountDualisScraperDecorator(originalScraper);
+
+    final result = await scraper.login(
+      'student@example.com',
+      'real-password',
+      CancellationToken(),
+    );
+
+    expect(result, LoginResult.LoginFailed);
+    expect(originalScraper.loginCalls, 1);
+
+    await scraper.loadStudyGrades(CancellationToken());
+    expect(originalScraper.loadStudyGradesCalls, 1);
+  });
+
+  test(
+    'setLoginCredentials selects demo data for previous-credentials login',
+    () async {
+      final originalScraper = _RecordingDualisScraper();
+      final scraper = FakeAccountDualisScraperDecorator(originalScraper);
+
+      scraper.setLoginCredentials(
+        FakeAccountDualisScraperDecorator.demoUsername,
+        FakeAccountDualisScraperDecorator.demoPassword,
+      );
+
+      final result = await scraper.loginWithPreviousCredentials(
+        CancellationToken(),
+      );
+      final modules = await scraper.loadAllModules(CancellationToken());
+
+      expect(result, LoginResult.LoggedIn);
+      expect(
+        modules.map((module) => module.name),
+        contains('Software Engineering'),
+      );
+      expect(originalScraper.setLoginCredentialsCalls, 0);
+      expect(originalScraper.loginWithPreviousCredentialsCalls, 0);
+    },
+  );
+
+  test('logout clears fake login state', () async {
+    final scraper = FakeAccountDualisScraperDecorator(
+      _RecordingDualisScraper(),
+    );
+
+    await scraper.login(
+      FakeAccountDualisScraperDecorator.demoUsername,
+      FakeAccountDualisScraperDecorator.demoPassword,
+      CancellationToken(),
+    );
+    expect(scraper.isLoggedIn(), isTrue);
+
+    await scraper.logout(CancellationToken());
+
+    expect(scraper.isLoggedIn(), isFalse);
+  });
+}
+
+class _RecordingDualisScraper implements DualisScraper {
+  int loginCalls = 0;
+  int loginWithPreviousCredentialsCalls = 0;
+  int setLoginCredentialsCalls = 0;
+  int loadStudyGradesCalls = 0;
+  int loadSemestersCalls = 0;
+  int loadAllModulesCalls = 0;
+  int loadSemesterModulesCalls = 0;
+  int loadModuleExamsCalls = 0;
+
+  @override
+  bool isLoggedIn() => false;
+
+  @override
+  Future<List<DualisModule>> loadAllModules([
+    CancellationToken? cancellationToken,
+  ]) async {
+    loadAllModulesCalls += 1;
+    return const <DualisModule>[];
+  }
+
+  @override
+  Future<List<DualisExam>> loadModuleExams(
+    String moduleDetailsUrl, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    loadModuleExamsCalls += 1;
+    return const <DualisExam>[];
+  }
+
+  @override
+  Future<Schedule> loadMonthlySchedule(
+    DateTime dateInMonth,
+    CancellationToken? cancellationToken,
+  ) async {
+    return Schedule.fromList([]);
+  }
+
+  @override
+  Future<List<DualisModule>> loadSemesterModules(
+    String semesterName, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    loadSemesterModulesCalls += 1;
+    return const <DualisModule>[];
+  }
+
+  @override
+  Future<List<DualisSemester>> loadSemesters([
+    CancellationToken? cancellationToken,
+  ]) async {
+    loadSemestersCalls += 1;
+    return const <DualisSemester>[];
+  }
+
+  @override
+  Future<StudyGrades> loadStudyGrades(
+    CancellationToken? cancellationToken,
+  ) async {
+    loadStudyGradesCalls += 1;
+    return StudyGrades(0, 0, 0, 0);
+  }
+
+  @override
+  Future<LoginResult> login(
+    String username,
+    String password,
+    CancellationToken? cancellationToken,
+  ) async {
+    loginCalls += 1;
+    return LoginResult.LoginFailed;
+  }
+
+  @override
+  Future<LoginResult> loginWithPreviousCredentials(
+    CancellationToken? cancellationToken,
+  ) async {
+    loginWithPreviousCredentialsCalls += 1;
+    return LoginResult.LoginFailed;
+  }
+
+  @override
+  Future<void> logout(CancellationToken? cancellationToken) async {}
+
+  @override
+  void setLoginCredentials(String username, String password) {
+    setLoginCredentialsCalls += 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add stable hidden Dualis demo credentials for Google Play App Access review
- route those credentials to deterministic local mock Dualis data while keeping all other logins on the real scraper
- document the reviewer credentials and add focused service tests

## Demo credentials
Username: `review@dualmate.app`
Password: `DualisDemo2026!`

Suggested Play Console text is included in `docs/solutions/integration-issues/dualis-google-play-demo-account-20260604.md`.

## Validation
- `flutter test test/dualis/service/fake_account_dualis_scraper_decorator_test.dart test/dualis/ui/viewmodels/study_grades_view_model_test.dart test/dualis/ui/dualis_page_session_restore_test.dart test/dualis/ui/study_overview_loading_animation_test.dart`
- `flutter analyze lib/dualis lib/common/appstart/service_injector.dart test/dualis`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo account credential matching now tolerates leading/trailing whitespace for more flexible login attempts.

* **Refactor**
  * Centralized demo-account detection logic to ensure consistent behavior across login operations.
  * Updated mock demo data values for modules, exams, semesters, and study grades.

* **Tests**
  * Added comprehensive test suite validating demo account routing and credential-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->