### PR TITLE
Rename app copy for DHBW-wide support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Bisher verfügbare Funktionen:
 - Offline modus: Du kannst auf deinen Vorlesungsplan zugreifen, auch wenn du keine Internetverbindung hast
 - Benachrichtigung am Vorabend zum nächsten Tag
 - Benachrichtigung, wenn sich etwas im Plan geändert hat
-- Integration der [Termindatenbank](https://it.dhbw-stuttgart.de/DHermine/) der DHBW Stuttgart
+- Integration der [Termindatenbank](https://it.dhbw-stuttgart.de/DHermine/) der DHBW
 - Rapla-Termine (Klausuren, Klausurwochen, Feiertage) auf der Terminseite
 - Mensa-Speiseplan für die DHBW Karlsruhe inklusive Home-Screen-Widget
 - Mehrtägige Home-Screen-Widgets für Vorlesungsplan und Mensa (adaptive Höhe)
@@ -37,7 +37,7 @@ Bisher verfügbare Funktionen:
 - Landscape support on phones and tablets
 
 
-Diese App ist optimiert für die DHBW Stuttgart und manche Funktionen werden  an anderen Standorten möglicherweise nicht unterstützt. Dies ist kein offizielles Angebot der DHBW Stuttgart und wurde von Studenten in Eigeninitiative entwickelt!
+Diese App ist für alle DHBW-Standorte verfügbar. Dies ist kein offizielles Angebot der DHBW und wurde von Studenten in Eigeninitiative entwickelt!
 
 
 

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -10,7 +10,7 @@ final de = {
   "calendarSyncPageBeginSync": "Kalender synchronisieren",
   "applicationName": "DualMate",
   "applicationLegalese":
-      "Entwickelt von FarisZR, basierend auf der Arbeit von Benedikt Kolb. Dies ist keine offizielle App der DHBW Stuttgart und wird in Eigeninitiative entwickelt.",
+      "Entwickelt von FarisZR, basierend auf der Arbeit von Benedikt Kolb. Dies ist keine offizielle App der DHBW und wird in Eigeninitiative entwickelt.",
   "settingsAbout": "Über DualMate",
   "settingsAboutTitle": "Über",
   "settingsDarkMode": "Dark mode",
@@ -31,7 +31,7 @@ final de = {
   "notificationNextClassTomorrow": "Morgen geht's los mit %0 um %1!",
   "notificationNextClassTitle": "Nächste Vorlesung",
   "disclaimer":
-      "Dies ist keine offizielle App der DHBW Stuttgart. Es besteht keine Garantie für Korrektheit und Vollständigkeit der angezeigten Daten!",
+      "Dies ist keine offizielle App der DHBW. Es besteht keine Garantie für Korrektheit und Vollständigkeit der angezeigten Daten!",
   "notificationScheduleChangedNewClass": "Weitere Vorlesung: %0 am %1 um %2",
   "notificationScheduleChangedNewClassTitle": "Weitere Vorlesung",
   "notificationScheduleChangedRemovedClass": "%0 am %1 um %2 entfällt",

--- a/lib/common/i18n/localization_strings_en.dart
+++ b/lib/common/i18n/localization_strings_en.dart
@@ -5,7 +5,7 @@ final en = {
   "settingsViewSourceCode": "View the source code on GitHub",
   "applicationName": "DualMate",
   "applicationLegalese":
-      "Developed by FarisZR, based on the work of Benedikt Kolb. This is not an official app of the DHBW Stuttgart.",
+      "Developed by FarisZR, based on the work of Benedikt Kolb. This is not an official app of the DHBW.",
   "settingsAbout": "About this app",
   "settingsAboutTitle": "About",
   "settingsDarkMode": "Dark mode",
@@ -24,7 +24,7 @@ final en = {
   "notificationNextClassTomorrow": "Tomorrow starts with %0 at %1!",
   "notificationNextClassTitle": "Next class",
   "disclaimer":
-      "This is not an official DHBW Stuttgart app. There is no warranty for the correctness and completeness of the displayed data!",
+      "This is not an official DHBW app. There is no warranty for the correctness and completeness of the displayed data!",
   "notificationScheduleChangedNewClass": "New class: %0 on %1 at %2",
   "notificationScheduleChangedNewClassTitle": "New class",
   "notificationScheduleChangedRemovedClass":

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dualmate
-description: An app for the DHBW Stuttgart
+description: An app for the DHBW
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43


### PR DESCRIPTION
## Summary
- Updates the app description to refer to the DHBW generally instead of DHBW Stuttgart.
- Refreshes English and German legal/disclaimer strings to match the broader DHBW branding.
- Adjusts the README copy to remove Stuttgart-specific wording and describe the app as available across DHBW locations.

## Testing
- Not run (copy-only change).
- Reviewed updated strings in `lib/common/i18n/localization_strings_en.dart` and `lib/common/i18n/localization_strings_de.dart` for consistency.
- Verified `pubspec.yaml` description and `README.md` wording were updated to the new DHBW phrasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app description and localization strings to reflect updated branding, removing location-specific references from DHBW mentions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->