### PR TITLE
Add pull to refresh in the dates page

### DIFF
--- a/docs/solutions/ui-bugs/dates-page-pull-to-refresh-20260621.md
+++ b/docs/solutions/ui-bugs/dates-page-pull-to-refresh-20260621.md
@@ -1,0 +1,46 @@
+---
+module: Date Management
+date: 2026-06-21
+problem_type: feature
+component: Dates page UI
+root_cause: missing_interaction
+resolution_type: code_addition
+severity: low
+tags: [rapla, dates, refresh, ui]
+---
+
+# Pull-to-refresh on the Dates page
+
+## Problem
+
+The Dates page had no way to manually trigger a refresh of its content.
+Users had to navigate away or wait for background/lifecycle refreshes to
+pick up new Rapla important events or DHmine date entries.
+
+## Solution
+
+Wrapped the Dates page data views in a `RefreshIndicator` that calls
+`DateManagementViewModel.updateDates()`.
+
+- `lib/date_management/ui/date_management_page.dart` `_buildContent`:
+  - Rapla mode (important events list): wrapped in `RefreshIndicator`; the
+    underlying `ListView`/`ListView.separated` got
+    `AlwaysScrollableScrollPhysics` so the indicator arms even when the list
+    content is shorter than the viewport.
+  - DHmine mode (DataTable): wrapped in `RefreshIndicator` with an outer
+    `SingleChildScrollView` (`AlwaysScrollableScrollPhysics`) so the
+    non-scrollable DataTable can overscroll.
+  - The empty state and invalid-Rapla-URL banner are setup prompts and are
+    intentionally left without `RefreshIndicator` (they contain a
+    `LayoutBuilder`-based placeholder that is incompatible with intrinsic
+    layout, and refreshing a setup prompt is not meaningful).
+
+## Notes
+
+- `updateDates()` already cancels in-flight updates via `_updateMutex`, so it
+  is safe to call from the indicator.
+- During a pull-to-refresh the existing `LinearProgressIndicator` header may
+  also show because `updateDates` notifies `isLoading`; the
+  `RefreshIndicator` spinner is the primary affordance.
+- Widget tests in `test/date_management/ui/date_management_page_test.dart`
+  verify that pulling triggers `updateDates()` in both Rapla and DHmine modes.

--- a/ios/Flutter/ephemeral/flutter_native_integration.env
+++ b/ios/Flutter/ephemeral/flutter_native_integration.env
@@ -1,6 +1,6 @@
 FLUTTER_ROOT=/home/farahmani/flutter/flutter
-FLUTTER_APPLICATION_PATH=/home/farahmani/.synara/worktrees/DualMate/synara-fdcaeb9c
-FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=/home/farahmani/.synara/worktrees/DualMate/synara-fdcaeb9c/ios/Flutter/ephemeral/Packages/.packages/FlutterFramework
+FLUTTER_APPLICATION_PATH=/home/farahmani/.synara/worktrees/DualMate/synara-a12b95cf
+FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=/home/farahmani/.synara/worktrees/DualMate/synara-a12b95cf/ios/Flutter/ephemeral/Packages/.packages/FlutterFramework
 COCOAPODS_PARALLEL_CODE_SIGN=true
 FLUTTER_TARGET=lib/main.dart
 FLUTTER_BUILD_DIR=build

--- a/ios/Flutter/ephemeral/flutter_native_integration.env
+++ b/ios/Flutter/ephemeral/flutter_native_integration.env
@@ -1,0 +1,12 @@
+FLUTTER_ROOT=/home/farahmani/flutter/flutter
+FLUTTER_APPLICATION_PATH=/home/farahmani/.synara/worktrees/DualMate/synara-fdcaeb9c
+FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=/home/farahmani/.synara/worktrees/DualMate/synara-fdcaeb9c/ios/Flutter/ephemeral/Packages/.packages/FlutterFramework
+COCOAPODS_PARALLEL_CODE_SIGN=true
+FLUTTER_TARGET=lib/main.dart
+FLUTTER_BUILD_DIR=build
+FLUTTER_BUILD_NAME=2.0.0
+FLUTTER_BUILD_NUMBER=39
+DART_OBFUSCATION=false
+TRACK_WIDGET_CREATION=true
+TREE_SHAKE_ICONS=false
+PACKAGE_CONFIG=.dart_tool/package_config.json

--- a/lib/date_management/ui/date_management_page.dart
+++ b/lib/date_management/ui/date_management_page.dart
@@ -231,7 +231,13 @@ class _DateManagementPageState extends State<DateManagementPage> {
 
   Widget _buildContent(DateManagementViewModel model, BuildContext context) {
     if (model.useDhMineForDates) {
-      return _buildAllDatesDataTable(model, context);
+      return _wrapWithRefresh(
+        model,
+        SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: _buildAllDatesDataTable(model, context),
+        ),
+      );
     }
 
     if (model.bothSourcesUnconfigured) {
@@ -261,7 +267,11 @@ class _DateManagementPageState extends State<DateManagementPage> {
       );
     }
 
-    return _buildImportantEventsList(model, context);
+    return _wrapWithRefresh(model, _buildImportantEventsList(model, context));
+  }
+
+  Widget _wrapWithRefresh(DateManagementViewModel model, Widget child) {
+    return RefreshIndicator(onRefresh: () => model.updateDates(), child: child);
   }
 
   Widget _buildImportantEventsList(
@@ -273,6 +283,7 @@ class _DateManagementPageState extends State<DateManagementPage> {
       _scheduleRaplaAutoload(model);
       return ListView(
         controller: _raplaScrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(16),
         children: [
           if (!model.isLoading && !model.isLoadingNextRaplaPage)
@@ -294,6 +305,7 @@ class _DateManagementPageState extends State<DateManagementPage> {
       },
       child: ListView.separated(
         controller: _raplaScrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         cacheExtent: _importantEventsCacheExtent,
         itemBuilder: (context, index) {

--- a/lib/date_management/ui/date_management_page.dart
+++ b/lib/date_management/ui/date_management_page.dart
@@ -231,9 +231,9 @@ class _DateManagementPageState extends State<DateManagementPage> {
 
   Widget _buildContent(DateManagementViewModel model, BuildContext context) {
     if (model.useDhMineForDates) {
-      return _wrapWithRefresh(
-        model,
-        SingleChildScrollView(
+      return RefreshIndicator(
+        onRefresh: () => model.updateDates(),
+        child: SingleChildScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
           child: _buildAllDatesDataTable(model, context),
         ),
@@ -267,11 +267,10 @@ class _DateManagementPageState extends State<DateManagementPage> {
       );
     }
 
-    return _wrapWithRefresh(model, _buildImportantEventsList(model, context));
-  }
-
-  Widget _wrapWithRefresh(DateManagementViewModel model, Widget child) {
-    return RefreshIndicator(onRefresh: () => model.updateDates(), child: child);
+    return RefreshIndicator(
+      onRefresh: () => model.updateDates(),
+      child: _buildImportantEventsList(model, context),
+    );
   }
 
   Widget _buildImportantEventsList(

--- a/test/date_management/ui/date_management_page_test.dart
+++ b/test/date_management/ui/date_management_page_test.dart
@@ -72,6 +72,58 @@ void main() {
     viewModel.dispose();
   });
 
+  testWidgets('pull to refresh triggers updateDates in rapla mode',
+      (WidgetTester tester) async {
+    final viewModel = _buildRefreshTrackingViewModel(
+      useDhMineForDates: false,
+      raplaUrl: 'https://rapla.dhbw-stuttgart.de/rapla?key=abc',
+      importantEvents: _sampleEvents(),
+    );
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await tester.pump(const Duration(milliseconds: 420));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+
+    final before = viewModel.updateDatesCalls;
+    await tester.drag(find.byType(RefreshIndicator), const Offset(0, 250));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(viewModel.updateDatesCalls, greaterThan(before));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    viewModel.dispose();
+  });
+
+  testWidgets('pull to refresh triggers updateDates in DHmine mode',
+      (WidgetTester tester) async {
+    final viewModel = _buildRefreshTrackingViewModel(
+      useDhMineForDates: true,
+      raplaUrl: '',
+      importantEvents: const [],
+    );
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await tester.pump(const Duration(milliseconds: 420));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+
+    final before = viewModel.updateDatesCalls;
+    await tester.drag(find.byType(RefreshIndicator), const Offset(0, 250));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(viewModel.updateDatesCalls, greaterThan(before));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    viewModel.dispose();
+  });
+
   testWidgets('defers dates initialization to keep first drawer open smooth',
       (WidgetTester tester) async {
     final viewModel = _buildTrackingViewModel(
@@ -174,6 +226,35 @@ _TrackingDateManagementViewModel _buildTrackingViewModel({
   );
 }
 
+_RefreshTrackingDateManagementViewModel _buildRefreshTrackingViewModel({
+  required bool useDhMineForDates,
+  required String raplaUrl,
+  List<ImportantEvent> importantEvents = const [],
+}) {
+  final preferencesAccess = _FakePreferencesAccess({
+    PreferencesProvider.UseDhMineForDates: useDhMineForDates,
+    PreferencesProvider.RaplaUrlKey: raplaUrl,
+    PreferencesProvider.LastViewedDateEntryDatabase: '',
+    PreferencesProvider.LastViewedDateEntryYear: DateTime.now().year.toString(),
+  });
+  final preferencesProvider = PreferencesProvider(
+    preferencesAccess,
+    _FakeSecureStorageAccess(),
+  );
+
+  final dateEntryProvider = _FakeDateEntryProvider();
+  final raplaProvider = _FakeRaplaImportantEventsProvider(
+    preferencesProvider,
+    importantEvents,
+  );
+
+  return _RefreshTrackingDateManagementViewModel(
+    dateEntryProvider,
+    preferencesProvider,
+    raplaProvider,
+  );
+}
+
 class _TrackingDateManagementViewModel extends DateManagementViewModel {
   int initializeCalls = 0;
 
@@ -190,6 +271,27 @@ class _TrackingDateManagementViewModel extends DateManagementViewModel {
   @override
   void initialize() {
     initializeCalls += 1;
+  }
+}
+
+class _RefreshTrackingDateManagementViewModel
+    extends DateManagementViewModel {
+  int updateDatesCalls = 0;
+
+  _RefreshTrackingDateManagementViewModel(
+    DateEntryProvider dateEntryProvider,
+    PreferencesProvider preferencesProvider,
+    RaplaImportantEventsProvider raplaImportantEventsProvider,
+  ) : super(
+          dateEntryProvider,
+          preferencesProvider,
+          raplaImportantEventsProvider,
+        );
+
+  @override
+  Future<void> updateDates() async {
+    updateDatesCalls += 1;
+    return super.updateDates();
   }
 }
 

--- a/test/date_management/ui/date_management_page_test.dart
+++ b/test/date_management/ui/date_management_page_test.dart
@@ -74,7 +74,7 @@ void main() {
 
   testWidgets('pull to refresh triggers updateDates in rapla mode',
       (WidgetTester tester) async {
-    final viewModel = _buildRefreshTrackingViewModel(
+    final viewModel = _buildViewModel(
       useDhMineForDates: false,
       raplaUrl: 'https://rapla.dhbw-stuttgart.de/rapla?key=abc',
       importantEvents: _sampleEvents(),
@@ -100,7 +100,7 @@ void main() {
 
   testWidgets('pull to refresh triggers updateDates in DHmine mode',
       (WidgetTester tester) async {
-    final viewModel = _buildRefreshTrackingViewModel(
+    final viewModel = _buildViewModel(
       useDhMineForDates: true,
       raplaUrl: '',
       importantEvents: const [],
@@ -126,7 +126,7 @@ void main() {
 
   testWidgets('defers dates initialization to keep first drawer open smooth',
       (WidgetTester tester) async {
-    final viewModel = _buildTrackingViewModel(
+    final viewModel = _buildViewModel(
       useDhMineForDates: false,
       raplaUrl: 'https://rapla.dhbw-stuttgart.de/rapla?key=abc',
       importantEvents: _sampleEvents(),
@@ -168,36 +168,7 @@ Widget _wrapWithApp(DateManagementViewModel viewModel) {
   );
 }
 
-DateManagementViewModel _buildViewModel({
-  required bool useDhMineForDates,
-  required String raplaUrl,
-  List<ImportantEvent> importantEvents = const [],
-}) {
-  final preferencesAccess = _FakePreferencesAccess({
-    PreferencesProvider.UseDhMineForDates: useDhMineForDates,
-    PreferencesProvider.RaplaUrlKey: raplaUrl,
-    PreferencesProvider.LastViewedDateEntryDatabase: '',
-    PreferencesProvider.LastViewedDateEntryYear: DateTime.now().year.toString(),
-  });
-  final preferencesProvider = PreferencesProvider(
-    preferencesAccess,
-    _FakeSecureStorageAccess(),
-  );
-
-  final dateEntryProvider = _FakeDateEntryProvider();
-  final raplaProvider = _FakeRaplaImportantEventsProvider(
-    preferencesProvider,
-    importantEvents,
-  );
-
-  return DateManagementViewModel(
-    dateEntryProvider,
-    preferencesProvider,
-    raplaProvider,
-  );
-}
-
-_TrackingDateManagementViewModel _buildTrackingViewModel({
+_TrackingDateManagementViewModel _buildViewModel({
   required bool useDhMineForDates,
   required String raplaUrl,
   List<ImportantEvent> importantEvents = const [],
@@ -226,37 +197,9 @@ _TrackingDateManagementViewModel _buildTrackingViewModel({
   );
 }
 
-_RefreshTrackingDateManagementViewModel _buildRefreshTrackingViewModel({
-  required bool useDhMineForDates,
-  required String raplaUrl,
-  List<ImportantEvent> importantEvents = const [],
-}) {
-  final preferencesAccess = _FakePreferencesAccess({
-    PreferencesProvider.UseDhMineForDates: useDhMineForDates,
-    PreferencesProvider.RaplaUrlKey: raplaUrl,
-    PreferencesProvider.LastViewedDateEntryDatabase: '',
-    PreferencesProvider.LastViewedDateEntryYear: DateTime.now().year.toString(),
-  });
-  final preferencesProvider = PreferencesProvider(
-    preferencesAccess,
-    _FakeSecureStorageAccess(),
-  );
-
-  final dateEntryProvider = _FakeDateEntryProvider();
-  final raplaProvider = _FakeRaplaImportantEventsProvider(
-    preferencesProvider,
-    importantEvents,
-  );
-
-  return _RefreshTrackingDateManagementViewModel(
-    dateEntryProvider,
-    preferencesProvider,
-    raplaProvider,
-  );
-}
-
 class _TrackingDateManagementViewModel extends DateManagementViewModel {
   int initializeCalls = 0;
+  int updateDatesCalls = 0;
 
   _TrackingDateManagementViewModel(
     DateEntryProvider dateEntryProvider,
@@ -271,22 +214,8 @@ class _TrackingDateManagementViewModel extends DateManagementViewModel {
   @override
   void initialize() {
     initializeCalls += 1;
+    super.initialize();
   }
-}
-
-class _RefreshTrackingDateManagementViewModel
-    extends DateManagementViewModel {
-  int updateDatesCalls = 0;
-
-  _RefreshTrackingDateManagementViewModel(
-    DateEntryProvider dateEntryProvider,
-    PreferencesProvider preferencesProvider,
-    RaplaImportantEventsProvider raplaImportantEventsProvider,
-  ) : super(
-          dateEntryProvider,
-          preferencesProvider,
-          raplaImportantEventsProvider,
-        );
 
   @override
   Future<void> updateDates() async {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull-to-refresh support to the date management interface, allowing users to refresh their date information with a simple swipe-down gesture across all date source configurations.

* **Tests**
  * Added comprehensive test coverage for pull-to-refresh functionality across different date source modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->