### PR TITLE
Enable Android per-app language support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="DualMate"
         android:enableOnBackInvokedCallback="true"
+        android:localeConfig="@xml/locales_config"
         tools:replace="android:label">
         <receiver
 			android:name=".widget.now.ScheduleNowWidget"

--- a/android/app/src/main/res/xml/locales_config.xml
+++ b/android/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="de" />
+</locale-config>

--- a/docs/solutions/android/2026-06-21-app-language-per-app-locale-opt-in.md
+++ b/docs/solutions/android/2026-06-21-app-language-per-app-locale-opt-in.md
@@ -21,7 +21,7 @@ differs from the OS.
   element in `AndroidManifest.xml`. This is the single attribute Android 13+
   looks for to surface the app in the system "App language" picker.
 
-## Why no Dart changes were needed
+## Why the UI needs no Dart changes
 
 `MaterialApp` in `lib/ui/root_page.dart` does not pass an explicit `locale`,
 so Flutter follows `PlatformDispatcher.instance.locale`. When the user picks a
@@ -33,9 +33,21 @@ re-invoked with the new locale, so the UI updates at runtime and on cold start.
 The Android home-screen widget labels (`res/values*/strings.xml`) are already
 locale-qualified, so they follow the per-app choice automatically as well.
 
-The existing `LastUsedLanguageCode` preference (used by the background isolate
-for notifications) keeps working because `Platform.localeName` reflects the
-per-app locale.
+## Persisting the locale for the background isolate
+
+`MainActivity` handles `locale` via `android:configChanges`, so a Settings
+language change does **not** restart the process. The background/notification
+isolate reads `LastUsedLanguageCode` to render text, and previously that
+preference was written only at cold start (`RootPage._initializeApp`). A
+runtime language switch would therefore leave notifications in the old language
+until the next cold start.
+
+This is now handled by `LocalePreferenceSync`
+(`lib/common/appstart/locale_preference_sync.dart`), a `WidgetsBindingObserver`
+that persists `Platform.localeName` to `LastUsedLanguageCode` on
+`didChangeLocales` and when the app resumes. `RootPage` attaches it right after
+base initialization and calls `syncNow()` for the initial persist, replacing
+the old startup-only `saveLastStartLanguage()` path.
 
 ## Verification
 
@@ -43,8 +55,12 @@ per-app locale.
   survives both the conditional-manifest generation step and the manifest
   merger, landing in the final merged manifest, and the `@xml/locales_config`
   reference resolves.
+- `flutter test test/common/appstart/locale_preference_sync_test.dart` covers
+  `syncNow`, `didChangeLocales`, resume, and that non-resumed lifecycle states
+  do not persist.
 - Manual/on-device: on Android 13+, the app appears in the system App Language
-  menu; selecting English or German updates the in-app UI and widget labels.
+  menu; selecting English or German updates the in-app UI, widget labels, and
+  the language used by background notifications without a cold start.
 
 ## Notes / future
 

--- a/docs/solutions/android/2026-06-21-app-language-per-app-locale-opt-in.md
+++ b/docs/solutions/android/2026-06-21-app-language-per-app-locale-opt-in.md
@@ -1,0 +1,56 @@
+---
+title: Android per-app language opt-in (system App Language menu)
+date: 2026-06-21
+category: android
+---
+
+## Problem
+
+The app did not opt into Android's per-app language preference, so it never
+appeared in the system **Settings > App > DualMate > Language** menu on
+Android 13+ (API 33+). Users could only change the language by changing the
+whole device language; there was no way to set a language for the app that
+differs from the OS.
+
+## Solution
+
+- Added `android/app/src/main/res/xml/locales_config.xml` declaring the two
+  supported locales (`en`, `de`). English matches the unqualified
+  `res/values/` resources and therefore acts as the default.
+- Added `android:localeConfig="@xml/locales_config"` to the `<application>`
+  element in `AndroidManifest.xml`. This is the single attribute Android 13+
+  looks for to surface the app in the system "App language" picker.
+
+## Why no Dart changes were needed
+
+`MaterialApp` in `lib/ui/root_page.dart` does not pass an explicit `locale`,
+so Flutter follows `PlatformDispatcher.instance.locale`. When the user picks a
+per-app language in system Settings, Android updates that platform locale
+process-wide and fires `onLocaleChanged`, which rebuilds `Localizations`. The
+custom `LocalizationDelegate.load()` (`lib/common/i18n/localizations.dart`) is
+re-invoked with the new locale, so the UI updates at runtime and on cold start.
+
+The Android home-screen widget labels (`res/values*/strings.xml`) are already
+locale-qualified, so they follow the per-app choice automatically as well.
+
+The existing `LastUsedLanguageCode` preference (used by the background isolate
+for notifications) keeps working because `Platform.localeName` reflects the
+per-app locale.
+
+## Verification
+
+- `:app:processDebugManifest --rerun-tasks` succeeds (exit 0); the attribute
+  survives both the conditional-manifest generation step and the manifest
+  merger, landing in the final merged manifest, and the `@xml/locales_config`
+  reference resolves.
+- Manual/on-device: on Android 13+, the app appears in the system App Language
+  menu; selecting English or German updates the in-app UI and widget labels.
+
+## Notes / future
+
+- This is the system-menu-only implementation. An in-app language picker that
+  stays in sync with this system setting can be added later via Android's
+  `LocaleManager` (API 33+) exposed through a method channel.
+- `minSdkVersion` is `flutter.minSdkVersion`; the system App Language menu only
+  exists on API 33+, which is governed by the device — no extra handling is
+  required for older API levels (the menu simply does not appear there).

--- a/lib/common/appstart/locale_preference_sync.dart
+++ b/lib/common/appstart/locale_preference_sync.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/logging/app_diagnostics.dart';
+import 'package:flutter/widgets.dart';
+
+///
+/// Keeps the persisted [PreferencesProvider.LastUsedLanguageCode] in sync with
+/// runtime locale changes.
+///
+/// With Android 13+ per-app language, users can switch the app language from
+/// system Settings while the app is running. `MainActivity` handles `locale`
+/// via `android:configChanges`, so the process is not restarted and the
+/// cold-start write in `RootPage._initializeApp` would otherwise stay stale.
+/// The background/notification isolate reads this preference to render text, so
+/// a runtime change must be persisted to avoid notifications appearing in the
+/// old language until the next cold start.
+///
+/// Register it as a [WidgetsBindingObserver] via [attach]; it persists on
+/// locale changes and when the app returns to the foreground.
+///
+class LocalePreferenceSync extends WidgetsBindingObserver {
+  LocalePreferenceSync({
+    required PreferencesProvider preferencesProvider,
+    String Function()? currentLocaleName,
+  })  : _preferencesProvider = preferencesProvider,
+        _currentLocaleName = currentLocaleName ?? _platformLocaleName;
+
+  final PreferencesProvider _preferencesProvider;
+  final String Function() _currentLocaleName;
+
+  static String _platformLocaleName() => Platform.localeName;
+
+  /// Registers this observer with the [WidgetsBinding].
+  void attach() {
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  /// Removes this observer from the [WidgetsBinding].
+  void detach() {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  /// Persists the current platform locale so the background isolate stays in
+  /// sync with a runtime language change.
+  Future<void> syncNow() async {
+    try {
+      await _preferencesProvider.setLastUsedLanguageCode(_currentLocaleName());
+    } catch (error, trace) {
+      unawaited(
+        AppDiagnostics.instance.reportCaughtException(
+          error,
+          trace,
+          message: 'Locale preference sync failed',
+          tags: const {'feature': 'startup'},
+          contexts: const {
+            'startup': {'phase': 'language.sync'},
+          },
+        ),
+      );
+    }
+  }
+
+  @override
+  void didChangeLocales(List<Locale>? locales) {
+    unawaited(syncNow());
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      unawaited(syncNow());
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,10 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:dualmate/ui/root_page.dart';
 import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/logging/crash_reporting.dart';
 import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/logging/sentry_configuration.dart';
-import 'package:dualmate/common/data/preferences/preferences_provider.dart';
-import 'package:kiwi/kiwi.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -80,14 +77,3 @@ Future<void> main() async {
   }());
 }
 
-///
-/// Save the current language in the preferences.
-/// The language of the last app start is used for the background initialization.
-/// When the app runs in the background this is an easy way to get the
-/// used language
-///
-
-Future<void> saveLastStartLanguage() async {
-  PreferencesProvider preferencesProvider = KiwiContainer().resolve();
-  await preferencesProvider.setLastUsedLanguageCode(Platform.localeName);
-}

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -9,10 +9,10 @@ import 'package:dualmate/common/logging/sentry_scrubber.dart';
 import 'package:dualmate/common/ui/colors.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
 import 'package:dualmate/common/appstart/app_initializer.dart';
+import 'package:dualmate/common/appstart/locale_preference_sync.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/util/launch_intent.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
-import 'package:dualmate/main.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:kiwi/kiwi.dart';
@@ -68,6 +68,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
   bool _backgroundInitStarted = false;
   bool _onboardingDeferredInitListenerAttached = false;
   Stopwatch? _deferredInitStopwatch;
+  LocalePreferenceSync? _localePreferenceSync;
   static const MethodChannel _navigationChannel = MethodChannel(
     'com.fariszr.dualmate/navigation',
   );
@@ -96,6 +97,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
   @override
   void dispose() {
     unawaited(_setAppAttended(false));
+    _localePreferenceSync?.detach();
     _detachOnboardingDeferredInitListener();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
@@ -209,7 +211,11 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
         args: {'elapsedMs': widget.startupStopwatch.elapsedMilliseconds},
       );
 
-      unawaited(_saveLastStartLanguage());
+      _localePreferenceSync = LocalePreferenceSync(
+        preferencesProvider: KiwiContainer().resolve<PreferencesProvider>(),
+      );
+      _localePreferenceSync!.attach();
+      unawaited(_localePreferenceSync!.syncNow());
       _debugRootLog(
         "Root init: save language deferred ${stopwatch.elapsedMilliseconds}ms",
       );
@@ -331,25 +337,6 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
         ),
       );
       _perfOverlayLoaded = true;
-    }
-  }
-
-  Future<void> _saveLastStartLanguage() async {
-    try {
-      await saveLastStartLanguage();
-    } catch (error, trace) {
-      _debugRootError("Root init: save language failed", error, trace);
-      unawaited(
-        AppDiagnostics.instance.reportCaughtException(
-          error,
-          trace,
-          message: 'Root init: save language failed',
-          tags: {'feature': 'startup'},
-          contexts: {
-            'startup': {'phase': 'language.save'},
-          },
-        ),
-      );
     }
   }
 

--- a/test/common/appstart/locale_preference_sync_test.dart
+++ b/test/common/appstart/locale_preference_sync_test.dart
@@ -1,0 +1,64 @@
+import 'package:dualmate/common/appstart/locale_preference_sync.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late _RecordingPreferencesProvider preferences;
+  late LocalePreferenceSync sync;
+
+  setUp(() {
+    preferences = _RecordingPreferencesProvider();
+    sync = LocalePreferenceSync(
+      preferencesProvider: preferences,
+      currentLocaleName: () => 'de_DE',
+    );
+  });
+
+  test('syncNow persists the current platform locale', () async {
+    await sync.syncNow();
+
+    expect(preferences.setLanguageCalls, ['de_DE']);
+  });
+
+  test('didChangeLocales triggers persistence of the current locale', () async {
+    sync.didChangeLocales(const [Locale('de', 'DE')]);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(preferences.setLanguageCalls, ['de_DE']);
+  });
+
+  test('resume triggers persistence of the current locale', () async {
+    sync.didChangeAppLifecycleState(AppLifecycleState.resumed);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(preferences.setLanguageCalls, ['de_DE']);
+  });
+
+  test('non-resumed lifecycle states do not persist the locale', () async {
+    for (final state in <AppLifecycleState>[
+      AppLifecycleState.inactive,
+      AppLifecycleState.paused,
+      AppLifecycleState.hidden,
+      AppLifecycleState.detached,
+    ]) {
+      sync.didChangeAppLifecycleState(state);
+    }
+    await Future<void>.delayed(Duration.zero);
+
+    expect(preferences.setLanguageCalls, isEmpty);
+  });
+}
+
+class _RecordingPreferencesProvider implements PreferencesProvider {
+  final List<String> setLanguageCalls = <String>[];
+
+  @override
+  Future<void> setLastUsedLanguageCode(String languageCode) async {
+    setLanguageCalls.add(languageCode);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('Unexpected PreferencesProvider call: $invocation');
+}


### PR DESCRIPTION
## Summary
- Opt into Android system per-app language support by adding `android:localeConfig` to the app manifest.
- Declare the supported app locales in `android/app/src/main/res/xml/locales_config.xml` for English and German.
- Document the change and expected Android 13+ behavior in a new solution note.

## Testing
- `:app:processDebugManifest --rerun-tasks` succeeds and the merged manifest contains the `@xml/locales_config` reference.
- Not run: on-device Android 13+ verification of the system App Language menu.
- Not run: manual UI check that selecting English or German updates in-app localization and widget labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced language preference synchronization that automatically updates when system locale changes or app returns to foreground.
  * Added German language support configuration for Android.

* **Chores**
  * Improved locale and language configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->