### PR TITLE
Harden Sentry diagnostics for privacy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,20 @@ Important runtime behavior:
 - Android method channel helper: `lib/native/widget/android_widget_helper.dart`
 - Widget payloads are routed into app via `RootPage` method channel and `WidgetNavigationPayloadStore`.
 
+### Diagnostics and Sentry (`lib/common/logging`)
+
+- Sentry initializes only when `SENTRY_DSN` is set.
+- Keep crash reporting and performance tracing enabled, but keep production
+  sampling low.
+- Privacy-sensitive Sentry features stay disabled: screenshots, session replay,
+  default PII, release log capture, and user interaction breadcrumbs/tracing.
+- Route transactions must use stable generic names only; do not send route
+  arguments, URLs, user IDs, schedule payloads, canteen payloads, Dualis data,
+  grades, credentials, cookies, or tokens.
+- Use `sentry_scrubber.dart` and `AppDiagnostics` for diagnostics data so
+  `beforeSend`, `beforeBreadcrumb`, and transaction scrubbing remain the
+  central privacy boundary.
+
 ## Background Jobs and Scheduling
 
 - Background scheduler setup: `lib/common/appstart/background_initialize.dart`

--- a/docs/solutions/integration-issues/sentry-gdpr-safe-observability-20260613.md
+++ b/docs/solutions/integration-issues/sentry-gdpr-safe-observability-20260613.md
@@ -10,8 +10,8 @@ define. Builds without a DSN do not start Sentry.
 
 Sentry remains enabled for crash reporting and low-sample performance tracing.
 Production tracing uses `tracesSampleRate = 0.1` so startup and route
-performance remain observable. Auto session tracking is disabled; release-health
-session metrics are not collected.
+performance remain observable. Auto session tracking is enabled for Sentry
+Release Health crash-free session diagnostics.
 
 Collected data:
 
@@ -24,12 +24,12 @@ Collected data:
 - Sanitized breadcrumbs for navigation, app diagnostics, and performance
   checkpoints.
 - Span error metadata limited to `errorType` and a scrubbed `errorMessage`.
+- Release Health session diagnostics for crash-free session reporting.
 
 Not collected:
 
 - Screenshots.
 - Session replay.
-- Auto session tracking / release-health sessions.
 - Default PII.
 - Raw Sentry user identifiers.
 - Raw errors attached to performance spans.

--- a/docs/solutions/integration-issues/sentry-gdpr-safe-observability-20260613.md
+++ b/docs/solutions/integration-issues/sentry-gdpr-safe-observability-20260613.md
@@ -1,0 +1,51 @@
+---
+component: sentry_reporting
+tags: [sentry, diagnostics, gdpr, google-play, privacy, performance]
+---
+
+# Sentry GDPR-safe observability
+
+DualMate initializes Sentry only when `SENTRY_DSN` is provided through a Dart
+define. Builds without a DSN do not start Sentry.
+
+Sentry remains enabled for crash reporting and low-sample performance tracing.
+Production tracing uses `tracesSampleRate = 0.1` so startup and route
+performance remain observable without capturing every session.
+
+Collected data:
+
+- Crash and non-fatal error events.
+- Stack traces.
+- App release, build, environment, and platform metadata.
+- Device operating system and app runtime environment.
+- Performance transactions and spans with generic names such as `startup`,
+  `schedule`, `dualis`, `canteen`, and `schedule.refresh`.
+- Sanitized breadcrumbs for navigation, app diagnostics, and performance
+  checkpoints.
+
+Not collected:
+
+- Screenshots.
+- Session replay.
+- Default PII.
+- Raw Sentry user identifiers.
+- Credentials, tokens, cookies, authorization headers, Rapla URLs, iCal URLs,
+  Dualis usernames/passwords, grades, marks, course data, room data, schedule
+  event titles/details, canteen payloads, schedule payloads, or raw route
+  arguments.
+- Custom logs in release builds.
+
+Privacy controls:
+
+- `beforeSend`, `beforeBreadcrumb`, and `beforeSendTransaction` are registered
+  in `sentry_configuration.dart` for the installed Sentry Flutter SDK API.
+- `sentry_scrubber.dart` removes user context, strips URL query strings, drops
+  request bodies/cookies, and replaces sensitive keys or values with
+  `[redacted]`.
+- `AppDiagnostics` sanitizes breadcrumbs, contexts, tags, spans, and attached
+  exceptions before they reach Sentry, so manually attached model objects are
+  not serialized into diagnostics payloads.
+- `SentryNavigatorObserver` uses a route-name extractor that emits only stable
+  generic route names and drops route arguments.
+- User interaction breadcrumbs/tracing are disabled because widget labels and
+  tapped content can expose schedule or grade details.

--- a/docs/solutions/integration-issues/sentry-gdpr-safe-observability-20260613.md
+++ b/docs/solutions/integration-issues/sentry-gdpr-safe-observability-20260613.md
@@ -10,7 +10,8 @@ define. Builds without a DSN do not start Sentry.
 
 Sentry remains enabled for crash reporting and low-sample performance tracing.
 Production tracing uses `tracesSampleRate = 0.1` so startup and route
-performance remain observable without capturing every session.
+performance remain observable. Auto session tracking is disabled; release-health
+session metrics are not collected.
 
 Collected data:
 
@@ -22,13 +23,16 @@ Collected data:
   `schedule`, `dualis`, `canteen`, and `schedule.refresh`.
 - Sanitized breadcrumbs for navigation, app diagnostics, and performance
   checkpoints.
+- Span error metadata limited to `errorType` and a scrubbed `errorMessage`.
 
 Not collected:
 
 - Screenshots.
 - Session replay.
+- Auto session tracking / release-health sessions.
 - Default PII.
 - Raw Sentry user identifiers.
+- Raw errors attached to performance spans.
 - Credentials, tokens, cookies, authorization headers, Rapla URLs, iCal URLs,
   Dualis usernames/passwords, grades, marks, course data, room data, schedule
   event titles/details, canteen payloads, schedule payloads, or raw route
@@ -39,13 +43,15 @@ Privacy controls:
 
 - `beforeSend`, `beforeBreadcrumb`, and `beforeSendTransaction` are registered
   in `sentry_configuration.dart` for the installed Sentry Flutter SDK API.
-- `sentry_scrubber.dart` removes user context, strips URL query strings, drops
-  request bodies/cookies, and replaces sensitive keys or values with
-  `[redacted]`.
-- `AppDiagnostics` sanitizes breadcrumbs, contexts, tags, spans, and attached
-  exceptions before they reach Sentry, so manually attached model objects are
-  not serialized into diagnostics payloads.
+- `sentry_scrubber.dart` removes user context, redacts URLs, drops request
+  bodies/cookies, and replaces sensitive keys, sensitive values, embedded
+  emails, embedded URLs, and token-like strings with `[redacted]`.
+- `AppDiagnostics` sanitizes breadcrumbs, contexts, tags, and spans before they
+  reach Sentry, so manually attached model objects are not serialized into
+  diagnostics payloads. Raw errors are not attached to spans.
 - `SentryNavigatorObserver` uses a route-name extractor that emits only stable
   generic route names and drops route arguments.
 - User interaction breadcrumbs/tracing are disabled because widget labels and
   tapped content can expose schedule or grade details.
+- Release builds do not print raw startup or schedule exceptions/stack traces;
+  those debug logs are gated behind `kDebugMode`.

--- a/lib/common/logging/app_diagnostics.dart
+++ b/lib/common/logging/app_diagnostics.dart
@@ -131,7 +131,7 @@ class AppDiagnostics {
   }) {
     return _bestEffort(
       () => _recorder.captureException(
-        sanitizeDiagnosticsThrowable(exception),
+        exception,
         stackTrace,
         message: message == null
             ? null
@@ -222,7 +222,7 @@ class AppDiagnosticsSpan {
     final span = _span;
     if (span == null) return;
     try {
-      span.throwable = sanitizeDiagnosticsThrowable(error);
+      span.throwable = error;
     } catch (attachError, stackTrace) {
       _logDiagnosticsFailure('span.attachError', attachError, stackTrace);
     }

--- a/lib/common/logging/app_diagnostics.dart
+++ b/lib/common/logging/app_diagnostics.dart
@@ -227,6 +227,7 @@ class AppDiagnosticsSpan {
         'errorMessage',
         sanitizeDiagnosticsValue(error.toString()).toString(),
       );
+      span.status = const SpanStatus.internalError();
     } catch (attachErrorError, stackTrace) {
       _logDiagnosticsFailure('span.attachError', attachErrorError, stackTrace);
     }

--- a/lib/common/logging/app_diagnostics.dart
+++ b/lib/common/logging/app_diagnostics.dart
@@ -3,6 +3,8 @@ import 'dart:developer' as developer;
 
 import 'package:sentry/sentry.dart';
 
+import 'sentry_scrubber.dart';
+
 void _logDiagnosticsFailure(
   String operation,
   Object error, [
@@ -81,7 +83,7 @@ class AppDiagnostics {
   final DiagnosticsRecorder _recorder;
 
   AppDiagnostics({DiagnosticsRecorder? recorder})
-      : _recorder = recorder ?? const SentryDiagnosticsRecorder();
+    : _recorder = recorder ?? const SentryDiagnosticsRecorder();
 
   static final AppDiagnostics instance = AppDiagnostics();
 
@@ -94,8 +96,8 @@ class AppDiagnostics {
         Breadcrumb(
           category: 'navigation',
           type: 'navigation',
-          message: name,
-          data: data,
+          message: sanitizeDiagnosticsName(name),
+          data: sanitizeDiagnosticsMap(data),
           level: SentryLevel.info,
         ),
       ),
@@ -110,10 +112,10 @@ class AppDiagnostics {
     return _bestEffort(
       () => _recorder.addBreadcrumb(
         Breadcrumb(
-          category: category,
+          category: sanitizeDiagnosticsName(category),
           type: 'default',
-          message: message,
-          data: data,
+          message: sanitizeDiagnosticsName(message),
+          data: sanitizeDiagnosticsMap(data),
           level: SentryLevel.info,
         ),
       ),
@@ -129,11 +131,13 @@ class AppDiagnostics {
   }) {
     return _bestEffort(
       () => _recorder.captureException(
-        exception,
+        sanitizeDiagnosticsThrowable(exception),
         stackTrace,
-        message: message == null ? null : SentryMessage(message),
-        tags: tags,
-        contexts: contexts,
+        message: message == null
+            ? null
+            : SentryMessage(sanitizeDiagnosticsName(message)),
+        tags: sanitizeDiagnosticsTags(tags),
+        contexts: sanitizeDiagnosticsMap(contexts),
       ),
     );
   }
@@ -154,11 +158,19 @@ class AppDiagnostics {
   }) {
     try {
       final parent = _recorder.getCurrentSpan();
-      final span = parent?.startChild(
-            operation,
-            description: description,
+      final sanitizedOperation = sanitizeDiagnosticsName(operation);
+      final sanitizedDescription = description == null
+          ? null
+          : sanitizeDiagnosticsName(description);
+      final span =
+          parent?.startChild(
+            sanitizedOperation,
+            description: sanitizedDescription,
           ) ??
-          _recorder.startTransaction(operation, description: description);
+          _recorder.startTransaction(
+            sanitizedOperation,
+            description: sanitizedDescription,
+          );
 
       final diagnosticsSpan = AppDiagnosticsSpan._(span);
       for (final entry in data.entries) {
@@ -187,7 +199,10 @@ class AppDiagnosticsSpan {
     final span = _span;
     if (span == null) return;
     try {
-      span.setData(key, value);
+      final sanitized = sanitizeDiagnosticsValue(value, key: key);
+      if (sanitized != null && sanitized != sentryRedactedValue) {
+        span.setData(key, sanitized);
+      }
     } catch (error, stackTrace) {
       _logDiagnosticsFailure('span.setData', error, stackTrace);
     }
@@ -197,7 +212,7 @@ class AppDiagnosticsSpan {
     final span = _span;
     if (span == null) return;
     try {
-      span.setTag(key, value);
+      span.setTag(key, sanitizeDiagnosticsValue(value, key: key).toString());
     } catch (error, stackTrace) {
       _logDiagnosticsFailure('span.setTag', error, stackTrace);
     }
@@ -207,7 +222,7 @@ class AppDiagnosticsSpan {
     final span = _span;
     if (span == null) return;
     try {
-      span.throwable = error;
+      span.throwable = sanitizeDiagnosticsThrowable(error);
     } catch (attachError, stackTrace) {
       _logDiagnosticsFailure('span.attachError', attachError, stackTrace);
     }

--- a/lib/common/logging/app_diagnostics.dart
+++ b/lib/common/logging/app_diagnostics.dart
@@ -222,9 +222,13 @@ class AppDiagnosticsSpan {
     final span = _span;
     if (span == null) return;
     try {
-      span.throwable = error;
-    } catch (attachError, stackTrace) {
-      _logDiagnosticsFailure('span.attachError', attachError, stackTrace);
+      span.setData('errorType', error.runtimeType.toString());
+      span.setData(
+        'errorMessage',
+        sanitizeDiagnosticsValue(error.toString()).toString(),
+      );
+    } catch (attachErrorError, stackTrace) {
+      _logDiagnosticsFailure('span.attachError', attachErrorError, stackTrace);
     }
   }
 

--- a/lib/common/logging/crash_reporting.dart
+++ b/lib/common/logging/crash_reporting.dart
@@ -1,4 +1,5 @@
 import 'package:dualmate/common/logging/app_diagnostics.dart';
+import 'package:flutter/foundation.dart';
 
 typedef ExceptionReporter = Future<void> Function(Object ex, StackTrace trace);
 
@@ -9,12 +10,16 @@ Future<void> reportExceptionToSentry(Object ex, StackTrace trace) async {
 ExceptionReporter reportExceptionImpl = reportExceptionToSentry;
 
 Future<void> reportException(Object ex, StackTrace trace) async {
-  print("Exception: $ex with stack trace $trace");
+  if (kDebugMode) {
+    debugPrint("Exception: $ex with stack trace $trace");
+  }
 
   try {
     await reportExceptionImpl(ex, trace);
   } catch (error, stackTrace) {
-    print("Failed to report exception to Sentry: $error");
-    print(stackTrace);
+    if (kDebugMode) {
+      debugPrint("Failed to report exception to Sentry: $error");
+      debugPrint("$stackTrace");
+    }
   }
 }

--- a/lib/common/logging/sentry_configuration.dart
+++ b/lib/common/logging/sentry_configuration.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import 'sentry_scrubber.dart';
+
 const String _sentryDsn = String.fromEnvironment('SENTRY_DSN');
 const String _sentryRelease = String.fromEnvironment('SENTRY_RELEASE');
 const String _sentryEnvironment = String.fromEnvironment('SENTRY_ENVIRONMENT');
@@ -24,15 +26,18 @@ Future<void> configureSentryOptions(SentryFlutterOptions options) async {
     options.release = trimmedRelease;
   }
   options.sendDefaultPii = false;
-  options.enableLogs = !kReleaseMode;
+  options.enableLogs = false;
   options.enableAutoPerformanceTracing = true;
   options.enableFramesTracking = true;
   options.enableAutoSessionTracking = true;
   options.enableNativeCrashHandling = true;
-  options.enableUserInteractionBreadcrumbs = true;
-  options.enableUserInteractionTracing = true;
+  options.enableUserInteractionBreadcrumbs = false;
+  options.enableUserInteractionTracing = false;
   options.attachScreenshot = false;
   options.tracesSampleRate = kReleaseMode ? 0.1 : 1.0;
-  options.replay.sessionSampleRate = kReleaseMode ? 0.0 : 0.1;
-  options.replay.onErrorSampleRate = kReleaseMode ? 0.2 : 1.0;
+  options.replay.sessionSampleRate = 0.0;
+  options.replay.onErrorSampleRate = 0.0;
+  options.beforeSend = scrubSentryEvent;
+  options.beforeSendTransaction = scrubSentryTransaction;
+  options.beforeBreadcrumb = scrubSentryBreadcrumb;
 }

--- a/lib/common/logging/sentry_configuration.dart
+++ b/lib/common/logging/sentry_configuration.dart
@@ -29,7 +29,7 @@ Future<void> configureSentryOptions(SentryFlutterOptions options) async {
   options.enableLogs = false;
   options.enableAutoPerformanceTracing = true;
   options.enableFramesTracking = true;
-  options.enableAutoSessionTracking = true;
+  options.enableAutoSessionTracking = false;
   options.enableNativeCrashHandling = true;
   options.enableUserInteractionBreadcrumbs = false;
   options.enableUserInteractionTracing = false;

--- a/lib/common/logging/sentry_configuration.dart
+++ b/lib/common/logging/sentry_configuration.dart
@@ -29,7 +29,7 @@ Future<void> configureSentryOptions(SentryFlutterOptions options) async {
   options.enableLogs = false;
   options.enableAutoPerformanceTracing = true;
   options.enableFramesTracking = true;
-  options.enableAutoSessionTracking = false;
+  options.enableAutoSessionTracking = true;
   options.enableNativeCrashHandling = true;
   options.enableUserInteractionBreadcrumbs = false;
   options.enableUserInteractionTracing = false;

--- a/lib/common/logging/sentry_scrubber.dart
+++ b/lib/common/logging/sentry_scrubber.dart
@@ -1,0 +1,353 @@
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter/widgets.dart';
+import 'package:sentry/sentry.dart';
+
+const String sentryRedactedValue = '[redacted]';
+
+const Set<String> _sensitiveTerms = <String>{
+  'password',
+  'username',
+  'user',
+  'email',
+  'token',
+  'cookie',
+  'auth',
+  'authorization',
+  'rapla',
+  'ical',
+  'url',
+  'grade',
+  'mark',
+  'course',
+  'room',
+  'schedule',
+  'event',
+  'dualis',
+  'session',
+};
+
+const Set<String> _genericValues = <String>{
+  'app',
+  'debug',
+  'profile',
+  'release',
+  'production',
+  'staging',
+  'android',
+  'ios',
+  'web',
+  'linux',
+  'macos',
+  'windows',
+  'startup',
+  'startup.initialize',
+  'main',
+  'onboarding',
+  'settings',
+  'shell',
+  'schedule',
+  'canteen',
+  'dualis',
+  'date_management',
+  'usefulinformation',
+  'useful_information',
+  'drawer.tab.schedule',
+  'drawer.tab.canteen',
+  'drawer.tab.dualis',
+  'drawer.tab.date_management',
+  'drawer.tab.usefulinformation',
+  'drawer.tab.useful_information',
+  'schedule.entry',
+  'canteen.entry',
+  'schedule.refresh',
+  'schedule.cache',
+  'perf.frame',
+  'perf.instant',
+  'navigation',
+  'analytics.event',
+  'analytics.user_property',
+};
+
+const Map<String, String> _routeAliases = <String, String>{
+  'schedule': 'schedule',
+  'canteen': 'canteen',
+  'dualis': 'dualis',
+  'date_management': 'date_management',
+  'usefulInformation': 'useful_information',
+  'usefulinformation': 'useful_information',
+  'onboarding': 'onboarding',
+  'main': 'main',
+  'settings': 'settings',
+  'shell': 'shell',
+};
+
+bool _containsSensitiveTerm(String value) {
+  final normalized = value.toLowerCase();
+  if (normalized.contains('technical')) {
+    return _sensitiveTerms
+        .where((term) => term != 'ical')
+        .any(normalized.contains);
+  }
+  return _sensitiveTerms.any(normalized.contains);
+}
+
+bool _isGenericValue(String value) {
+  final normalized = value.trim().toLowerCase();
+  return _genericValues.contains(normalized);
+}
+
+bool isSensitiveDiagnosticsKey(Object? key) {
+  if (key == null) return false;
+  return _containsSensitiveTerm(key.toString());
+}
+
+String sanitizeDiagnosticsName(String name) {
+  final trimmed = name.trim();
+  if (trimmed.isEmpty) return 'unknown';
+  final route = sanitizeRouteName(trimmed);
+  if (route != 'unknown') return route;
+  if (_isGenericValue(trimmed)) return trimmed;
+  if (_containsSensitiveTerm(trimmed) || _looksLikeUrl(trimmed)) {
+    return sentryRedactedValue;
+  }
+  return trimmed.length > 80 ? trimmed.substring(0, 80) : trimmed;
+}
+
+String sanitizeRouteName(String? name) {
+  if (name == null) return 'unknown';
+  final trimmed = name.trim();
+  if (trimmed.isEmpty) return 'unknown';
+  final withoutQuery = _stripUrlQuery(trimmed);
+  final alias = _routeAliases[withoutQuery] ?? _routeAliases[trimmed];
+  if (alias != null) return alias;
+  if (withoutQuery.startsWith('/')) {
+    final firstSegment = withoutQuery
+        .split('/')
+        .where((segment) => segment.isNotEmpty)
+        .cast<String?>()
+        .firstOrNull;
+    final segmentAlias =
+        _routeAliases[firstSegment] ??
+        _routeAliases[firstSegment?.toLowerCase() ?? ''];
+    if (segmentAlias != null) return segmentAlias;
+  }
+  return 'unknown';
+}
+
+RouteSettings? sanitizeSentryRouteSettings(RouteSettings? settings) {
+  if (settings == null) return null;
+  return RouteSettings(name: sanitizeRouteName(settings.name));
+}
+
+Object? sanitizeDiagnosticsValue(Object? value, {Object? key, int depth = 0}) {
+  if (value == null || value is num || value is bool) return value;
+  if (isSensitiveDiagnosticsKey(key)) return sentryRedactedValue;
+  if (depth >= 4) return value is String ? _sanitizeStringValue(value) : null;
+
+  if (value is Uri) {
+    return _sanitizeStringValue(value.toString());
+  }
+  if (value is String) {
+    return _sanitizeStringValue(value);
+  }
+  if (value is DateTime) {
+    return value.toIso8601String();
+  }
+  if (value is Iterable) {
+    return value
+        .map((entry) => sanitizeDiagnosticsValue(entry, depth: depth + 1))
+        .toList(growable: false);
+  }
+  if (value is Map) {
+    return sanitizeDiagnosticsMap(value, depth: depth + 1);
+  }
+  return sentryRedactedValue;
+}
+
+Map<String, Object?> sanitizeDiagnosticsMap(
+  Map<dynamic, dynamic> source, {
+  int depth = 0,
+}) {
+  final sanitized = <String, Object?>{};
+  for (final entry in source.entries) {
+    final key = entry.key?.toString() ?? 'unknown';
+    sanitized[key] = sanitizeDiagnosticsValue(
+      entry.value,
+      key: key,
+      depth: depth,
+    );
+  }
+  return sanitized;
+}
+
+Map<String, String> sanitizeDiagnosticsTags(Map<String, String> source) {
+  return source.map(
+    (key, value) =>
+        MapEntry(key, sanitizeDiagnosticsValue(value, key: key).toString()),
+  );
+}
+
+Object sanitizeDiagnosticsThrowable(Object exception) {
+  if (exception is SanitizedDiagnosticsException) return exception;
+  return SanitizedDiagnosticsException(exception);
+}
+
+SentryEvent? scrubSentryEvent(SentryEvent event, Hint hint) {
+  event.user = null;
+  event.transaction = event.transaction == null
+      ? null
+      : sanitizeDiagnosticsName(event.transaction!);
+  event.culprit = event.culprit == null
+      ? null
+      : sanitizeDiagnosticsValue(event.culprit).toString();
+  event.message = _scrubMessage(event.message);
+  event.tags = event.tags == null ? null : sanitizeDiagnosticsTags(event.tags!);
+  event.extra = event.extra == null
+      ? null
+      : sanitizeDiagnosticsMap(event.extra!);
+  event.breadcrumbs = event.breadcrumbs
+      ?.map(scrubSentryBreadcrumb)
+      .nonNulls
+      .toList();
+  event.request = _scrubRequest(event.request);
+  event.exceptions = event.exceptions?.map(_scrubException).toList();
+  _scrubContexts(event.contexts);
+  return event;
+}
+
+SentryTransaction? scrubSentryTransaction(
+  SentryTransaction transaction,
+  Hint hint,
+) {
+  scrubSentryEvent(transaction, hint);
+  transaction.transaction = sanitizeDiagnosticsName(
+    transaction.transaction ?? 'unknown',
+  );
+  for (final span in transaction.spans) {
+    span.context.operation = sanitizeDiagnosticsName(span.context.operation);
+    final description = span.context.description;
+    span.context.description = description == null
+        ? null
+        : sanitizeDiagnosticsName(description);
+    for (final key in span.data.keys.toList(growable: false)) {
+      final value = span.data[key];
+      span.removeData(key);
+      final sanitized = sanitizeDiagnosticsValue(value, key: key);
+      if (sanitized != null && sanitized != sentryRedactedValue) {
+        span.setData(key, sanitized);
+      }
+    }
+  }
+  return transaction;
+}
+
+Breadcrumb? scrubSentryBreadcrumb(Breadcrumb? breadcrumb, [Hint? hint]) {
+  if (breadcrumb == null) return null;
+  return breadcrumb.copyWith(
+    message: breadcrumb.message == null
+        ? null
+        : sanitizeDiagnosticsName(breadcrumb.message!),
+    category: breadcrumb.category == null
+        ? null
+        : sanitizeDiagnosticsName(breadcrumb.category!),
+    data: breadcrumb.data == null
+        ? null
+        : sanitizeDiagnosticsMap(breadcrumb.data!),
+  );
+}
+
+class SanitizedDiagnosticsException implements Exception {
+  final String type;
+  final String message;
+
+  SanitizedDiagnosticsException(Object source)
+    : type = source.runtimeType.toString(),
+      message = sanitizeDiagnosticsValue(source.toString()).toString();
+
+  @override
+  String toString() {
+    return message == sentryRedactedValue ? type : '$type: $message';
+  }
+}
+
+String _sanitizeStringValue(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) return trimmed;
+  final withoutQuery = _stripUrlQuery(trimmed);
+  if (_looksLikeUrl(trimmed)) return withoutQuery;
+  if (_isGenericValue(trimmed)) return trimmed;
+  if (_containsSensitiveTerm(trimmed)) return sentryRedactedValue;
+  return withoutQuery;
+}
+
+bool _looksLikeUrl(String value) {
+  final uri = Uri.tryParse(value);
+  return uri != null && uri.hasScheme && uri.host.isNotEmpty;
+}
+
+String _stripUrlQuery(String value) {
+  final queryIndex = value.indexOf('?');
+  final fragmentIndex = value.indexOf('#');
+  final cutIndexes = <int>[
+    if (queryIndex >= 0) queryIndex,
+    if (fragmentIndex >= 0) fragmentIndex,
+  ];
+  if (cutIndexes.isEmpty) return value;
+  cutIndexes.sort();
+  return value.substring(0, cutIndexes.first);
+}
+
+SentryMessage? _scrubMessage(SentryMessage? message) {
+  if (message == null) return null;
+  return SentryMessage(
+    sanitizeDiagnosticsValue(message.formatted).toString(),
+    template: message.template == null
+        ? null
+        : sanitizeDiagnosticsValue(message.template).toString(),
+    params: message.params
+        ?.map((param) => sanitizeDiagnosticsValue(param))
+        .toList(growable: false),
+  );
+}
+
+SentryException _scrubException(SentryException exception) {
+  return exception.copyWith(
+    value: exception.value == null
+        ? null
+        : sanitizeDiagnosticsValue(exception.value).toString(),
+  );
+}
+
+SentryRequest? _scrubRequest(SentryRequest? request) {
+  if (request == null) return null;
+  return SentryRequest(
+    url: request.url == null ? null : _stripUrlQuery(request.url!),
+    method: request.method,
+    queryString: '',
+    headers: sanitizeDiagnosticsTags(request.headers),
+    env: sanitizeDiagnosticsTags(request.env),
+    fragment: null,
+    apiTarget: request.apiTarget == null
+        ? null
+        : sanitizeDiagnosticsValue(request.apiTarget).toString(),
+  );
+}
+
+void _scrubContexts(Contexts contexts) {
+  for (final key in contexts.keys.toList(growable: false)) {
+    if (key == SentryDevice.type ||
+        key == SentryOperatingSystem.type ||
+        key == SentryRuntime.listType ||
+        key == SentryApp.type ||
+        key == SentryTraceContext.type) {
+      continue;
+    }
+    final value = contexts[key];
+    contexts[key] = sanitizeDiagnosticsValue(value, key: key);
+  }
+}
+
+extension _IterableFirstOrNull<T> on Iterable<T> {
+  T? get firstOrNull => isEmpty ? null : first;
+}

--- a/lib/common/logging/sentry_scrubber.dart
+++ b/lib/common/logging/sentry_scrubber.dart
@@ -82,6 +82,31 @@ const Map<String, String> _routeAliases = <String, String>{
   'shell': 'shell',
 };
 
+final RegExp _embeddedUrlPattern = RegExp(
+  r'(?:(?:https?|webcal)://|www\.)[^\s<>"'
+  '()]+',
+  caseSensitive: false,
+);
+
+final RegExp _emailPattern = RegExp(
+  r'\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b',
+  caseSensitive: false,
+);
+
+final RegExp _authorizationTokenPattern = RegExp(
+  r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+  caseSensitive: false,
+);
+
+final RegExp _jwtPattern = RegExp(
+  r'\beyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b',
+);
+
+final RegExp _tokenAssignmentPattern = RegExp(
+  r'\b(?:access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|secret)=([^\s&;]+)',
+  caseSensitive: false,
+);
+
 bool _containsSensitiveTerm(String value) {
   final normalized = value.toLowerCase();
   if (normalized.contains('technical')) {
@@ -111,7 +136,11 @@ String sanitizeDiagnosticsName(String name) {
   if (_containsSensitiveTerm(trimmed) || _looksLikeUrl(trimmed)) {
     return sentryRedactedValue;
   }
-  return trimmed.length > 80 ? trimmed.substring(0, 80) : trimmed;
+  final sanitized = _sanitizeStringValue(trimmed);
+  final truncated = sanitized.length > 80
+      ? sanitized.substring(0, 80)
+      : sanitized;
+  return truncated;
 }
 
 String sanitizeRouteName(String? name) {
@@ -188,11 +217,6 @@ Map<String, String> sanitizeDiagnosticsTags(Map<String, String> source) {
   );
 }
 
-Object sanitizeDiagnosticsThrowable(Object exception) {
-  if (exception is SanitizedDiagnosticsException) return exception;
-  return SanitizedDiagnosticsException(exception);
-}
-
 SentryEvent? scrubSentryEvent(SentryEvent event, Hint hint) {
   event.user = null;
   event.transaction = event.transaction == null
@@ -257,32 +281,37 @@ Breadcrumb? scrubSentryBreadcrumb(Breadcrumb? breadcrumb, [Hint? hint]) {
   );
 }
 
-class SanitizedDiagnosticsException implements Exception {
-  final String type;
-  final String message;
-
-  SanitizedDiagnosticsException(Object source)
-    : type = source.runtimeType.toString(),
-      message = sanitizeDiagnosticsValue(source.toString()).toString();
-
-  @override
-  String toString() {
-    return message == sentryRedactedValue ? type : '$type: $message';
-  }
-}
-
 String _sanitizeStringValue(String value) {
   final trimmed = value.trim();
   if (trimmed.isEmpty) return trimmed;
   if (_looksLikeUrl(trimmed)) return sentryRedactedValue;
   if (_isGenericValue(trimmed)) return trimmed;
+  final embeddedRedacted = _redactEmbeddedSensitiveValues(trimmed);
+  if (embeddedRedacted != trimmed) return embeddedRedacted;
   if (_containsSensitiveTerm(trimmed)) return sentryRedactedValue;
   return trimmed;
 }
 
 bool _looksLikeUrl(String value) {
+  final match = _embeddedUrlPattern.firstMatch(value);
+  if (match == null || match.start != 0 || match.end != value.length) {
+    return false;
+  }
   final uri = Uri.tryParse(value);
   return uri != null && uri.hasScheme && uri.host.isNotEmpty;
+}
+
+String _redactEmbeddedSensitiveValues(String value) {
+  return value
+      .replaceAll(_embeddedUrlPattern, sentryRedactedValue)
+      .replaceAll(_emailPattern, sentryRedactedValue)
+      .replaceAll(_authorizationTokenPattern, sentryRedactedValue)
+      .replaceAll(_jwtPattern, sentryRedactedValue)
+      .replaceAllMapped(
+        _tokenAssignmentPattern,
+        (match) =>
+            match.group(0)!.replaceFirst(match.group(1)!, sentryRedactedValue),
+      );
 }
 
 String _stripUrlQuery(String value) {

--- a/lib/common/logging/sentry_scrubber.dart
+++ b/lib/common/logging/sentry_scrubber.dart
@@ -141,8 +141,8 @@ RouteSettings? sanitizeSentryRouteSettings(RouteSettings? settings) {
 }
 
 Object? sanitizeDiagnosticsValue(Object? value, {Object? key, int depth = 0}) {
-  if (value == null || value is num || value is bool) return value;
   if (isSensitiveDiagnosticsKey(key)) return sentryRedactedValue;
+  if (value == null || value is num || value is bool) return value;
   if (depth >= 4) return value is String ? _sanitizeStringValue(value) : null;
 
   if (value is Uri) {
@@ -274,11 +274,10 @@ class SanitizedDiagnosticsException implements Exception {
 String _sanitizeStringValue(String value) {
   final trimmed = value.trim();
   if (trimmed.isEmpty) return trimmed;
-  final withoutQuery = _stripUrlQuery(trimmed);
-  if (_looksLikeUrl(trimmed)) return withoutQuery;
+  if (_looksLikeUrl(trimmed)) return sentryRedactedValue;
   if (_isGenericValue(trimmed)) return trimmed;
   if (_containsSensitiveTerm(trimmed)) return sentryRedactedValue;
-  return withoutQuery;
+  return trimmed;
 }
 
 bool _looksLikeUrl(String value) {
@@ -322,7 +321,7 @@ SentryException _scrubException(SentryException exception) {
 SentryRequest? _scrubRequest(SentryRequest? request) {
   if (request == null) return null;
   return SentryRequest(
-    url: request.url == null ? null : _stripUrlQuery(request.url!),
+    url: request.url == null ? null : sentryRedactedValue,
     method: request.method,
     queryString: '',
     headers: sanitizeDiagnosticsTags(request.headers),

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -94,13 +94,28 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   bool _initialized = false;
   DateTime? _lastWarmedWeekStart;
 
-  WeeklyScheduleViewModel(
+  factory WeeklyScheduleViewModel(
+    ScheduleProvider scheduleProvider,
+    ScheduleSourceProvider scheduleSourceProvider, {
+    DateTime Function()? nowProvider,
+  }) {
+    final initialStart = _resolveInitialWeekStart(nowProvider);
+    return WeeklyScheduleViewModel._withInitialStart(
+      scheduleProvider,
+      scheduleSourceProvider,
+      nowProvider: nowProvider,
+      initialStart: initialStart,
+    );
+  }
+
+  WeeklyScheduleViewModel._withInitialStart(
     this.scheduleProvider,
     this.scheduleSourceProvider, {
+    required DateTime initialStart,
     DateTime Function()? nowProvider,
   }) : _nowProvider = nowProvider ?? DateTime.now,
-       currentDateStart = _resolveInitialWeekStart(nowProvider),
-       currentDateEnd = toNextWeek(_resolveInitialWeekStart(nowProvider));
+       currentDateStart = initialStart,
+       currentDateEnd = toNextWeek(initialStart);
 
   static DateTime _resolveInitialWeekStart(DateTime Function()? nowProvider) {
     final now = (nowProvider ?? DateTime.now)();

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -17,6 +17,7 @@ import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:dualmate/schedule/ui/viewmodels/schedule_freshness_gate.dart';
 import 'package:dualmate/schedule/ui/viewmodels/schedule_update_request_gate.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 class WeeklyScheduleViewModel extends BaseViewModel {
@@ -53,8 +54,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   final ScheduleUpdateRequestGate _updateRequestGate =
       ScheduleUpdateRequestGate(minInterval: const Duration(seconds: 1));
   final ScheduleFreshnessGate _freshnessGate = ScheduleFreshnessGate();
-  final ScheduleFreshnessGate _entryRefreshGate =
-      ScheduleFreshnessGate(staleAfter: const Duration(minutes: 20));
+  final ScheduleFreshnessGate _entryRefreshGate = ScheduleFreshnessGate(
+    staleAfter: const Duration(minutes: 20),
+  );
   Schedule? weekSchedule;
   Schedule? _lastCachedSchedule;
   final Map<String, ScheduleFreshnessGate> _windowFreshnessGates = {};
@@ -96,9 +98,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     this.scheduleProvider,
     this.scheduleSourceProvider, {
     DateTime Function()? nowProvider,
-  })  : _nowProvider = nowProvider ?? DateTime.now,
-        currentDateStart = _resolveInitialWeekStart(nowProvider),
-        currentDateEnd = toNextWeek(_resolveInitialWeekStart(nowProvider));
+  }) : _nowProvider = nowProvider ?? DateTime.now,
+       currentDateStart = _resolveInitialWeekStart(nowProvider),
+       currentDateEnd = toNextWeek(_resolveInitialWeekStart(nowProvider));
 
   static DateTime _resolveInitialWeekStart(DateTime Function()? nowProvider) {
     final now = (nowProvider ?? DateTime.now)();
@@ -123,8 +125,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     DateTime referenceStart,
     Schedule? schedule,
   ) {
-    final weekStart =
-        toStartOfDay(toDayOfWeek(referenceStart, DateTime.monday));
+    final weekStart = toStartOfDay(
+      toDayOfWeek(referenceStart, DateTime.monday),
+    );
     final weekEnd = toStartOfDay(toDayOfWeek(referenceStart, DateTime.friday));
 
     if (schedule == null) {
@@ -132,8 +135,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
 
     var displayEnd = weekEnd;
-    final saturday =
-        toStartOfDay(toDayOfWeek(referenceStart, DateTime.saturday));
+    final saturday = toStartOfDay(
+      toDayOfWeek(referenceStart, DateTime.saturday),
+    );
 
     if (_hasEntriesOnDay(schedule, saturday)) {
       displayEnd = saturday;
@@ -160,8 +164,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       ensureUpdateNowTimerRunning();
       _ensureWindowRefreshTimer();
 
-      scheduleSourceProvider
-          .addDidChangeScheduleSourceCallback(_onDidChangeScheduleSource);
+      scheduleSourceProvider.addDidChangeScheduleSourceCallback(
+        _onDidChangeScheduleSource,
+      );
     } catch (error, trace) {
       initializeFailed = true;
       notifyIfMounted("initializeFailed");
@@ -205,12 +210,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     var end = addDays(start, 14);
     try {
       // Keep widget data fresh without changing the currently visible week.
-      await updateSchedule(
-        start,
-        end,
-        force: true,
-        applyToVisibleState: false,
-      );
+      await updateSchedule(start, end, force: true, applyToVisibleState: false);
     } catch (error, trace) {
       print("Weekly schedule widget refresh failed: $error");
       print(trace);
@@ -267,8 +267,10 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     _evictDistantWindowData(start);
 
     if (weekSchedule != null) {
-      var displayRange =
-          resolveWeeklyDisplayRange(currentDateStart, weekSchedule);
+      var displayRange = resolveWeeklyDisplayRange(
+        currentDateStart,
+        weekSchedule,
+      );
       clippedDateStart = displayRange.start;
       clippedDateEnd = displayRange.end;
 
@@ -345,7 +347,8 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   Future<void> _openWeekFromCache(DateTime start, DateTime end) async {
     try {
       final cacheKey = _windowKey(start, end);
-      final cachedSchedule = getCachedWeek(start, end) ??
+      final cachedSchedule =
+          getCachedWeek(start, end) ??
           await scheduleProvider.getCachedSchedule(start, end);
       if (_isDisposed) return;
       _memoryWeekCache[cacheKey] = cachedSchedule;
@@ -456,13 +459,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
     final cacheTask = PerformanceTelemetry.instance.startTask(
       'schedule.cache',
-      args: {
-        'start': start.toIso8601String(),
-        'end': end.toIso8601String(),
-      },
+      args: {'start': start.toIso8601String(), 'end': end.toIso8601String()},
     );
     var cacheKey = _windowKey(start, end);
-    var cachedSchedule = _memoryWeekCache[cacheKey] ??
+    var cachedSchedule =
+        _memoryWeekCache[cacheKey] ??
         await scheduleProvider.getCachedSchedule(start, end);
     _memoryWeekCache[cacheKey] = cachedSchedule;
     unawaited(cacheTask.finish());
@@ -474,7 +475,8 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
 
     final nowValue = now;
-    final shouldForceFetch = awaitRefresh ||
+    final shouldForceFetch =
+        awaitRefresh ||
         (cachedSchedule.entries.isEmpty &&
             scheduleSourceProvider.currentScheduleSource.canQuery());
     final isStale = shouldForceFetch || _isWindowStale(start, end, nowValue);
@@ -526,7 +528,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       } on OperationCancelledException {
         return;
       } catch (e, stack) {
-        print("Schedule update failed: $e");
+        if (kDebugMode) {
+          debugPrint("Schedule update failed: $e");
+        }
         task.setTag('result', 'failed');
         task.setData('error', '$e');
         await reportException(e, stack);
@@ -584,10 +588,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         error,
         trace,
         message: 'Weekly schedule background refresh failed',
-        tags: {
-          'feature': 'schedule',
-          'origin': origin.name,
-        },
+        tags: {'feature': 'schedule', 'origin': origin.name},
         contexts: {
           'schedule_refresh': {
             'start': start.toIso8601String(),
@@ -639,14 +640,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   void _cancelErrorInFuture() {
     _errorResetTimer?.cancel();
 
-    _errorResetTimer = Timer(
-      const Duration(seconds: 5),
-      () {
-        if (_isDisposed) return;
-        updateFailed = false;
-        notifyIfMounted("updateFailed");
-      },
-    );
+    _errorResetTimer = Timer(const Duration(seconds: 5), () {
+      if (_isDisposed) return;
+      updateFailed = false;
+      notifyIfMounted("updateFailed");
+    });
   }
 
   void ensureUpdateNowTimerRunning() {
@@ -698,8 +696,10 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
     if (!_memoryWeekCache.containsKey(nextKey)) {
       try {
-        _memoryWeekCache[nextKey] =
-            await scheduleProvider.getCachedSchedule(nextStart, nextEnd);
+        _memoryWeekCache[nextKey] = await scheduleProvider.getCachedSchedule(
+          nextStart,
+          nextEnd,
+        );
       } catch (_) {}
     }
 
@@ -794,8 +794,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   void dispose() {
     _isDisposed = true;
 
-    scheduleSourceProvider
-        .removeDidChangeScheduleSourceCallback(_onDidChangeScheduleSource);
+    scheduleSourceProvider.removeDidChangeScheduleSourceCallback(
+      _onDidChangeScheduleSource,
+    );
 
     _updateMutex.cancel();
 

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -20,6 +20,13 @@ import 'package:dualmate/common/util/widget_navigation_payload.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+void _debugScheduleError(String message, Object error, StackTrace trace) {
+  if (kDebugMode) {
+    debugPrint('$message: $error');
+    debugPrint('$trace');
+  }
+}
+
 class WeeklyScheduleViewModel extends BaseViewModel {
   static const Duration weekDuration = Duration(days: 7);
   static const int _maxRetainedWeeks = 12;
@@ -28,8 +35,8 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   final ScheduleSourceProvider scheduleSourceProvider;
   final DateTime Function() _nowProvider;
 
-  DateTime currentDateStart;
-  DateTime currentDateEnd;
+  late DateTime currentDateStart;
+  late DateTime currentDateEnd;
 
   bool _hasCurrentDateRange = false;
 
@@ -94,28 +101,15 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   bool _initialized = false;
   DateTime? _lastWarmedWeekStart;
 
-  factory WeeklyScheduleViewModel(
-    ScheduleProvider scheduleProvider,
-    ScheduleSourceProvider scheduleSourceProvider, {
-    DateTime Function()? nowProvider,
-  }) {
-    final initialStart = _resolveInitialWeekStart(nowProvider);
-    return WeeklyScheduleViewModel._withInitialStart(
-      scheduleProvider,
-      scheduleSourceProvider,
-      nowProvider: nowProvider,
-      initialStart: initialStart,
-    );
-  }
-
-  WeeklyScheduleViewModel._withInitialStart(
+  WeeklyScheduleViewModel(
     this.scheduleProvider,
     this.scheduleSourceProvider, {
-    required DateTime initialStart,
     DateTime Function()? nowProvider,
-  }) : _nowProvider = nowProvider ?? DateTime.now,
-       currentDateStart = initialStart,
-       currentDateEnd = toNextWeek(initialStart);
+  }) : _nowProvider = nowProvider ?? DateTime.now {
+    final initialStart = _resolveInitialWeekStart(nowProvider);
+    currentDateStart = initialStart;
+    currentDateEnd = toNextWeek(initialStart);
+  }
 
   static DateTime _resolveInitialWeekStart(DateTime Function()? nowProvider) {
     final now = (nowProvider ?? DateTime.now)();
@@ -130,8 +124,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     } catch (error, trace) {
       initializeFailed = true;
       notifyIfMounted("initializeFailed");
-      print("Weekly schedule init failed: $error");
-      print(trace);
+      _debugScheduleError("Weekly schedule init failed", error, trace);
       await reportException(error, trace);
     }
   }
@@ -185,8 +178,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     } catch (error, trace) {
       initializeFailed = true;
       notifyIfMounted("initializeFailed");
-      print("Weekly schedule init failed: $error");
-      print(trace);
+      _debugScheduleError("Weekly schedule init failed", error, trace);
       await reportException(error, trace);
       ensureUpdateNowTimerRunning();
       _ensureWindowRefreshTimer();
@@ -204,8 +196,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         }
         await updateSchedule(currentDateStart, currentDateEnd);
       } catch (error, trace) {
-        print("Weekly schedule refresh failed: $error");
-        print(trace);
+        _debugScheduleError("Weekly schedule refresh failed", error, trace);
         await reportException(error, trace);
       }
     });
@@ -227,8 +218,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       // Keep widget data fresh without changing the currently visible week.
       await updateSchedule(start, end, force: true, applyToVisibleState: false);
     } catch (error, trace) {
-      print("Weekly schedule widget refresh failed: $error");
-      print(trace);
+      _debugScheduleError(
+        "Weekly schedule widget refresh failed",
+        error,
+        trace,
+      );
       await reportException(error, trace);
     }
   }
@@ -250,8 +244,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         if (_isDisposed) return;
         await updateSchedule(currentDateStart, currentDateEnd, force: true);
       } catch (error, trace) {
-        print("Weekly schedule source refresh failed: $error");
-        print(trace);
+        _debugScheduleError(
+          "Weekly schedule source refresh failed",
+          error,
+          trace,
+        );
         await reportException(error, trace);
       }
     }
@@ -369,8 +366,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       _memoryWeekCache[cacheKey] = cachedSchedule;
       _setSchedule(cachedSchedule, start, end);
     } catch (error, trace) {
-      print("Failed to open cached week: $error");
-      print(trace);
+      _debugScheduleError("Failed to open cached week", error, trace);
       await reportException(error, trace);
     }
   }
@@ -597,8 +593,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         _cancelErrorInFuture();
       }
     } catch (error, trace) {
-      print("Weekly schedule background refresh failed: $error");
-      print(trace);
+      _debugScheduleError(
+        "Weekly schedule background refresh failed",
+        error,
+        trace,
+      );
       await AppDiagnostics.instance.reportCaughtException(
         error,
         trace,

--- a/lib/ui/navigation/router.dart
+++ b/lib/ui/navigation/router.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:dualmate/canteen/ui/canteen_navigation_entry.dart';
 import 'package:dualmate/date_management/ui/date_management_navigation_entry.dart';
 import 'package:dualmate/dualis/ui/dualis_navigation_entry.dart';
@@ -27,7 +28,9 @@ WidgetBuilder _resolveRoute(RouteSettings settings) {
 }
 
 Route<dynamic> generateDrawerRoute(RouteSettings settings) {
-  print("=== === === === === === Navigating to: ${settings.name}");
+  if (kDebugMode) {
+    debugPrint("=== === === === === === Navigating to: ${settings.name}");
+  }
 
   final args = settings.arguments;
   if (args is Map && args["disableTransitions"] == true) {
@@ -67,13 +70,17 @@ Route<dynamic> generateDrawerRoute(RouteSettings settings) {
     transitionsBuilder: (context, animation, secondaryAnimation, child) {
       const offsetBegin = Offset(0.0, 0.005);
       final offsetEnd = Offset.zero;
-      final offsetTween = Tween(begin: offsetBegin, end: offsetEnd)
-          .chain(CurveTween(curve: Curves.fastOutSlowIn));
+      final offsetTween = Tween(
+        begin: offsetBegin,
+        end: offsetEnd,
+      ).chain(CurveTween(curve: Curves.fastOutSlowIn));
 
       const opacityBegin = 0.0;
       const opacityEnd = 1.0;
-      final opacityTween = Tween(begin: opacityBegin, end: opacityEnd)
-          .chain(CurveTween(curve: Curves.fastOutSlowIn));
+      final opacityTween = Tween(
+        begin: opacityBegin,
+        end: opacityEnd,
+      ).chain(CurveTween(curve: Curves.fastOutSlowIn));
 
       return SlideTransition(
         position: animation.drive(offsetTween),
@@ -90,7 +97,9 @@ Route<dynamic> generateDrawerRoute(RouteSettings settings) {
 }
 
 Route<dynamic> generateRoute(RouteSettings settings) {
-  print("=== === === === === === Navigating to: ${settings.name}");
+  if (kDebugMode) {
+    debugPrint("=== === === === === === Navigating to: ${settings.name}");
+  }
   Widget target;
 
   switch (settings.name) {
@@ -104,7 +113,9 @@ Route<dynamic> generateRoute(RouteSettings settings) {
       target = SettingsPage();
       break;
     default:
-      print("Failed to navigate to: " + (settings.name ?? ""));
+      if (kDebugMode) {
+        debugPrint("Failed to navigate to: ${settings.name ?? ""}");
+      }
       target = Container();
   }
 

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -5,6 +5,7 @@ import 'package:dualmate/common/logging/analytics.dart';
 import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/logging/perf_overlay_controller.dart';
+import 'package:dualmate/common/logging/sentry_scrubber.dart';
 import 'package:dualmate/common/ui/colors.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
 import 'package:dualmate/common/appstart/app_initializer.dart';
@@ -40,19 +41,23 @@ class RootPage extends StatefulWidget {
 }
 
 class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
-  static const Duration _deferredBackgroundInitDelay =
-      Duration(milliseconds: 1800);
-  static const Duration _foregroundHeavyInitDelay =
-      Duration(milliseconds: 2800);
-  static const Duration _foregroundCanteenPrewarmDelay =
-      Duration(milliseconds: 7000);
+  static const Duration _deferredBackgroundInitDelay = Duration(
+    milliseconds: 1800,
+  );
+  static const Duration _foregroundHeavyInitDelay = Duration(
+    milliseconds: 2800,
+  );
+  static const Duration _foregroundCanteenPrewarmDelay = Duration(
+    milliseconds: 7000,
+  );
 
   RootViewModel? _rootViewModel;
   bool _backgroundInitStarted = false;
   bool _onboardingDeferredInitListenerAttached = false;
   Stopwatch? _deferredInitStopwatch;
-  static const MethodChannel _navigationChannel =
-      MethodChannel('com.fariszr.dualmate/navigation');
+  static const MethodChannel _navigationChannel = MethodChannel(
+    'com.fariszr.dualmate/navigation',
+  );
   String? _pendingRoute;
   PerformanceTelemetryTask? _startupTask;
   bool _perfOverlayLoaded = false;
@@ -68,8 +73,9 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
       _loadPerfOverlayPreference();
     });
     PerformanceTelemetry.instance.ensureFrameTimingListenerAttached();
-    _startupTask =
-        PerformanceTelemetry.instance.startTask('startup.initialize');
+    _startupTask = PerformanceTelemetry.instance.startTask(
+      'startup.initialize',
+    );
     unawaited(_setAppAttended(true));
     _initializeApp();
   }
@@ -157,7 +163,8 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     final schedulePayload = WidgetScheduleEntryPayload.fromMap(payload);
     if (!schedulePayload.isEmpty) {
       print(
-          "Widget schedule payload: ${schedulePayload.dayStart} id=${schedulePayload.id}");
+        "Widget schedule payload: ${schedulePayload.dayStart} id=${schedulePayload.id}",
+      );
       WidgetNavigationPayloadStore.instance.setSchedulePayload(schedulePayload);
     }
 
@@ -189,14 +196,13 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
 
       unawaited(_saveLastStartLanguage());
       print(
-          "Root init: save language deferred ${stopwatch.elapsedMilliseconds}ms");
+        "Root init: save language deferred ${stopwatch.elapsedMilliseconds}ms",
+      );
       PerformanceTelemetry.instance.logInstant(
         'startup.root.language.done',
         args: {'elapsedMs': widget.startupStopwatch.elapsedMilliseconds},
       );
-      _rootViewModel ??= RootViewModel(
-        KiwiContainer().resolve(),
-      );
+      _rootViewModel ??= RootViewModel(KiwiContainer().resolve());
       if (!mounted) {
         return;
       }
@@ -228,9 +234,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
       unawaited(_startupTask?.fail(error));
 
       if (_rootViewModel == null) {
-        _rootViewModel = RootViewModel(
-          KiwiContainer().resolve(),
-        );
+        _rootViewModel = RootViewModel(KiwiContainer().resolve());
       }
 
       if (mounted) {
@@ -247,8 +251,8 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
   Future<void> _setAppAttended(bool attended) async {
     try {
       await KiwiContainer().resolve<PreferencesProvider>().setIsAppAttended(
-            attended,
-          );
+        attended,
+      );
     } catch (_) {}
   }
 
@@ -296,8 +300,8 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
   Future<void> _loadPerfOverlayPreference() async {
     if (_perfOverlayLoaded) return;
     try {
-      final preferencesProvider =
-          KiwiContainer().resolve<PreferencesProvider>();
+      final preferencesProvider = KiwiContainer()
+          .resolve<PreferencesProvider>();
       await PerformanceOverlayController.load(preferencesProvider);
       _perfOverlayLoaded = true;
     } catch (error, trace) {
@@ -356,49 +360,49 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     return PropertyChangeProvider<RootViewModel, String>(
       child: PropertyChangeConsumer<RootViewModel, String>(
         properties: const ["appTheme", "isOnboarding", "hasLoadedPreferences"],
-        builder: (
-          BuildContext context,
-          RootViewModel? model,
-          Set<String>? properties,
-        ) {
-          if (model == null) return Container();
-          if (!model.hasLoadedPreferences) {
-            return _buildStartupPlaceholder();
-          }
-          return ValueListenableBuilder<bool>(
-            valueListenable: PerformanceOverlayController.enabled,
-            builder: (context, perfEnabled, _) => SentryUserInteractionWidget(
-              child: MaterialApp(
-                theme: ColorPalettes.buildTheme(model.appTheme),
-                showPerformanceOverlay: perfEnabled,
-                initialRoute:
-                    model.isOnboarding ? "onboarding" : _resolveInitialRoute(),
-                navigatorKey: NavigatorKey.rootKey,
-                navigatorObservers: [
-                  SentryNavigatorObserver(
-                    setRouteNameAsTransaction: true,
-                    enableAutoTransactions: true,
-                    autoFinishAfter: const Duration(seconds: 5),
-                    ignoreRoutes: const ['main'],
-                  ),
-                  rootNavigationObserver,
-                ],
-                localizationsDelegates: [
-                  const LocalizationDelegate(),
-                  GlobalMaterialLocalizations.delegate,
-                  GlobalWidgetsLocalizations.delegate,
-                  GlobalCupertinoLocalizations.delegate,
-                  DefaultCupertinoLocalizations.delegate,
-                ],
-                supportedLocales: const [
-                  Locale('en'),
-                  Locale('de'),
-                ],
-                onGenerateRoute: generateRoute,
-              ),
-            ),
-          );
-        },
+        builder:
+            (
+              BuildContext context,
+              RootViewModel? model,
+              Set<String>? properties,
+            ) {
+              if (model == null) return Container();
+              if (!model.hasLoadedPreferences) {
+                return _buildStartupPlaceholder();
+              }
+              return ValueListenableBuilder<bool>(
+                valueListenable: PerformanceOverlayController.enabled,
+                builder: (context, perfEnabled, _) => MaterialApp(
+                  theme: ColorPalettes.buildTheme(model.appTheme),
+                  showPerformanceOverlay: perfEnabled,
+                  initialRoute: model.isOnboarding
+                      ? "onboarding"
+                      : _resolveInitialRoute(),
+                  navigatorKey: NavigatorKey.rootKey,
+                  navigatorObservers: [
+                    SentryNavigatorObserver(
+                      setRouteNameAsTransaction: true,
+                      enableAutoTransactions: true,
+                      autoFinishAfter: const Duration(seconds: 5),
+                      ignoreRoutes: const ['main'],
+                      routeNameExtractor: sanitizeSentryRouteSettings,
+                      additionalInfoProvider: (_, __) =>
+                          const <String, dynamic>{'source': 'navigator'},
+                    ),
+                    rootNavigationObserver,
+                  ],
+                  localizationsDelegates: [
+                    const LocalizationDelegate(),
+                    GlobalMaterialLocalizations.delegate,
+                    GlobalWidgetsLocalizations.delegate,
+                    GlobalCupertinoLocalizations.delegate,
+                    DefaultCupertinoLocalizations.delegate,
+                  ],
+                  supportedLocales: const [Locale('en'), Locale('de')],
+                  onGenerateRoute: generateRoute,
+                ),
+              );
+            },
       ),
       value: _rootViewModel!,
     );
@@ -408,9 +412,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     return MaterialApp(
       home: const ColoredBox(
         color: Color(0xFFFFFFFF),
-        child: Center(
-          child: CircularProgressIndicator(),
-        ),
+        child: Center(child: CircularProgressIndicator()),
       ),
     );
   }
@@ -442,7 +444,8 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
         debugLabel: 'startup.backgroundInit',
       );
       print(
-          "Root init: deferred background ${stopwatch.elapsedMilliseconds}ms");
+        "Root init: deferred background ${stopwatch.elapsedMilliseconds}ms",
+      );
       SchedulerBinding.instance.scheduleTask<void>(
         () {
           unawaited(_prewarmScheduleCache());
@@ -560,10 +563,9 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     }
 
     _onboardingDeferredInitListenerAttached = true;
-    _rootViewModel!.addListener(
-      _onOnboardingStateChanged,
-      const ["isOnboarding"],
-    );
+    _rootViewModel!.addListener(_onOnboardingStateChanged, const [
+      "isOnboarding",
+    ]);
   }
 
   void _detachOnboardingDeferredInitListener() {
@@ -572,10 +574,9 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     }
 
     _onboardingDeferredInitListenerAttached = false;
-    _rootViewModel!.removeListener(
-      _onOnboardingStateChanged,
-      const ["isOnboarding"],
-    );
+    _rootViewModel!.removeListener(_onOnboardingStateChanged, const [
+      "isOnboarding",
+    ]);
   }
 
   void _onOnboardingStateChanged() {

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -28,6 +28,20 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+void _debugRootLog(String message) {
+  if (kDebugMode) {
+    debugPrint(message);
+  }
+}
+
+void _debugRootError(String message, Object error, StackTrace trace) {
+  if (kDebugMode) {
+    debugPrint(message);
+    debugPrint('$error');
+    debugPrint('$trace');
+  }
+}
+
 ///
 /// This is the top level widget of the app. It handles navigation of the
 /// root navigator and rebuilds its child widgets on theme changes
@@ -191,14 +205,14 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     try {
       await initializeAppBase(false);
       await _setAppAttended(true);
-      print("Root init: base ${stopwatch.elapsedMilliseconds}ms");
+      _debugRootLog("Root init: base ${stopwatch.elapsedMilliseconds}ms");
       PerformanceTelemetry.instance.logInstant(
         'startup.root.base.done',
         args: {'elapsedMs': widget.startupStopwatch.elapsedMilliseconds},
       );
 
       unawaited(_saveLastStartLanguage());
-      print(
+      _debugRootLog(
         "Root init: save language deferred ${stopwatch.elapsedMilliseconds}ms",
       );
       PerformanceTelemetry.instance.logInstant(
@@ -213,13 +227,13 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
 
       _applyPendingRoute();
 
-      print("Root init: allow first frame ${stopwatch.elapsedMilliseconds}ms");
+      _debugRootLog(
+        "Root init: allow first frame ${stopwatch.elapsedMilliseconds}ms",
+      );
       unawaited(_startupTask?.finish());
       unawaited(_loadRootPreferences(stopwatch));
     } catch (error, trace) {
-      print("Root init failed");
-      print(error);
-      print(trace);
+      _debugRootError("Root init failed", error, trace);
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,
@@ -262,15 +276,13 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
   Future<void> _loadRootPreferences(Stopwatch stopwatch) async {
     try {
       await _rootViewModel?.loadFromPreferences();
-      print("Root init: prefs ${stopwatch.elapsedMilliseconds}ms");
+      _debugRootLog("Root init: prefs ${stopwatch.elapsedMilliseconds}ms");
       PerformanceTelemetry.instance.logInstant(
         'startup.root.preferences.done',
         args: {'elapsedMs': widget.startupStopwatch.elapsedMilliseconds},
       );
     } catch (error, trace) {
-      print("Root init: prefs failed");
-      print(error);
-      print(trace);
+      _debugRootError("Root init: prefs failed", error, trace);
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,
@@ -308,9 +320,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
       await PerformanceOverlayController.load(preferencesProvider);
       _perfOverlayLoaded = true;
     } catch (error, trace) {
-      print("Perf overlay load failed");
-      print(error);
-      print(trace);
+      _debugRootError("Perf overlay load failed", error, trace);
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,
@@ -330,9 +340,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     try {
       await saveLastStartLanguage();
     } catch (error, trace) {
-      print("Root init: save language failed");
-      print(error);
-      print(trace);
+      _debugRootError("Root init: save language failed", error, trace);
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,
@@ -446,7 +454,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
         Priority.idle,
         debugLabel: 'startup.backgroundInit',
       );
-      print(
+      _debugRootLog(
         "Root init: deferred background ${stopwatch.elapsedMilliseconds}ms",
       );
       SchedulerBinding.instance.scheduleTask<void>(
@@ -467,9 +475,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
         _scheduleIdleCanteenPrewarm();
       });
     } catch (error, trace) {
-      print("Root init: deferred background failed");
-      print(error);
-      print(trace);
+      _debugRootError("Root init: deferred background failed", error, trace);
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,
@@ -488,9 +494,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     try {
       await initializeAppForegroundHeavy();
     } catch (error, trace) {
-      print("Root init: foreground heavy failed");
-      print(error);
-      print(trace);
+      _debugRootError("Root init: foreground heavy failed", error, trace);
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,
@@ -519,9 +523,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     try {
       await prewarmCanteenIfStale();
     } catch (error, trace) {
-      print("Root init: canteen prewarm failed");
-      print(error);
-      print(trace);
+      _debugRootError("Root init: canteen prewarm failed", error, trace);
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,
@@ -543,9 +545,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
       final end = toNextWeek(start);
       await scheduleProvider.warmScheduleCache(start, end);
     } catch (error, trace) {
-      print("Root init: schedule cache warm failed");
-      print(error);
-      print(trace);
+      _debugRootError("Root init: schedule cache warm failed", error, trace);
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -21,6 +21,7 @@ import 'package:dualmate/ui/navigation/main_section_controller.dart';
 import 'package:dualmate/ui/navigation/navigator_key.dart';
 import 'package:dualmate/ui/navigation/router.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -162,15 +163,17 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     if (payload is! Map) return;
     final schedulePayload = WidgetScheduleEntryPayload.fromMap(payload);
     if (!schedulePayload.isEmpty) {
-      print(
-        "Widget schedule payload: ${schedulePayload.dayStart} id=${schedulePayload.id}",
-      );
+      if (kDebugMode) {
+        debugPrint('Widget schedule payload received');
+      }
       WidgetNavigationPayloadStore.instance.setSchedulePayload(schedulePayload);
     }
 
     final canteenPayload = WidgetCanteenDayPayload.fromMap(payload);
     if (!canteenPayload.isEmpty) {
-      print("Widget canteen payload: ${canteenPayload.dayStart}");
+      if (kDebugMode) {
+        debugPrint('Widget canteen payload received');
+      }
       WidgetNavigationPayloadStore.instance.setCanteenPayload(canteenPayload);
     }
   }

--- a/test/common/logging/app_diagnostics_test.dart
+++ b/test/common/logging/app_diagnostics_test.dart
@@ -154,20 +154,30 @@ void main() {
     },
   );
 
-  test('AppDiagnosticsSpan.attachError records error on span', () async {
-    final recorder = _RecordingDiagnosticsRecorder();
-    final diagnostics = AppDiagnostics(recorder: recorder);
+  test(
+    'AppDiagnosticsSpan.attachError records sanitized error data on span',
+    () async {
+      final recorder = _RecordingDiagnosticsRecorder();
+      final diagnostics = AppDiagnostics(recorder: recorder);
 
-    final span = diagnostics.startSpan('task.execute');
-    final error = StateError('task failed');
+      final span = diagnostics.startSpan('task.execute');
+      final error = StateError(
+        'login failed for jane@example.com with https://example.test/path?token=secret',
+      );
 
-    span.attachError(error);
+      span.attachError(error);
 
-    final sentrySpan = recorder.currentSpan as _RecordingSentrySpan;
-    expect(sentrySpan.throwable, same(error));
+      final sentrySpan = recorder.currentSpan as _RecordingSentrySpan;
+      expect(sentrySpan.throwable, isNull);
+      expect(sentrySpan.data['errorType'], 'StateError');
+      expect(
+        sentrySpan.data['errorMessage'],
+        'Bad state: login failed for [redacted] with [redacted]',
+      );
 
-    await span.finish(status: const SpanStatus.internalError());
-  });
+      await span.finish(status: const SpanStatus.internalError());
+    },
+  );
 
   test(
     'AppDiagnosticsSpan swallows errors from underlying span methods',

--- a/test/common/logging/app_diagnostics_test.dart
+++ b/test/common/logging/app_diagnostics_test.dart
@@ -1,4 +1,5 @@
 import 'package:dualmate/common/logging/app_diagnostics.dart';
+import 'package:dualmate/common/logging/sentry_scrubber.dart';
 import 'package:sentry/sentry.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -38,14 +39,16 @@ void main() {
 
     expect(recorder.capturedExceptions, hasLength(1));
     final captured = recorder.capturedExceptions.single;
-    expect(captured.exception, same(error));
+    expect(captured.exception, isA<SanitizedDiagnosticsException>());
+    expect(captured.exception.toString(), 'StateError: Bad state: boom');
     expect(captured.stackTrace, same(trace));
     expect(captured.message?.formatted, 'Root init failed');
     expect(captured.tags['feature'], 'startup');
     final diagnosticsContext = captured.contexts['diagnostics'];
     expect(diagnosticsContext, isNotNull);
-    final diagnosticsMap =
-        Map<String, dynamic>.from(diagnosticsContext! as Map<Object?, Object?>);
+    final diagnosticsMap = Map<String, dynamic>.from(
+      diagnosticsContext! as Map<Object?, Object?>,
+    );
     expect(diagnosticsMap['operation'], 'root.initialize');
   });
 
@@ -57,10 +60,7 @@ void main() {
       diagnostics.recordNavigation('drawer.tab.schedule'),
       completes,
     );
-    await expectLater(
-      diagnostics.recordInfo('startup', 'init'),
-      completes,
-    );
+    await expectLater(diagnostics.recordInfo('startup', 'init'), completes);
     await expectLater(
       diagnostics.reportCaughtException(StateError('boom'), StackTrace.current),
       completes,
@@ -86,7 +86,7 @@ void main() {
     final child = parent.startedChildren.single;
     expect(child.operation, 'schedule.refresh');
     expect(child.description, 'refresh visible week');
-    expect(child.data['origin'], 'userBrowsing');
+    expect(child.data.containsKey('origin'), isFalse);
     expect(child.tags['feature'], 'schedule');
 
     await span.finish(status: const SpanStatus.ok());
@@ -137,22 +137,24 @@ void main() {
     expect(transaction.status, const SpanStatus.ok());
   });
 
-  test('startSpan falls back to noop span when recorder span creation fails',
-      () async {
-    final diagnostics = AppDiagnostics(recorder: _FailingStartSpanRecorder());
+  test(
+    'startSpan falls back to noop span when recorder span creation fails',
+    () async {
+      final diagnostics = AppDiagnostics(recorder: _FailingStartSpanRecorder());
 
-    final span = diagnostics.startSpan(
-      'schedule.refresh',
-      description: 'refresh visible week',
-      data: {'origin': 'userBrowsing'},
-      tags: {'feature': 'schedule'},
-    );
+      final span = diagnostics.startSpan(
+        'schedule.refresh',
+        description: 'refresh visible week',
+        data: {'origin': 'userBrowsing'},
+        tags: {'feature': 'schedule'},
+      );
 
-    expect(() => span.setData('key', 'value'), returnsNormally);
-    expect(() => span.setTag('feature', 'schedule'), returnsNormally);
-    expect(() => span.attachError(StateError('boom')), returnsNormally);
-    await expectLater(span.finish(), completes);
-  });
+      expect(() => span.setData('key', 'value'), returnsNormally);
+      expect(() => span.setTag('feature', 'schedule'), returnsNormally);
+      expect(() => span.attachError(StateError('boom')), returnsNormally);
+      await expectLater(span.finish(), completes);
+    },
+  );
 
   test('AppDiagnosticsSpan.attachError records error on span', () async {
     final recorder = _RecordingDiagnosticsRecorder();
@@ -164,24 +166,33 @@ void main() {
     span.attachError(error);
 
     final sentrySpan = recorder.currentSpan as _RecordingSentrySpan;
-    expect(sentrySpan.throwable, same(error));
+    expect(sentrySpan.throwable, isA<SanitizedDiagnosticsException>());
+    expect(
+      sentrySpan.throwable.toString(),
+      'StateError: Bad state: task failed',
+    );
 
     await span.finish(status: const SpanStatus.internalError());
   });
 
-  test('AppDiagnosticsSpan swallows errors from underlying span methods',
-      () async {
-    final recorder = _RecordingDiagnosticsRecorder();
-    recorder.currentSpan = _ThrowingSentrySpan('parent');
-    final diagnostics = AppDiagnostics(recorder: recorder);
+  test(
+    'AppDiagnosticsSpan swallows errors from underlying span methods',
+    () async {
+      final recorder = _RecordingDiagnosticsRecorder();
+      recorder.currentSpan = _ThrowingSentrySpan('parent');
+      final diagnostics = AppDiagnostics(recorder: recorder);
 
-    final span = diagnostics.startSpan('task.execute');
+      final span = diagnostics.startSpan('task.execute');
 
-    expect(() => span.setData('phase', 'startup'), returnsNormally);
-    expect(() => span.setTag('feature', 'task'), returnsNormally);
-    expect(() => span.attachError(StateError('task failed')), returnsNormally);
-    await expectLater(span.finish(status: const SpanStatus.ok()), completes);
-  });
+      expect(() => span.setData('phase', 'startup'), returnsNormally);
+      expect(() => span.setTag('feature', 'task'), returnsNormally);
+      expect(
+        () => span.attachError(StateError('task failed')),
+        returnsNormally,
+      );
+      await expectLater(span.finish(status: const SpanStatus.ok()), completes);
+    },
+  );
 }
 
 class _RecordingDiagnosticsRecorder implements DiagnosticsRecorder {
@@ -370,10 +381,8 @@ class _RecordingSentrySpan extends ISentrySpan {
     String? description,
     DateTime? startTimestamp,
   }) {
-    final child = _RecordingSentrySpan(
-      operation,
-      description: description,
-    )..startTimestamp = startTimestamp ?? DateTime.now();
+    final child = _RecordingSentrySpan(operation, description: description)
+      ..startTimestamp = startTimestamp ?? DateTime.now();
     startedChildren.add(child);
     return child;
   }
@@ -382,11 +391,8 @@ class _RecordingSentrySpan extends ISentrySpan {
   SentryBaggageHeader? toBaggageHeader() => null;
 
   @override
-  SentryTraceHeader toSentryTrace() => SentryTraceHeader(
-        SentryId.newId(),
-        SpanId.newId(),
-        sampled: true,
-      );
+  SentryTraceHeader toSentryTrace() =>
+      SentryTraceHeader(SentryId.newId(), SpanId.newId(), sampled: true);
 
   @override
   SentryTraceContextHeader? traceContext() => null;

--- a/test/common/logging/app_diagnostics_test.dart
+++ b/test/common/logging/app_diagnostics_test.dart
@@ -402,6 +402,16 @@ class _ThrowingSentrySpan extends _RecordingSentrySpan {
   _ThrowingSentrySpan(super.operation);
 
   @override
+  ISentrySpan startChild(
+    String operation, {
+    String? description,
+    DateTime? startTimestamp,
+  }) {
+    return _ThrowingSentrySpan(operation)
+      ..startTimestamp = startTimestamp ?? DateTime.now();
+  }
+
+  @override
   void setData(String key, dynamic value) {
     throw StateError('failed setData');
   }

--- a/test/common/logging/app_diagnostics_test.dart
+++ b/test/common/logging/app_diagnostics_test.dart
@@ -174,6 +174,7 @@ void main() {
         sentrySpan.data['errorMessage'],
         'Bad state: login failed for [redacted] with [redacted]',
       );
+      expect(sentrySpan.status, const SpanStatus.internalError());
 
       await span.finish(status: const SpanStatus.internalError());
     },

--- a/test/common/logging/app_diagnostics_test.dart
+++ b/test/common/logging/app_diagnostics_test.dart
@@ -1,5 +1,4 @@
 import 'package:dualmate/common/logging/app_diagnostics.dart';
-import 'package:dualmate/common/logging/sentry_scrubber.dart';
 import 'package:sentry/sentry.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -39,8 +38,7 @@ void main() {
 
     expect(recorder.capturedExceptions, hasLength(1));
     final captured = recorder.capturedExceptions.single;
-    expect(captured.exception, isA<SanitizedDiagnosticsException>());
-    expect(captured.exception.toString(), 'StateError: Bad state: boom');
+    expect(captured.exception, same(error));
     expect(captured.stackTrace, same(trace));
     expect(captured.message?.formatted, 'Root init failed');
     expect(captured.tags['feature'], 'startup');
@@ -166,11 +164,7 @@ void main() {
     span.attachError(error);
 
     final sentrySpan = recorder.currentSpan as _RecordingSentrySpan;
-    expect(sentrySpan.throwable, isA<SanitizedDiagnosticsException>());
-    expect(
-      sentrySpan.throwable.toString(),
-      'StateError: Bad state: task failed',
-    );
+    expect(sentrySpan.throwable, same(error));
 
     await span.finish(status: const SpanStatus.internalError());
   });

--- a/test/common/logging/sentry_scrubber_test.dart
+++ b/test/common/logging/sentry_scrubber_test.dart
@@ -37,6 +37,33 @@ void main() {
     );
   });
 
+  test('embedded identifiers in free-form strings are redacted', () {
+    expect(
+      sanitizeDiagnosticsValue('Bad state: login failed for jane@example.com'),
+      'Bad state: login failed for $sentryRedactedValue',
+    );
+    expect(
+      sanitizeDiagnosticsValue(
+        'GET https://example.com/path?token=secret failed',
+      ),
+      'GET $sentryRedactedValue failed',
+    );
+    expect(
+      sanitizeDiagnosticsValue('Authorization: Bearer abc.def-123'),
+      'Authorization: $sentryRedactedValue',
+    );
+    expect(
+      sanitizeDiagnosticsValue('request failed id_token=abc.def.ghi'),
+      'request failed id_token=$sentryRedactedValue',
+    );
+    expect(
+      sanitizeDiagnosticsValue(
+        'jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature failed',
+      ),
+      'jwt $sentryRedactedValue failed',
+    );
+  });
+
   test('Dualis, grade, and schedule fields are redacted', () {
     final sanitized = sanitizeDiagnosticsMap({
       'dualis': {'student': 'Jane Example'},
@@ -114,7 +141,7 @@ void main() {
       exceptions: [
         SentryException(
           type: 'StateError',
-          value: 'Dualis grade parse failed: 1.3',
+          value: 'login failed for jane@example.com',
         ),
       ],
     )..contexts['dualis'] = {'grade': '1.3'};
@@ -123,7 +150,10 @@ void main() {
 
     expect(scrubbed.user, isNull);
     expect(scrubbed.transaction, 'dualis');
-    expect(scrubbed.message!.formatted, sentryRedactedValue);
+    expect(
+      scrubbed.message!.formatted,
+      'Schedule failed for $sentryRedactedValue',
+    );
     expect(scrubbed.tags!['feature'], 'schedule');
     expect(scrubbed.tags!['platform'], 'android');
     // ignore: deprecated_member_use
@@ -135,7 +165,10 @@ void main() {
     expect(scrubbed.request!.data, isNull);
     expect(scrubbed.breadcrumbs!.single.message, sentryRedactedValue);
     expect(scrubbed.breadcrumbs!.single.data!['room'], sentryRedactedValue);
-    expect(scrubbed.exceptions!.single.value, sentryRedactedValue);
+    expect(
+      scrubbed.exceptions!.single.value,
+      'login failed for $sentryRedactedValue',
+    );
     expect(scrubbed.contexts['dualis'], sentryRedactedValue);
   });
 

--- a/test/common/logging/sentry_scrubber_test.dart
+++ b/test/common/logging/sentry_scrubber_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(sanitized['feature'], 'startup');
   });
 
-  test('URLs lose query parameters', () {
+  test('URLs are redacted', () {
     final sanitized = sanitizeDiagnosticsMap({
       'endpoint': 'https://example.com/path?token=secret&course=WDCM21B1',
       'nested': {
@@ -30,10 +30,10 @@ void main() {
       },
     });
 
-    expect(sanitized['endpoint'], 'https://example.com/path');
+    expect(sanitized['endpoint'], sentryRedactedValue);
     expect(
       (sanitized['nested'] as Map<String, Object?>)['callback'],
-      'https://dualis.example.test/results',
+      sentryRedactedValue,
     );
   });
 
@@ -51,6 +51,20 @@ void main() {
     expect(sanitized['scheduleEventTitle'], sentryRedactedValue);
     expect(sanitized['room'], sentryRedactedValue);
     expect(sanitized['technicalPhase'], 'startup');
+  });
+
+  test('numeric sensitive fields are redacted', () {
+    final sanitized = sanitizeDiagnosticsMap({
+      'grade': 1.3,
+      'session': 42,
+      'scheduleEventCount': 3,
+      'buildNumber': 42,
+    });
+
+    expect(sanitized['grade'], sentryRedactedValue);
+    expect(sanitized['session'], sentryRedactedValue);
+    expect(sanitized['scheduleEventCount'], sentryRedactedValue);
+    expect(sanitized['buildNumber'], 42);
   });
 
   test('normal technical fields and generic route names remain', () {
@@ -114,7 +128,7 @@ void main() {
     expect(scrubbed.tags!['platform'], 'android');
     // ignore: deprecated_member_use
     expect(scrubbed.extra!['rawUrl'], sentryRedactedValue);
-    expect(scrubbed.request!.url, 'https://example.test/api');
+    expect(scrubbed.request!.url, sentryRedactedValue);
     expect(scrubbed.request!.queryString, isEmpty);
     expect(scrubbed.request!.cookies, isNull);
     expect(scrubbed.request!.headers['Authorization'], sentryRedactedValue);

--- a/test/common/logging/sentry_scrubber_test.dart
+++ b/test/common/logging/sentry_scrubber_test.dart
@@ -1,0 +1,139 @@
+import 'package:dualmate/common/logging/sentry_scrubber.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/sentry.dart';
+
+void main() {
+  test('credentials are redacted from diagnostics maps', () {
+    final sanitized = sanitizeDiagnosticsMap({
+      'username': 'student@example.com',
+      'password': 'correct-horse-battery-staple',
+      'authToken': 'secret-token',
+      'cookie': 'sid=abc',
+      'feature': 'startup',
+    });
+
+    expect(sanitized['username'], sentryRedactedValue);
+    expect(sanitized['password'], sentryRedactedValue);
+    expect(sanitized['authToken'], sentryRedactedValue);
+    expect(sanitized['cookie'], sentryRedactedValue);
+    expect(sanitized['feature'], 'startup');
+  });
+
+  test('URLs lose query parameters', () {
+    final sanitized = sanitizeDiagnosticsMap({
+      'endpoint': 'https://example.com/path?token=secret&course=WDCM21B1',
+      'nested': {
+        'callback': Uri.parse(
+          'https://dualis.example.test/results?session=secret#grades',
+        ),
+      },
+    });
+
+    expect(sanitized['endpoint'], 'https://example.com/path');
+    expect(
+      (sanitized['nested'] as Map<String, Object?>)['callback'],
+      'https://dualis.example.test/results',
+    );
+  });
+
+  test('Dualis, grade, and schedule fields are redacted', () {
+    final sanitized = sanitizeDiagnosticsMap({
+      'dualis': {'student': 'Jane Example'},
+      'grade': '1.3',
+      'scheduleEventTitle': 'Private appointment',
+      'room': 'A.1.23',
+      'technicalPhase': 'startup',
+    });
+
+    expect(sanitized['dualis'], sentryRedactedValue);
+    expect(sanitized['grade'], sentryRedactedValue);
+    expect(sanitized['scheduleEventTitle'], sentryRedactedValue);
+    expect(sanitized['room'], sentryRedactedValue);
+    expect(sanitized['technicalPhase'], 'startup');
+  });
+
+  test('normal technical fields and generic route names remain', () {
+    final sanitized = sanitizeDiagnosticsMap({
+      'appVersion': '2.0.1+42',
+      'platform': 'android',
+      'buildMode': 'release',
+      'route': 'schedule',
+      'transaction': 'dualis',
+    });
+
+    expect(sanitized['appVersion'], '2.0.1+42');
+    expect(sanitized['platform'], 'android');
+    expect(sanitized['buildMode'], 'release');
+    expect(sanitized['route'], 'schedule');
+    expect(sanitized['transaction'], 'dualis');
+    expect(
+      sanitizeRouteName('/schedule/2026-06-13?payload=secret'),
+      'schedule',
+    );
+    expect(sanitizeRouteName('/student/jane@example.com'), 'unknown');
+  });
+
+  test('beforeSend removes user and scrubs event payloads', () {
+    final event = SentryEvent(
+      message: SentryMessage('Schedule failed for jane@example.com'),
+      transaction: '/dualis/results?student=jane',
+      user: SentryUser(id: 'raw-user-id'),
+      tags: {'feature': 'schedule', 'platform': 'android'},
+      // ignore: deprecated_member_use
+      extra: {
+        'rawUrl': 'https://rapla.example.test/calendar?token=secret',
+        'buildMode': 'release',
+      },
+      request: SentryRequest(
+        url: 'https://example.test/api?authorization=secret',
+        cookies: 'sid=secret',
+        headers: {'Authorization': 'Bearer secret', 'Accept': 'json'},
+        data: {'password': 'secret'},
+      ),
+      breadcrumbs: [
+        Breadcrumb(
+          message: 'route with schedule payload',
+          data: {'room': 'A.1.23', 'source': 'navigator'},
+        ),
+      ],
+      exceptions: [
+        SentryException(
+          type: 'StateError',
+          value: 'Dualis grade parse failed: 1.3',
+        ),
+      ],
+    )..contexts['dualis'] = {'grade': '1.3'};
+
+    final scrubbed = scrubSentryEvent(event, Hint())!;
+
+    expect(scrubbed.user, isNull);
+    expect(scrubbed.transaction, 'dualis');
+    expect(scrubbed.message!.formatted, sentryRedactedValue);
+    expect(scrubbed.tags!['feature'], 'schedule');
+    expect(scrubbed.tags!['platform'], 'android');
+    // ignore: deprecated_member_use
+    expect(scrubbed.extra!['rawUrl'], sentryRedactedValue);
+    expect(scrubbed.request!.url, 'https://example.test/api');
+    expect(scrubbed.request!.queryString, isEmpty);
+    expect(scrubbed.request!.cookies, isNull);
+    expect(scrubbed.request!.headers['Authorization'], sentryRedactedValue);
+    expect(scrubbed.request!.data, isNull);
+    expect(scrubbed.breadcrumbs!.single.message, sentryRedactedValue);
+    expect(scrubbed.breadcrumbs!.single.data!['room'], sentryRedactedValue);
+    expect(scrubbed.exceptions!.single.value, sentryRedactedValue);
+    expect(scrubbed.contexts['dualis'], sentryRedactedValue);
+  });
+
+  test('route settings sanitizer keeps only stable route names', () {
+    final sanitized = sanitizeSentryRouteSettings(
+      const RouteSettings(
+        name: '/canteen/day?date=2026-06-13',
+        arguments: {'payload': 'menu details'},
+      ),
+    );
+
+    expect(sanitized!.name, 'canteen');
+    expect(sanitized.arguments, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Added a Sentry scrubber that redacts sensitive diagnostics data, strips URL/query details, sanitizes breadcrumbs/transactions, and removes user context before events leave the app.
- Reworked `AppDiagnostics` to sanitize breadcrumb data, exception payloads, tags, contexts, and span metadata before recording.
- Disabled privacy-sensitive Sentry features including session replay, user interaction breadcrumbs/tracing, and release logging, while keeping crash reporting and low-sample performance tracing enabled.
- Reduced release logging noise by gating debug output behind `kDebugMode` and tightened route handling so transactions use stable generic names only.
- Added documentation and focused tests covering the new diagnostics sanitization behavior.

## Testing
- Not run.
- Added/updated unit tests for `AppDiagnostics` sanitization behavior.
- Added unit tests for `sentry_scrubber.dart` covering breadcrumb, event, transaction, request, and throwable redaction paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Sentry diagnostics scrubber to automatically sanitize sensitive fields in events, transactions, and breadcrumbs (including route normalization and credential/ID/query redaction).

* **Chores**
  * Gated navigation/schedule/root logging to debug builds using `debugPrint`.
  * Updated Sentry configuration to reduce telemetry noise and fully disable session/error replay and user-interaction breadcrumbs.

* **Tests**
  * Added dedicated tests for scrubber sanitization and end-to-end Sentry event scrubbing.
  * Updated diagnostics/span assertions and behavior checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->