### PR TITLE
Make `flutter analyze` a valid CI gate

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - third_party/**

--- a/lib/date_management/ui/date_management_page.dart
+++ b/lib/date_management/ui/date_management_page.dart
@@ -12,6 +12,7 @@ import 'package:dualmate/date_management/ui/widgets/important_event_section_card
 import 'package:dualmate/schedule/ui/widgets/select_source_dialog.dart';
 import 'package:dualmate/ui/banner_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:intl/intl.dart';
 import 'package:kiwi/kiwi.dart';
@@ -306,7 +307,7 @@ class _DateManagementPageState extends State<DateManagementPage> {
         controller: _raplaScrollController,
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        cacheExtent: _importantEventsCacheExtent,
+        scrollCacheExtent: ScrollCacheExtent.pixels(_importantEventsCacheExtent),
         itemBuilder: (context, index) {
           if (index < sections.length) {
             final section = sections[index];

--- a/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
@@ -3,6 +3,7 @@ import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/filter/filter_view_model.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:kiwi/kiwi.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 
@@ -137,7 +138,7 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
                                         itemCount:
                                             viewModel.filterStates.length,
                                         itemExtent: 56,
-                                        cacheExtent: 320,
+                                        scrollCacheExtent: const ScrollCacheExtent.pixels(320),
                                         itemBuilder: (context, index) =>
                                             FilterStateRow(
                                                 viewModel.filterStates[index]),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: dualmate
 description: An app for the DHBW
+publish_to: none
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43


### PR DESCRIPTION
## Summary

Plain \`flutter analyze\` currently fails for three unrelated reasons. This PR fixes all three so analyze can be used as a CI gate, with no runtime behavior changes.

### Changes
1. **New \`analysis_options.yaml\`** — excludes \`third_party/**\` so the vendored Pigeon input (\`third_party/path_provider_android/pigeons/messages.dart\`, which imports \`package:pigeon/pigeon.dart\`) is not analyzed as app code. \`lib/**\` and \`test/**\` analysis is unchanged.
2. **\`pubspec.yaml\`** — added \`publish_to: none\`. The app has a path dependency (\`dualmate_widget_bridge\`) and is not intended for pub.dev, which was triggering \`invalid_dependency\`.
3. **Deprecated API migration** — replaced the deprecated \`cacheExtent\` (\`double\`) with \`scrollCacheExtent: ScrollCacheExtent.pixels(...)\` (\`ScrollCacheExtent\`) in:
   - \`lib/date_management/ui/date_management_page.dart\`
   - \`lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart\`
   
   \`.pixels()\` preserves the exact previous pixel-based behavior. Added \`import 'package:flutter/rendering.dart'\` where needed (\`ScrollCacheExtent\` is not re-exported by \`material.dart\`/\`widgets.dart\`).

### Not changed
- No app behavior changes beyond the deprecation rename.
- No signing, release secrets, package name, app id, or Play Store config.
- \`pigeon\` was **not** added as an app dependency; the vendored source is excluded instead.

## Validation
- [x] \`flutter pub get\`
- [x] \`flutter analyze\` — **No issues found** (previously 22 issues: 18 errors, 1 warning, 2 infos)
- [x] \`flutter test\` — **294 tests passed**
- [x] \`./android/gradlew -p android :app:testDebugUnitTest --console=plain\` — **BUILD SUCCESSFUL**

Target Flutter: \`3.44.2\` (matches release workflow).