### PR TITLE
Speed up refresh for unfetched empty schedule weeks

### DIFF
--- a/docs/solutions/ui-bugs/schedule-unknown-empty-week-fast-refresh-20260621.md
+++ b/docs/solutions/ui-bugs/schedule-unknown-empty-week-fast-refresh-20260621.md
@@ -1,0 +1,50 @@
+---
+module: Schedule UI
+date: 2026-06-21
+problem_type: ui_bug
+component: weekly_schedule
+symptoms:
+  - "Unloaded weeks with empty cache looked like genuinely empty weeks"
+  - "Visible-week first load waited for the slow stale-check debounce"
+root_cause: state_modeling
+resolution_type: code_fix
+severity: medium
+tags: [schedule, weekly, cache, refresh, pager, metadata]
+---
+
+# Troubleshooting: Unknown Empty Weeks Stay Blank Until Manual Refresh
+
+## Problem
+After the schedule pager was optimized to avoid refresh work during active
+swipes, newly visited weeks could render from an empty cache and then wait for
+the normal visible-week stale-check debounce. Users saw a blank week long
+enough to read it as genuinely empty.
+
+## Cause
+The weekly view model treated "empty cache" and "already fetched but empty" too
+similarly. It only had in-memory freshness gates, so an empty week with no
+entries could be unknown after app restart or after browsing into a new window.
+
+## Fix
+- Keep cache-first week opening.
+- Track fetched windows separately from stale/fresh timing.
+- Use persisted schedule query metadata to recognize known empty weeks.
+- When the committed visible week has an empty cache and no query metadata,
+  schedule a short request-aware forced refresh instead of waiting for the
+  long stale-check debounce.
+- Keep the slow debounce for known weeks so browsing does not start network
+  refreshes for intermediate pages.
+
+## Guardrails
+- Scheduled initial refreshes verify the view model is mounted, the original
+  open request is still current, the target week is still visible, the schedule
+  source is queryable, and the week still lacks query metadata.
+- Background refreshes still avoid mutating visible state when requested for
+  widget/range maintenance.
+- Adjacent prefetch remains cache-only.
+
+## Related files
+- `lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart`
+- `lib/schedule/business/schedule_provider.dart`
+- `test/schedule/ui/viewmodels/weekly_schedule_view_model_pager_test.dart`
+- `test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart`

--- a/lib/schedule/business/schedule_provider.dart
+++ b/lib/schedule/business/schedule_provider.dart
@@ -99,6 +99,24 @@ class ScheduleProvider {
     return cachedSchedule;
   }
 
+  Future<DateTime?> getLastQueryTimeForWindow(
+    DateTime start,
+    DateTime end,
+  ) async {
+    final queryInformation = await _scheduleQueryInformationRepository
+        .getQueryInformationBetweenDates(start, end);
+
+    DateTime? newestQueryTime;
+    for (final information in queryInformation) {
+      final queryTime = information.queryTime;
+      if (newestQueryTime == null || queryTime.isAfter(newestQueryTime)) {
+        newestQueryTime = queryTime;
+      }
+    }
+
+    return newestQueryTime;
+  }
+
   Future<ScheduleQueryResult> getUpdatedSchedule(
     DateTime start,
     DateTime end,

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -566,8 +566,10 @@ class WeeklyScheduleViewModel extends BaseViewModel {
           cancellationToken,
           origin: origin,
         );
-        _freshnessGate.markFetched(start, end, now);
-        _markWindowFetched(start, end, now);
+        if (updatedSchedule != null) {
+          _freshnessGate.markFetched(start, end, now);
+          _markWindowFetched(start, end, now);
+        }
       } on OperationCancelledException {
         return;
       } catch (e, stack) {
@@ -766,7 +768,17 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     DateTime end, {
     bool Function()? isCurrentRequest,
   }) async {
-    if (await _visibleWeekNeedsInitialFetch(start, end)) {
+    if (isCurrentRequest != null && !isCurrentRequest()) {
+      return;
+    }
+
+    final needsInitialFetch = await _visibleWeekNeedsInitialFetch(start, end);
+
+    if (isCurrentRequest != null && !isCurrentRequest()) {
+      return;
+    }
+
+    if (needsInitialFetch) {
       _scheduleVisibleInitialRefresh(
         start,
         end,
@@ -874,6 +886,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     DateTime end, {
     bool Function()? isCurrentRequest,
   }) {
+    if (isCurrentRequest != null && !isCurrentRequest()) {
+      return;
+    }
     _visibleRefreshDebounce?.cancel();
     _visibleInitialRefreshTimer?.cancel();
     _visibleInitialRefreshTimer = Timer(_visibleInitialRefreshDelay, () async {

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -29,6 +29,9 @@ void _debugScheduleError(String message, Object error, StackTrace trace) {
 class WeeklyScheduleViewModel extends BaseViewModel {
   static const Duration weekDuration = Duration(days: 7);
   static const Duration _initialRefreshDelay = Duration(seconds: 8);
+  static const Duration _visibleInitialRefreshDelay = Duration(
+    milliseconds: 80,
+  );
   static const Duration _visibleRefreshDebounceDelay = Duration(
     milliseconds: 2500,
   );
@@ -70,6 +73,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   Schedule? weekSchedule;
   Schedule? _lastCachedSchedule;
   final Map<String, ScheduleFreshnessGate> _windowFreshnessGates = {};
+  final Set<String> _knownFetchedWindows = <String>{};
   final Map<String, Schedule> _memoryWeekCache = {};
   final Map<String, Future<void>> _prefetchInFlight = {};
   Timer? _windowRefreshTimer;
@@ -82,12 +86,17 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     if (!_hasCurrentDateRange) {
       return false;
     }
+    if (!scheduleSourceProvider.didSetupCorrectly() ||
+        !scheduleSourceProvider.currentScheduleSource.canQuery()) {
+      return false;
+    }
     return _needsInitialFetchForWindow(currentDateStart, currentDateEnd);
   }
 
   Timer? _errorResetTimer;
   Timer? _updateNowTimer;
   Timer? _visibleRefreshDebounce;
+  Timer? _visibleInitialRefreshTimer;
   Timer? _initialRefreshTimer;
 
   bool _isDisposed = false;
@@ -238,6 +247,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       try {
         _memoryWeekCache.clear();
         _windowFreshnessGates.clear();
+        _knownFetchedWindows.clear();
         _lastWarmedWeekStart = null;
         _freshnessGate.reset();
         _entryRefreshGate.reset();
@@ -311,21 +321,21 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     final nextStart = toNextWeek(currentDateStart);
     final nextEnd = toNextWeek(currentDateEnd);
     await _openWeekFromCache(nextStart, nextEnd);
-    _debounceVisibleRefresh(nextStart, nextEnd);
+    await _scheduleVisibleRefreshAfterOpen(nextStart, nextEnd);
   }
 
   Future previousWeek() async {
     final previousStart = toPreviousWeek(currentDateStart);
     final previousEnd = toPreviousWeek(currentDateEnd);
     await _openWeekFromCache(previousStart, previousEnd);
-    _debounceVisibleRefresh(previousStart, previousEnd);
+    await _scheduleVisibleRefreshAfterOpen(previousStart, previousEnd);
   }
 
   Future goToToday() async {
     currentDateStart = toStartOfDay(toDayOfWeek(now, DateTime.monday));
     currentDateEnd = toNextWeek(currentDateStart);
     await _openWeekFromCache(currentDateStart, currentDateEnd);
-    _debounceVisibleRefresh(currentDateStart, currentDateEnd);
+    await _scheduleVisibleRefreshAfterOpen(currentDateStart, currentDateEnd);
   }
 
   Future openWeekContaining(
@@ -340,7 +350,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       isCurrentRequest: isCurrentRequest,
     );
     if (isCurrentRequest == null || isCurrentRequest()) {
-      _debounceVisibleRefresh(weekStart, weekEnd);
+      await _scheduleVisibleRefreshAfterOpen(
+        weekStart,
+        weekEnd,
+        isCurrentRequest: isCurrentRequest,
+      );
     }
   }
 
@@ -358,6 +372,8 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     final weekEnd = toNextWeek(weekStart);
     _lockWidgetWeek(weekStart, weekEnd);
     _updateMutex.cancel();
+    _visibleInitialRefreshTimer?.cancel();
+    _visibleRefreshDebounce?.cancel();
 
     await _openWeekFromCache(weekStart, weekEnd);
     await updateSchedule(weekStart, weekEnd, force: true);
@@ -446,6 +462,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         visibleUpdateRequestId: visibleUpdateRequestId,
         applyToVisibleState: applyToVisibleState,
         awaitRefresh: awaitRefresh,
+        forceRefresh: force,
         origin: applyToVisibleState
             ? ScheduleRefreshOrigin.userBrowsing
             : ScheduleRefreshOrigin.foregroundMaintenance,
@@ -464,6 +481,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     int? visibleUpdateRequestId,
     bool applyToVisibleState = true,
     bool awaitRefresh = false,
+    bool forceRefresh = false,
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
   }) async {
     final task = PerformanceTelemetry.instance.startTask(
@@ -499,9 +517,11 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
     final nowValue = now;
     final shouldForceFetch =
+        forceRefresh ||
         awaitRefresh ||
         (cachedSchedule.entries.isEmpty &&
-            scheduleSourceProvider.currentScheduleSource.canQuery());
+            scheduleSourceProvider.currentScheduleSource.canQuery() &&
+            !await _isKnownFetchedWindow(start, end));
     final isStale = shouldForceFetch || _isWindowStale(start, end, nowValue);
 
     if (!isStale) {
@@ -688,13 +708,74 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   }
 
   bool _needsInitialFetchForWindow(DateTime start, DateTime end) {
-    return !_windowFreshnessGates.containsKey(_windowKey(start, end));
+    final cacheKey = _windowKey(start, end);
+    final schedule = currentDateStart == start && currentDateEnd == end
+        ? weekSchedule
+        : _memoryWeekCache[cacheKey];
+    if (schedule == null || schedule.entries.isNotEmpty) {
+      return false;
+    }
+    return !_knownFetchedWindows.contains(cacheKey);
   }
 
   void _markWindowFetched(DateTime start, DateTime end, DateTime now) {
     var key = _windowKey(start, end);
+    _knownFetchedWindows.add(key);
     var gate = _windowFreshnessGates[key] ??= ScheduleFreshnessGate();
     gate.markFetched(start, end, now);
+  }
+
+  Future<bool> _isKnownFetchedWindow(DateTime start, DateTime end) async {
+    final key = _windowKey(start, end);
+    if (_knownFetchedWindows.contains(key)) {
+      return true;
+    }
+
+    final queryTime = await scheduleProvider.getLastQueryTimeForWindow(
+      start,
+      end,
+    );
+    if (queryTime == null) {
+      return false;
+    }
+
+    _markWindowFetched(start, end, queryTime);
+    return true;
+  }
+
+  Future<bool> _visibleWeekNeedsInitialFetch(
+    DateTime start,
+    DateTime end,
+  ) async {
+    if (_isDisposed) return false;
+    if (currentDateStart != start || currentDateEnd != end) {
+      return false;
+    }
+    if (!scheduleSourceProvider.didSetupCorrectly() ||
+        !scheduleSourceProvider.currentScheduleSource.canQuery()) {
+      return false;
+    }
+    if (!_needsInitialFetchForWindow(start, end)) {
+      return false;
+    }
+    return !await _isKnownFetchedWindow(start, end);
+  }
+
+  Future<void> _scheduleVisibleRefreshAfterOpen(
+    DateTime start,
+    DateTime end, {
+    bool Function()? isCurrentRequest,
+  }) async {
+    if (await _visibleWeekNeedsInitialFetch(start, end)) {
+      _scheduleVisibleInitialRefresh(
+        start,
+        end,
+        isCurrentRequest: isCurrentRequest,
+      );
+      return;
+    }
+
+    _debounceVisibleRefresh(start, end);
   }
 
   String _windowKey(DateTime start, DateTime end) {
@@ -780,10 +861,31 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   }
 
   void _debounceVisibleRefresh(DateTime start, DateTime end) {
+    _visibleInitialRefreshTimer?.cancel();
     _visibleRefreshDebounce?.cancel();
     _visibleRefreshDebounce = Timer(_visibleRefreshDebounceDelay, () {
       if (_isDisposed) return;
       unawaited(updateSchedule(start, end));
+    });
+  }
+
+  void _scheduleVisibleInitialRefresh(
+    DateTime start,
+    DateTime end, {
+    bool Function()? isCurrentRequest,
+  }) {
+    _visibleRefreshDebounce?.cancel();
+    _visibleInitialRefreshTimer?.cancel();
+    _visibleInitialRefreshTimer = Timer(_visibleInitialRefreshDelay, () async {
+      if (_isDisposed) return;
+      if (isCurrentRequest != null && !isCurrentRequest()) return;
+      if (currentDateStart != start || currentDateEnd != end) return;
+      if (!await _visibleWeekNeedsInitialFetch(start, end)) return;
+      if (_isDisposed) return;
+      if (isCurrentRequest != null && !isCurrentRequest()) return;
+      if (currentDateStart != start || currentDateEnd != end) return;
+
+      unawaited(updateSchedule(start, end, force: true));
     });
   }
 
@@ -803,6 +905,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     final retained = sortedKeys.take(_maxRetainedWeeks).toSet();
     _memoryWeekCache.removeWhere((key, _) => !retained.contains(key));
     _windowFreshnessGates.removeWhere((key, _) => !retained.contains(key));
+    _knownFetchedWindows.removeWhere((key) => !retained.contains(key));
   }
 
   int _windowDistanceFromCenter(String key, DateTime centerWeekStart) {
@@ -829,6 +932,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     _updateNowTimer?.cancel();
     _windowRefreshTimer?.cancel();
     _visibleRefreshDebounce?.cancel();
+    _visibleInitialRefreshTimer?.cancel();
     _initialRefreshTimer?.cancel();
 
     _errorResetTimer?.cancel();

--- a/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
@@ -279,6 +279,14 @@ class _FakeScheduleProvider implements ScheduleProvider {
     return ScheduleQueryResult(_trim(start, end), const []);
   }
 
+  @override
+  Future<DateTime?> getLastQueryTimeForWindow(
+    DateTime start,
+    DateTime end,
+  ) async {
+    return null;
+  }
+
   Schedule _trim(DateTime start, DateTime end) {
     final entries = _entries.where((entry) {
       return start.isBefore(entry.end) && end.isAfter(entry.start);

--- a/test/schedule/ui/viewmodels/weekly_schedule_view_model_pager_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_view_model_pager_test.dart
@@ -114,6 +114,121 @@ void main() {
       });
     },
   );
+
+  test(
+    'opening a never-fetched empty week schedules forced refresh before visible debounce',
+    () {
+      fakeAsync((async) {
+        final provider = _FakeScheduleProvider(const <ScheduleEntry>[]);
+        final viewModel = WeeklyScheduleViewModel(
+          provider,
+          _FakeScheduleSourceProvider(),
+          nowProvider: () => DateTime(2026, 2, 10, 10),
+        );
+
+        unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 16)));
+        async.flushMicrotasks();
+
+        expect(viewModel.currentDateStart, DateTime(2026, 2, 16));
+        expect(viewModel.visibleWeekNeedsInitialFetch, isTrue);
+        expect(provider.updatedScheduleRequests, 0);
+
+        async.elapse(const Duration(milliseconds: 120));
+        async.flushMicrotasks();
+
+        expect(provider.updatedScheduleRequests, 1);
+        viewModel.dispose();
+      });
+    },
+  );
+
+  test('stale open-week requests do not schedule initial refreshes', () {
+    fakeAsync((async) {
+      final provider = _FakeScheduleProvider(const <ScheduleEntry>[]);
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        _FakeScheduleSourceProvider(),
+        nowProvider: () => DateTime(2026, 2, 10, 10),
+      );
+
+      unawaited(
+        viewModel.openWeekContaining(
+          DateTime(2026, 2, 16),
+          isCurrentRequest: () => false,
+        ),
+      );
+      async.flushMicrotasks();
+      async.elapse(const Duration(milliseconds: 120));
+      async.flushMicrotasks();
+
+      expect(provider.updatedScheduleRequests, 0);
+      viewModel.dispose();
+    });
+  });
+
+  test('persisted query information treats an empty week as known empty', () {
+    fakeAsync((async) {
+      final provider = _FakeScheduleProvider(const <ScheduleEntry>[]);
+      provider.markWindowQueried(
+        DateTime(2026, 2, 16),
+        DateTime(2026, 2, 23),
+        DateTime(2026, 2, 16, 8, 45),
+      );
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        _FakeScheduleSourceProvider(),
+        nowProvider: () => DateTime(2026, 2, 16, 9),
+      );
+
+      unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 16)));
+      async.flushMicrotasks();
+
+      expect(viewModel.visibleWeekNeedsInitialFetch, isFalse);
+
+      async.elapse(const Duration(milliseconds: 120));
+      async.flushMicrotasks();
+      expect(provider.updatedScheduleRequests, 0);
+
+      async.elapse(const Duration(seconds: 3));
+      async.flushMicrotasks();
+      expect(provider.updatedScheduleRequests, 0);
+      viewModel.dispose();
+    });
+  });
+
+  test(
+    'switching back to a recently fetched empty week does not refetch immediately',
+    () {
+      fakeAsync((async) {
+        final provider = _FakeScheduleProvider(const <ScheduleEntry>[]);
+        final viewModel = WeeklyScheduleViewModel(
+          provider,
+          _FakeScheduleSourceProvider(),
+          nowProvider: () => DateTime(2026, 2, 10, 10),
+        );
+
+        unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 9)));
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 120));
+        async.flushMicrotasks();
+        expect(provider.updatedScheduleRequests, 1);
+
+        unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 16)));
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 120));
+        async.flushMicrotasks();
+        expect(provider.updatedScheduleRequests, 2);
+
+        unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 9)));
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 120));
+        async.flushMicrotasks();
+        expect(provider.updatedScheduleRequests, 2);
+
+        viewModel.dispose();
+      });
+    },
+  );
 }
 
 ScheduleEntry _entry(DateTime day, String title) {
@@ -130,8 +245,14 @@ ScheduleEntry _entry(DateTime day, String title) {
 
 class _FakeScheduleProvider implements ScheduleProvider {
   final List<ScheduleEntry> _entries;
+  final Map<String, DateTime> _queryTimesByWindow = <String, DateTime>{};
+  int updatedScheduleRequests = 0;
 
   _FakeScheduleProvider(this._entries);
+
+  void markWindowQueried(DateTime start, DateTime end, DateTime queryTime) {
+    _queryTimesByWindow[_windowKey(start, end)] = queryTime;
+  }
 
   @override
   Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
@@ -148,7 +269,21 @@ class _FakeScheduleProvider implements ScheduleProvider {
     CancellationToken cancellationToken, {
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
   }) async {
+    updatedScheduleRequests += 1;
+    markWindowQueried(start, end, DateTime.now());
     return ScheduleQueryResult(await getCachedSchedule(start, end), const []);
+  }
+
+  @override
+  Future<DateTime?> getLastQueryTimeForWindow(
+    DateTime start,
+    DateTime end,
+  ) async {
+    return _queryTimesByWindow[_windowKey(start, end)];
+  }
+
+  String _windowKey(DateTime start, DateTime end) {
+    return '${start.toIso8601String()}_${end.toIso8601String()}';
   }
 
   @override

--- a/test/schedule/ui/viewmodels/weekly_schedule_view_model_pager_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_view_model_pager_test.dart
@@ -229,6 +229,88 @@ void main() {
       });
     },
   );
+
+  test(
+    'failed initial refresh keeps empty week eligible for another initial fetch',
+    () {
+      fakeAsync((async) {
+        final provider = _FailingFirstUpdateScheduleProvider();
+        final viewModel = WeeklyScheduleViewModel(
+          provider,
+          _FakeScheduleSourceProvider(),
+          nowProvider: () => DateTime(2026, 2, 10, 10),
+        );
+
+        unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 16)));
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 120));
+        async.flushMicrotasks();
+
+        expect(provider.updatedScheduleRequests, 1);
+        expect(viewModel.visibleWeekNeedsInitialFetch, isTrue);
+
+        unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 16)));
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 120));
+        async.flushMicrotasks();
+
+        expect(provider.updatedScheduleRequests, 2);
+        expect(viewModel.visibleWeekNeedsInitialFetch, isFalse);
+        viewModel.dispose();
+      });
+    },
+  );
+
+  test(
+    'stale metadata checks do not cancel newer visible initial refresh timers',
+    () {
+      fakeAsync((async) {
+        final provider = _MetadataBlockingScheduleProvider();
+        var requestId = 1;
+        final viewModel = WeeklyScheduleViewModel(
+          provider,
+          _FakeScheduleSourceProvider(),
+          nowProvider: () => DateTime(2026, 2, 10, 10),
+        );
+
+        unawaited(
+          viewModel.openWeekContaining(
+            DateTime(2026, 2, 16),
+            isCurrentRequest: () => requestId == 1,
+          ),
+        );
+        async.flushMicrotasks();
+
+        requestId = 2;
+        unawaited(
+          viewModel.openWeekContaining(
+            DateTime(2026, 2, 23),
+            isCurrentRequest: () => requestId == 2,
+          ),
+        );
+        async.flushMicrotasks();
+
+        provider.completeQueryInformation(
+          DateTime(2026, 2, 23),
+          DateTime(2026, 3, 2),
+        );
+        async.flushMicrotasks();
+
+        provider.completeQueryInformation(
+          DateTime(2026, 2, 16),
+          DateTime(2026, 2, 23),
+        );
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(milliseconds: 120));
+        async.flushMicrotasks();
+
+        expect(viewModel.currentDateStart, DateTime(2026, 2, 23));
+        expect(provider.updatedScheduleRequests, 1);
+        viewModel.dispose();
+      });
+    },
+  );
 }
 
 ScheduleEntry _entry(DateTime day, String title) {
@@ -289,6 +371,50 @@ class _FakeScheduleProvider implements ScheduleProvider {
   @override
   dynamic noSuchMethod(Invocation invocation) {
     throw UnsupportedError('Unexpected ScheduleProvider call: $invocation');
+  }
+}
+
+class _FailingFirstUpdateScheduleProvider extends _FakeScheduleProvider {
+  var _shouldFail = true;
+
+  _FailingFirstUpdateScheduleProvider() : super(const <ScheduleEntry>[]);
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken, {
+    ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
+  }) async {
+    updatedScheduleRequests += 1;
+    if (_shouldFail) {
+      _shouldFail = false;
+      throw ScheduleQueryFailedException(Exception('schedule unavailable'));
+    }
+    markWindowQueried(start, end, DateTime.now());
+    return ScheduleQueryResult(await getCachedSchedule(start, end), const []);
+  }
+}
+
+class _MetadataBlockingScheduleProvider extends _FakeScheduleProvider {
+  final Map<String, Completer<DateTime?>> _metadataCompleters =
+      <String, Completer<DateTime?>>{};
+
+  _MetadataBlockingScheduleProvider() : super(const <ScheduleEntry>[]);
+
+  @override
+  Future<DateTime?> getLastQueryTimeForWindow(DateTime start, DateTime end) {
+    return (_metadataCompleters[_windowKey(start, end)] ??=
+            Completer<DateTime?>())
+        .future;
+  }
+
+  void completeQueryInformation(DateTime start, DateTime end) {
+    final completer = _metadataCompleters[_windowKey(start, end)];
+    if (completer == null || completer.isCompleted) {
+      return;
+    }
+    completer.complete(null);
   }
 }
 

--- a/test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart
+++ b/test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart
@@ -266,57 +266,58 @@ void main() {
     viewModel.dispose();
   });
 
-  testWidgets('defers unfetched week refresh until swipe navigation settles', (
-    tester,
-  ) async {
-    final provider = _QueuedBlockingTrackingScheduleProvider(
-      const <ScheduleEntry>[],
-    );
-    final sourceProvider = _FakeScheduleSourceProvider();
-    final viewModel = WeeklyScheduleViewModel(
-      provider,
-      sourceProvider,
-      nowProvider: () => DateTime(2026, 2, 10, 11, 0),
-    );
+  testWidgets(
+    'loads an unfetched empty week shortly after navigation settles',
+    (tester) async {
+      final provider = _QueuedBlockingTrackingScheduleProvider(
+        const <ScheduleEntry>[],
+      );
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        sourceProvider,
+        nowProvider: () => DateTime(2026, 2, 10, 11, 0),
+      );
 
-    await viewModel.updateSchedule(
-      DateTime(2026, 2, 9),
-      DateTime(2026, 2, 16),
-      force: true,
-    );
-    expect(viewModel.isUpdating, isTrue);
-    provider.completeNextUpdate();
-    await tester.pump(const Duration(milliseconds: 40));
-    expect(viewModel.isUpdating, isFalse);
+      await viewModel.updateSchedule(
+        DateTime(2026, 2, 9),
+        DateTime(2026, 2, 16),
+        force: true,
+      );
+      expect(viewModel.isUpdating, isTrue);
+      provider.completeNextUpdate();
+      await tester.pump(const Duration(milliseconds: 40));
+      expect(viewModel.isUpdating, isFalse);
 
-    await tester.pumpWidget(_wrapWithApp(viewModel));
-    await tester.pump();
+      await tester.pumpWidget(_wrapWithApp(viewModel));
+      await tester.pump();
 
-    unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 17)));
-    await tester.pump(const Duration(milliseconds: 40));
+      unawaited(viewModel.openWeekContaining(DateTime(2026, 2, 17)));
+      await tester.pump(const Duration(milliseconds: 40));
 
-    expect(
-      find.byKey(const ValueKey<String>('weekly_schedule_loading_line')),
-      findsNothing,
-    );
-    expect(provider.updatedOrigins.length, 1);
+      expect(
+        find.byKey(const ValueKey<String>('weekly_schedule_loading_line')),
+        findsNothing,
+      );
+      expect(provider.updatedOrigins.length, 1);
 
-    await tester.pump(const Duration(milliseconds: 2500));
-    await tester.pump(const Duration(milliseconds: 40));
+      await tester.pump(const Duration(milliseconds: 120));
+      await tester.pump(const Duration(milliseconds: 40));
 
-    expect(
-      find.byKey(const ValueKey<String>('weekly_schedule_loading_line')),
-      findsOneWidget,
-    );
-    expect(provider.updatedOrigins.length, 2);
+      expect(
+        find.byKey(const ValueKey<String>('weekly_schedule_loading_line')),
+        findsOneWidget,
+      );
+      expect(provider.updatedOrigins.length, 2);
 
-    provider.completeNextUpdate();
-    await tester.pump(const Duration(milliseconds: 300));
+      provider.completeNextUpdate();
+      await tester.pump(const Duration(milliseconds: 300));
 
-    await tester.pumpWidget(const SizedBox.shrink());
-    await tester.pump();
-    viewModel.dispose();
-  });
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      viewModel.dispose();
+    },
+  );
 }
 
 Widget _wrapWithApp(WeeklyScheduleViewModel viewModel) {
@@ -374,6 +375,14 @@ class _TrackingScheduleProvider implements ScheduleProvider {
   }) async {
     updatedOrigins.add(origin);
     return ScheduleQueryResult(_trim(start, end), const []);
+  }
+
+  @override
+  Future<DateTime?> getLastQueryTimeForWindow(
+    DateTime start,
+    DateTime end,
+  ) async {
+    return null;
   }
 
   Schedule _trim(DateTime start, DateTime end) {


### PR DESCRIPTION
## Summary
- Add persisted query-window tracking so the weekly schedule can distinguish a truly unfetched empty week from a week that was already queried and happened to be empty.
- Start a short visible-week initial refresh for newly opened empty weeks instead of waiting for the longer visible debounce.
- Keep cache-first navigation and preserve the slower debounce for weeks that are already known, reducing unnecessary refreshes while paging.
- Update lifecycle/background refresh handling and add tests for empty-week refresh timing, stale requests, and known-empty windows.

## Testing
- Added unit coverage in `test/schedule/ui/viewmodels/weekly_schedule_view_model_pager_test.dart` for:
  - forced refresh on a never-fetched empty week
  - stale open-week requests not scheduling refreshes
  - persisted query metadata preventing repeat refreshes
  - revisiting a recently fetched empty week not refetching immediately
- Updated widget coverage in `test/schedule/ui/weeklyschedule/weekly_schedule_page_lifecycle_test.dart` to verify an unfetched empty week refreshes shortly after navigation settles.
- Not run: full Flutter test suite and Android device verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved weekly schedule refresh behavior with smarter tracking of previously fetched time windows.
  * Schedule now loads faster by remembering which weeks have already been queried.

* **Bug Fixes**
  * Refined initial schedule loading to prevent unnecessary refetches of recently viewed weeks.
  * Enhanced staleness protection during week navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->