### PR TITLE
Fix settings crash when background tasks are unregistered

### DIFF
--- a/docs/solutions/runtime-errors/settings-startup-kiwi-taskcallback-race-20260622.md
+++ b/docs/solutions/runtime-errors/settings-startup-kiwi-taskcallback-race-20260622.md
@@ -1,0 +1,68 @@
+---
+module: Settings
+date: 2026-06-22
+problem_type: runtime_error
+component: settings_startup
+symptoms:
+  - "NotRegisteredKiwiError while opening Settings immediately after startup"
+  - "Failed to resolve TaskCallback for NextDayInformationNotification"
+root_cause: deferred_startup_dependency_race
+resolution_type: code_fix
+severity: high
+tags: [flutter, kiwi, settings, startup, notifications, android]
+---
+
+# Troubleshooting: Settings startup Kiwi TaskCallback race
+
+## Problem
+
+Opening Settings very quickly after app startup could render an empty gray page
+and report a `NotRegisteredKiwiError` for the named
+`NextDayInformationNotification` `TaskCallback`.
+
+## Environment
+
+- Module: Settings
+- Platform: Android
+- Affected Component: `SettingsPage` notification settings wiring
+- Date: 2026-06-22
+
+## Root Cause
+
+The main app intentionally allows the first frame before deferred background
+initialization completes. `NotificationApi`, `WorkSchedulerService`, and the
+named next-day notification task are registered by that deferred path.
+
+`SettingsPage` was still resolving notification dependencies while constructing
+its state. A fast navigation to Settings could therefore beat background
+registration. Checking `KiwiContainer.isRegistered` before `resolve` was not
+sufficient protection for the race; the optional path also needed to tolerate a
+not-registered error from the actual resolve call.
+
+## Solution
+
+Resolve only the always-available Settings dependencies eagerly. Resolve
+notification dependencies through a defensive optional resolver, and hide the
+notification section unless the real notification API, scheduler, and next-day
+task are all available.
+
+The fallback `SettingsViewModel` receives a no-op task and `VoidNotificationApi`
+so non-notification settings remain usable during startup. Do not create or
+register the real next-day task from `SettingsPage`; background initialization
+owns task registration and scheduling.
+
+## Verification
+
+- `flutter test test/ui/settings test/common/appstart/background_initialize_test.dart`
+- `flutter analyze lib/ui/settings/settings_page.dart test/ui/settings/settings_page_lifecycle_test.dart`
+- Pixel 8 Pro cold-start fast navigation: force-stop app, launch, tap drawer,
+  tap Settings before deferred background init completes, then confirm Settings
+  renders and logcat has no `NotRegisteredKiwiError`, `Failed to resolve`, or
+  `FATAL EXCEPTION`.
+
+## Prevention
+
+- UI routes should not assume deferred startup services are present.
+- Treat Kiwi `isRegistered` as a hint, not a complete optional-resolve API.
+- Keep background task construction and registration in startup/background
+  initialization code, not in UI page constructors.

--- a/lib/common/appstart/background_initialize.dart
+++ b/lib/common/appstart/background_initialize.dart
@@ -13,9 +13,16 @@ import 'package:kiwi/kiwi.dart';
 /// Note: More or less reliable background scheduling only works on android
 ///
 class BackgroundInitialize {
+  final WorkSchedulerService Function()? _schedulerFactory;
+
+  BackgroundInitialize({WorkSchedulerService Function()? schedulerFactory})
+    : _schedulerFactory = schedulerFactory;
+
   Future<void> setupBackgroundScheduling() async {
     WorkSchedulerService scheduler;
-    if (Platform.isAndroid) {
+    if (_schedulerFactory != null) {
+      scheduler = _schedulerFactory();
+    } else if (Platform.isAndroid) {
       scheduler = BackgroundWorkScheduler();
     } else {
       scheduler = VoidBackgroundWorkScheduler();
@@ -44,12 +51,10 @@ class BackgroundInitialize {
 
     for (var task in tasks) {
       scheduler.registerTask(task);
+      KiwiContainer().registerInstance(task, name: task.getName());
+    }
 
-      KiwiContainer().registerInstance(
-        task,
-        name: task.getName(),
-      );
-
+    for (var task in tasks) {
       await task.schedule();
     }
   }

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -4,9 +4,12 @@ import 'package:dualmate/common/application_constants.dart';
 import 'package:dualmate/common/background/task_callback.dart';
 import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/app_theme_enum.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
 import 'package:dualmate/common/ui/widgets/title_list_tile.dart';
+import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
 import 'package:dualmate/schedule/ui/widgets/select_source_dialog.dart';
 import 'package:dualmate/ui/settings/select_theme_dialog.dart';
@@ -30,7 +33,7 @@ class _SettingsPageState extends State<SettingsPage> {
   final SettingsViewModel settingsViewModel = SettingsViewModel(
     KiwiContainer().resolve(),
     KiwiContainer().resolve(),
-    KiwiContainer().resolve<TaskCallback>(NextDayInformationNotification.name),
+    _resolveNextDayInformationNotification(),
     KiwiContainer().resolve(),
   );
 
@@ -96,8 +99,7 @@ class _SettingsPageState extends State<SettingsPage> {
     final theme = Theme.of(context);
     final localizations = MaterialLocalizations.of(context);
     final useUpperCase = !theme.useMaterial3;
-    String label(String text) =>
-        useUpperCase ? text.toUpperCase() : text;
+    String label(String text) => useUpperCase ? text.toUpperCase() : text;
 
     showDialog<void>(
       context: context,
@@ -151,14 +153,14 @@ class _SettingsPageState extends State<SettingsPage> {
                   context: dialogContext,
                   applicationName: L.of(dialogContext).applicationName,
                   applicationVersion: ApplicationVersion,
-                  applicationIcon:
-                      Image.asset("assets/app_icon.png", width: 75),
+                  applicationIcon: Image.asset(
+                    "assets/app_icon.png",
+                    width: 75,
+                  ),
                   applicationLegalese: L.of(dialogContext).applicationLegalese,
                 );
               },
-              child: Text(
-                label(localizations.viewLicensesButtonLabel),
-              ),
+              child: Text(label(localizations.viewLicensesButtonLabel)),
             ),
             TextButton(
               onPressed: () => Navigator.of(dialogContext).pop(),
@@ -254,7 +256,11 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   List<Widget> buildNotificationSettings(BuildContext context) {
-    WorkSchedulerService service = KiwiContainer().resolve();
+    final service = _resolveWorkSchedulerServiceOrNull();
+    if (service == null) {
+      return [];
+    }
+
     if (service.isSchedulingAvailable()) {
       return [
         TitleListTile(title: L.of(context).settingsNotificationsTitle),
@@ -372,4 +378,56 @@ class _SettingsPageState extends State<SettingsPage> {
     settingsViewModel.dispose();
     super.dispose();
   }
+}
+
+TaskCallback _resolveNextDayInformationNotification() {
+  final container = KiwiContainer();
+  if (container.isRegistered<TaskCallback>(
+    name: NextDayInformationNotification.name,
+  )) {
+    return container.resolve<TaskCallback>(NextDayInformationNotification.name);
+  }
+
+  if (!container.isRegistered<NotificationApi>() ||
+      !container.isRegistered<ScheduleEntryRepository>() ||
+      !container.isRegistered<WorkSchedulerService>() ||
+      !container.isRegistered<PreferencesProvider>()) {
+    return _NoopTaskCallback(NextDayInformationNotification.name);
+  }
+
+  final task = NextDayInformationNotification(
+    container.resolve<NotificationApi>(),
+    container.resolve<ScheduleEntryRepository>(),
+    container.resolve<WorkSchedulerService>(),
+    container.resolve<PreferencesProvider>(),
+  );
+  container.resolve<WorkSchedulerService>().registerTask(task);
+  container.registerInstance<TaskCallback>(task, name: task.getName());
+  return task;
+}
+
+WorkSchedulerService? _resolveWorkSchedulerServiceOrNull() {
+  final container = KiwiContainer();
+  if (!container.isRegistered<WorkSchedulerService>()) {
+    return null;
+  }
+  return container.resolve<WorkSchedulerService>();
+}
+
+class _NoopTaskCallback implements TaskCallback {
+  final String _name;
+
+  const _NoopTaskCallback(this._name);
+
+  @override
+  Future<void> cancel() async {}
+
+  @override
+  String getName() => _name;
+
+  @override
+  Future<void> run() async {}
+
+  @override
+  Future<void> schedule() async {}
 }

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -4,12 +4,10 @@ import 'package:dualmate/common/application_constants.dart';
 import 'package:dualmate/common/background/task_callback.dart';
 import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/app_theme_enum.dart';
-import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
 import 'package:dualmate/common/ui/widgets/title_list_tile.dart';
-import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
 import 'package:dualmate/schedule/ui/widgets/select_source_dialog.dart';
 import 'package:dualmate/ui/settings/select_theme_dialog.dart';
@@ -30,12 +28,10 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  final SettingsViewModel settingsViewModel = SettingsViewModel(
-    KiwiContainer().resolve(),
-    KiwiContainer().resolve(),
-    _resolveNextDayInformationNotification(),
-    KiwiContainer().resolve(),
-  );
+  late final _SettingsPageDependencies _dependencies =
+      _resolveSettingsPageDependencies();
+
+  SettingsViewModel get settingsViewModel => _dependencies.settingsViewModel;
 
   @override
   Widget build(BuildContext context) {
@@ -256,12 +252,13 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   List<Widget> buildNotificationSettings(BuildContext context) {
-    final service = _resolveWorkSchedulerServiceOrNull();
+    final service = _dependencies.workSchedulerService;
     if (service == null) {
       return [];
     }
 
-    if (service.isSchedulingAvailable()) {
+    if (_dependencies.canShowNotificationSettings &&
+        service.isSchedulingAvailable()) {
       return [
         TitleListTile(title: L.of(context).settingsNotificationsTitle),
         PropertyChangeConsumer<SettingsViewModel, String>(
@@ -380,38 +377,60 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 }
 
-TaskCallback _resolveNextDayInformationNotification() {
-  final container = KiwiContainer();
-  if (container.isRegistered<TaskCallback>(
-    name: NextDayInformationNotification.name,
-  )) {
-    return container.resolve<TaskCallback>(NextDayInformationNotification.name);
-  }
+_SettingsPageDependencies _resolveSettingsPageDependencies() {
+  final notificationApi = _resolveNotificationApiOrNull();
+  final nextDayTask = _resolveNextDayInformationNotificationOrNull();
+  final workSchedulerService = _resolveWorkSchedulerServiceOrNull();
 
-  if (!container.isRegistered<NotificationApi>() ||
-      !container.isRegistered<ScheduleEntryRepository>() ||
-      !container.isRegistered<WorkSchedulerService>() ||
-      !container.isRegistered<PreferencesProvider>()) {
-    return _NoopTaskCallback(NextDayInformationNotification.name);
-  }
-
-  final task = NextDayInformationNotification(
-    container.resolve<NotificationApi>(),
-    container.resolve<ScheduleEntryRepository>(),
-    container.resolve<WorkSchedulerService>(),
-    container.resolve<PreferencesProvider>(),
+  return _SettingsPageDependencies(
+    settingsViewModel: SettingsViewModel(
+      KiwiContainer().resolve(),
+      KiwiContainer().resolve(),
+      nextDayTask ?? _NoopTaskCallback(NextDayInformationNotification.name),
+      notificationApi ?? VoidNotificationApi(),
+    ),
+    workSchedulerService: workSchedulerService,
+    canShowNotificationSettings:
+        notificationApi != null &&
+        nextDayTask != null &&
+        workSchedulerService != null,
   );
-  container.resolve<WorkSchedulerService>().registerTask(task);
-  container.registerInstance<TaskCallback>(task, name: task.getName());
-  return task;
+}
+
+TaskCallback? _resolveNextDayInformationNotificationOrNull() {
+  return _resolveOptional<TaskCallback>(NextDayInformationNotification.name);
+}
+
+NotificationApi? _resolveNotificationApiOrNull() {
+  return _resolveOptional<NotificationApi>();
 }
 
 WorkSchedulerService? _resolveWorkSchedulerServiceOrNull() {
+  return _resolveOptional<WorkSchedulerService>();
+}
+
+T? _resolveOptional<T>([String? name]) {
   final container = KiwiContainer();
-  if (!container.isRegistered<WorkSchedulerService>()) {
+  if (!container.isRegistered<T>(name: name)) {
     return null;
   }
-  return container.resolve<WorkSchedulerService>();
+  try {
+    return container.resolve<T>(name);
+  } on NotRegisteredKiwiError {
+    return null;
+  }
+}
+
+class _SettingsPageDependencies {
+  final SettingsViewModel settingsViewModel;
+  final WorkSchedulerService? workSchedulerService;
+  final bool canShowNotificationSettings;
+
+  const _SettingsPageDependencies({
+    required this.settingsViewModel,
+    required this.workSchedulerService,
+    required this.canShowNotificationSettings,
+  });
 }
 
 class _NoopTaskCallback implements TaskCallback {

--- a/test/common/appstart/background_initialize_test.dart
+++ b/test/common/appstart/background_initialize_test.dart
@@ -1,6 +1,7 @@
 import 'package:dualmate/canteen/business/canteen_provider.dart';
 import 'package:dualmate/common/appstart/background_initialize.dart';
 import 'package:dualmate/common/background/task_callback.dart';
+import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/native/widget/widget_helper.dart';
@@ -22,47 +23,140 @@ void main() {
     KiwiContainer().clear();
   });
 
-  test('setupBackgroundScheduling does not require localization in Kiwi',
-      () async {
-    final container = KiwiContainer();
-    container.registerInstance<NotificationApi>(VoidNotificationApi());
-    container.registerInstance<PreferencesProvider>(_FakePreferencesProvider());
-    container.registerInstance<CanteenProvider>(_FakeCanteenProvider());
-    container.registerInstance<ScheduleProvider>(_FakeScheduleProvider());
-    container.registerInstance<ScheduleSourceProvider>(
-        _FakeScheduleSourceProvider());
-    container.registerInstance<ScheduleEntryRepository>(
-        _FakeScheduleEntryRepository());
-    container.registerInstance<WidgetHelper>(_FakeWidgetHelper());
+  test(
+    'setupBackgroundScheduling does not require localization in Kiwi',
+    () async {
+      final container = KiwiContainer();
+      container.registerInstance<NotificationApi>(VoidNotificationApi());
+      container.registerInstance<PreferencesProvider>(
+        _FakePreferencesProvider(),
+      );
+      container.registerInstance<CanteenProvider>(_FakeCanteenProvider());
+      container.registerInstance<ScheduleProvider>(_FakeScheduleProvider());
+      container.registerInstance<ScheduleSourceProvider>(
+        _FakeScheduleSourceProvider(),
+      );
+      container.registerInstance<ScheduleEntryRepository>(
+        _FakeScheduleEntryRepository(),
+      );
+      container.registerInstance<WidgetHelper>(_FakeWidgetHelper());
 
-    expect(
-      container.isRegistered<TaskCallback>(
-        name: NextDayInformationNotification.name,
-      ),
-      isFalse,
-    );
+      expect(
+        container.isRegistered<TaskCallback>(
+          name: NextDayInformationNotification.name,
+        ),
+        isFalse,
+      );
 
-    await BackgroundInitialize().setupBackgroundScheduling();
+      await BackgroundInitialize().setupBackgroundScheduling();
 
-    expect(
-      container.isRegistered<TaskCallback>(
-        name: NextDayInformationNotification.name,
-      ),
-      isTrue,
-    );
-    expect(
-      container.isRegistered<TaskCallback>(
-        name: BackgroundCanteenUpdate.name,
-      ),
-      isTrue,
-    );
-    expect(
-      container.isRegistered<TaskCallback>(
-        name: BackgroundScheduleUpdate.name,
-      ),
-      isTrue,
-    );
-  });
+      expect(
+        container.isRegistered<TaskCallback>(
+          name: NextDayInformationNotification.name,
+        ),
+        isTrue,
+      );
+      expect(
+        container.isRegistered<TaskCallback>(
+          name: BackgroundCanteenUpdate.name,
+        ),
+        isTrue,
+      );
+      expect(
+        container.isRegistered<TaskCallback>(
+          name: BackgroundScheduleUpdate.name,
+        ),
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'setupBackgroundScheduling registers all tasks before scheduling',
+    () async {
+      final container = KiwiContainer();
+      container.registerInstance<NotificationApi>(VoidNotificationApi());
+      container.registerInstance<PreferencesProvider>(
+        _FakePreferencesProvider(),
+      );
+      container.registerInstance<CanteenProvider>(_FakeCanteenProvider());
+      container.registerInstance<ScheduleProvider>(_FakeScheduleProvider());
+      container.registerInstance<ScheduleSourceProvider>(
+        _FakeScheduleSourceProvider(),
+      );
+      container.registerInstance<ScheduleEntryRepository>(
+        _FakeScheduleEntryRepository(),
+      );
+      container.registerInstance<WidgetHelper>(_FakeWidgetHelper());
+
+      await expectLater(
+        BackgroundInitialize(
+          schedulerFactory: () => _ThrowingScheduleWorkScheduler(),
+        ).setupBackgroundScheduling(),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(
+        container.isRegistered<TaskCallback>(
+          name: NextDayInformationNotification.name,
+        ),
+        isTrue,
+      );
+      expect(
+        container.isRegistered<TaskCallback>(
+          name: BackgroundCanteenUpdate.name,
+        ),
+        isTrue,
+      );
+      expect(
+        container.isRegistered<TaskCallback>(
+          name: BackgroundScheduleUpdate.name,
+        ),
+        isTrue,
+      );
+    },
+  );
+}
+
+class _ThrowingScheduleWorkScheduler implements WorkSchedulerService {
+  @override
+  Future<void> cancelTask(String id) async {}
+
+  @override
+  Future<void> executeTask(String id) async {}
+
+  @override
+  bool isSchedulingAvailable() => true;
+
+  @override
+  void registerTask(TaskCallback task) {}
+
+  @override
+  Future<void> scheduleOneShotTaskAt(
+    DateTime date,
+    String id,
+    String name,
+  ) async {
+    throw StateError('scheduling failed');
+  }
+
+  @override
+  Future<void> scheduleOneShotTaskIn(
+    Duration delay,
+    String id,
+    String name,
+  ) async {
+    throw StateError('scheduling failed');
+  }
+
+  @override
+  Future<void> schedulePeriodic(
+    Duration delay,
+    String id, [
+    bool needsNetwork = false,
+  ]) async {
+    throw StateError('scheduling failed');
+  }
 }
 
 class _FakePreferencesProvider implements PreferencesProvider {

--- a/test/ui/settings/settings_page_lifecycle_test.dart
+++ b/test/ui/settings/settings_page_lifecycle_test.dart
@@ -59,6 +59,30 @@ void main() {
     },
   );
 
+  testWidgets('settings page opens when next-day task is not registered', (
+    tester,
+  ) async {
+    KiwiContainer().clear();
+    final preferencesProvider = _FakePreferencesProvider();
+    KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
+    KiwiContainer().registerInstance<CanteenLocationService>(
+      CanteenLocationService(preferencesProvider),
+    );
+    KiwiContainer().registerInstance<WorkSchedulerService>(
+      VoidBackgroundWorkScheduler(),
+    );
+    KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
+
+    final rootViewModel = RootViewModel(KiwiContainer().resolve());
+    await rootViewModel.loadFromPreferences();
+
+    await tester.pumpWidget(_wrapWithApp(rootViewModel, SettingsPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Settings'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('about dialog shows privacy policy link and View licenses', (
     tester,
   ) async {

--- a/test/ui/settings/settings_page_lifecycle_test.dart
+++ b/test/ui/settings/settings_page_lifecycle_test.dart
@@ -80,6 +80,57 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Settings'), findsOneWidget);
+    expect(find.text('Next day schedule'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('settings page opens before notification services are registered', (
+    tester,
+  ) async {
+    KiwiContainer().clear();
+    final preferencesProvider = _FakePreferencesProvider();
+    KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
+    KiwiContainer().registerInstance<CanteenLocationService>(
+      CanteenLocationService(preferencesProvider),
+    );
+
+    final rootViewModel = RootViewModel(KiwiContainer().resolve());
+    await rootViewModel.loadFromPreferences();
+
+    await tester.pumpWidget(_wrapWithApp(rootViewModel, SettingsPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Settings'), findsOneWidget);
+    expect(find.text('Next day schedule'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('settings page opens when next-day task resolve races startup', (
+    tester,
+  ) async {
+    KiwiContainer().clear();
+    final preferencesProvider = _FakePreferencesProvider();
+    KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
+    KiwiContainer().registerInstance<CanteenLocationService>(
+      CanteenLocationService(preferencesProvider),
+    );
+    KiwiContainer().registerInstance<WorkSchedulerService>(
+      VoidBackgroundWorkScheduler(),
+    );
+    KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
+    KiwiContainer().registerFactory<TaskCallback>(
+      (_) => throw NotRegisteredKiwiError('startup race'),
+      name: NextDayInformationNotification.name,
+    );
+
+    final rootViewModel = RootViewModel(KiwiContainer().resolve());
+    await rootViewModel.loadFromPreferences();
+
+    await tester.pumpWidget(_wrapWithApp(rootViewModel, SettingsPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Settings'), findsOneWidget);
+    expect(find.text('Next day schedule'), findsNothing);
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
## Summary
- Prevented `SettingsPage` from crashing when the `NextDayInformationNotification` task has not yet been registered in Kiwi.
- Added a safe fallback that resolves or creates the notification task only when the required dependencies are available, otherwise no-ops.
- Skips notification settings rendering when no `WorkSchedulerService` is registered.
- Updated background initialization so tasks are registered before scheduling, which keeps Kiwi state consistent even if scheduling fails.
- Added coverage for background initialization ordering and for opening the settings page when the next-day task is missing.

## Testing
- `flutter test test/common/appstart/background_initialize_test.dart`
- `flutter test test/ui/settings/settings_page_lifecycle_test.dart`
- Verified `SettingsPage` opens without throwing when `NextDayInformationNotification` is not registered.
- Verified background tasks are registered before scheduling is attempted, including the failure case exercised by the test double.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings page now gracefully handles cases where background scheduler or notification services are unavailable, hiding notification settings instead of crashing.

* **Tests**
  * Enhanced test coverage to verify task callbacks are registered before scheduling begins and that settings page renders correctly when required services are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->