### PR TITLE
Fix onboarding tiles missing Material ancestor

### DIFF
--- a/docs/solutions/ui-bugs/onboarding-list-tile-material-effects-sentry-20260622.md
+++ b/docs/solutions/ui-bugs/onboarding-list-tile-material-effects-sentry-20260622.md
@@ -38,6 +38,7 @@ can hide those effects unless each tile has its own local material surface.
 ## Test Coverage
 - `schedule source radios keep visible material effects under color`
 - `canteen location radios keep visible material effects under color`
+- `Mannheim course tiles keep visible material effects under color`
 
 ## Commands run
 ```bash

--- a/docs/solutions/ui-bugs/onboarding-list-tile-material-effects-sentry-20260622.md
+++ b/docs/solutions/ui-bugs/onboarding-list-tile-material-effects-sentry-20260622.md
@@ -1,0 +1,48 @@
+---
+module: Onboarding UI
+date: 2026-06-22
+problem_type: ui_bug
+component: onboarding
+symptoms:
+  - "Sentry reported FlutterError: ListTile background color or ink splashes may be invisible"
+  - "The onboarding route emitted framework-only ListTile assertions under the animated page transition"
+root_cause: onboarding_list_tiles_rendered_below_a_colored_transition_without_a_local_material_ancestor
+resolution_type: code_fix
+severity: low
+tags: [onboarding, sentry, flutter, listtile, material]
+---
+
+# Troubleshooting: Onboarding ListTile material effects
+
+## Problem
+Sentry issue `DUALMATE-A` reported Flutter's debug check for `ListTile`
+material effects during the `onboarding` transaction. The stack did not include
+application frames, but the framework message identified an opaque `ColoredBox`
+between `ListTile` and the nearest `Material` ancestor.
+
+## Root Cause
+The onboarding pages are rendered inside an animated transition that can insert
+a colored wrapper above the active page. `RadioListTile` and `ListTile` paint
+their tile background and ink effects on the nearest `Material`, so that wrapper
+can hide those effects unless each tile has its own local material surface.
+
+## Solution
+- Wrapped onboarding schedule source `RadioListTile` entries in transparent
+  `Material`.
+- Wrapped onboarding canteen location `RadioListTile` entries in transparent
+  `Material`.
+- Wrapped Mannheim course `ListTile` entries in transparent `Material`.
+- Added a widget regression that pumps onboarding radio pages below a
+  `ColoredBox` and asserts no Flutter framework exception is emitted.
+
+## Test Coverage
+- `schedule source radios keep visible material effects under color`
+- `canteen location radios keep visible material effects under color`
+
+## Commands run
+```bash
+sentry issue view 129632365 --json --fields shortId,title,culprit,metadata,tags,firstSeen,lastSeen,count,userCount,permalink
+flutter test test/ui/onboarding/onboarding_list_tile_material_test.dart
+flutter test test/ui/onboarding/onboarding_list_tile_material_test.dart test/ui/onboarding/onboarding_required_canteen_step_test.dart
+flutter analyze lib/ui/onboarding/widgets/select_source_page.dart lib/ui/onboarding/widgets/select_canteen_location_page.dart lib/ui/onboarding/widgets/mannheim_page.dart test/ui/onboarding/onboarding_list_tile_material_test.dart test/ui/onboarding/onboarding_required_canteen_step_test.dart
+```

--- a/lib/ui/onboarding/viewmodels/mannheim_view_model.dart
+++ b/lib/ui/onboarding/viewmodels/mannheim_view_model.dart
@@ -5,14 +5,13 @@ import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/service/mannheim/mannheim_course_scraper.dart';
 import 'package:dualmate/ui/onboarding/viewmodels/onboarding_view_model_base.dart';
 
-enum LoadCoursesState {
-  Loading,
-  Loaded,
-  Failed,
-}
+typedef MannheimCourseLoader = Future<List<Course>> Function();
+
+enum LoadCoursesState { Loading, Loaded, Failed }
 
 class MannheimViewModel extends OnboardingStepViewModel {
   final ScheduleSourceProvider _scheduleSourceProvider;
+  final MannheimCourseLoader _loadCoursesFromSource;
 
   LoadCoursesState _loadingState = LoadCoursesState.Loading;
   LoadCoursesState get loadingState => _loadingState;
@@ -23,7 +22,11 @@ class MannheimViewModel extends OnboardingStepViewModel {
   List<Course> _courses = [];
   List<Course> get courses => _courses;
 
-  MannheimViewModel(this._scheduleSourceProvider) {
+  MannheimViewModel(
+    this._scheduleSourceProvider, {
+    MannheimCourseLoader? loadCoursesFromSource,
+  }) : _loadCoursesFromSource =
+           loadCoursesFromSource ?? MannheimCourseScraper().loadCourses {
     setIsValid(false);
     loadCourses();
   }
@@ -34,7 +37,7 @@ class MannheimViewModel extends OnboardingStepViewModel {
 
     try {
       await Future.delayed(Duration(seconds: 1));
-      _courses = await MannheimCourseScraper().loadCourses();
+      _courses = await _loadCoursesFromSource();
       _loadingState = LoadCoursesState.Loaded;
     } catch (ex, trace) {
       _courses = [];

--- a/lib/ui/onboarding/widgets/mannheim_page.dart
+++ b/lib/ui/onboarding/widgets/mannheim_page.dart
@@ -87,30 +87,33 @@ class SelectMannheimCourseWidget extends StatelessWidget {
     );
   }
 
-  ListTile _buildCourseListTile(
+  Widget _buildCourseListTile(
     MannheimViewModel viewModel,
     int index,
     BuildContext context,
   ) {
     var isSelected = viewModel.selectedCourse == viewModel.courses[index];
 
-    return ListTile(
-      trailing: isSelected
-          ? Icon(
-              Icons.check,
-              color: Theme.of(context).colorScheme.secondary,
-            )
-          : null,
-      title: Text(
-        viewModel.courses[index].name,
-        style: isSelected
-            ? TextStyle(
+    return Material(
+      color: Colors.transparent,
+      child: ListTile(
+        trailing: isSelected
+            ? Icon(
+                Icons.check,
                 color: Theme.of(context).colorScheme.secondary,
               )
             : null,
+        title: Text(
+          viewModel.courses[index].name,
+          style: isSelected
+              ? TextStyle(
+                  color: Theme.of(context).colorScheme.secondary,
+                )
+              : null,
+        ),
+        subtitle: Text(viewModel.courses[index].title),
+        onTap: () => viewModel.setSelectedCourse(viewModel.courses[index]),
       ),
-      subtitle: Text(viewModel.courses[index].title),
-      onTap: () => viewModel.setSelectedCourse(viewModel.courses[index]),
     );
   }
 

--- a/lib/ui/onboarding/widgets/select_canteen_location_page.dart
+++ b/lib/ui/onboarding/widgets/select_canteen_location_page.dart
@@ -59,11 +59,14 @@ class SelectCanteenLocationPage extends StatelessWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: viewModel.locations
                             .map(
-                              (location) => RadioListTile<CanteenLocation>(
-                                value: location,
-                                title: Text(location.name),
-                                subtitle: CanteenLocationSubtitle(
-                                  location: location,
+                              (location) => Material(
+                                color: Colors.transparent,
+                                child: RadioListTile<CanteenLocation>(
+                                  value: location,
+                                  title: Text(location.name),
+                                  subtitle: CanteenLocationSubtitle(
+                                    location: location,
+                                  ),
                                 ),
                               ),
                             )

--- a/lib/ui/onboarding/widgets/select_source_page.dart
+++ b/lib/ui/onboarding/widgets/select_source_page.dart
@@ -90,11 +90,14 @@ class SelectSourcePage extends StatelessWidget {
     );
   }
 
-  RadioListTile<ScheduleSourceType> buildScheduleTypeRadio(
+  Widget buildScheduleTypeRadio(
       ScheduleSourceType type, String title) {
-    return RadioListTile(
-      value: type,
-      title: Text(title),
+    return Material(
+      color: Colors.transparent,
+      child: RadioListTile<ScheduleSourceType>(
+        value: type,
+        title: Text(title),
+      ),
     );
   }
 }

--- a/test/ui/onboarding/onboarding_list_tile_material_test.dart
+++ b/test/ui/onboarding/onboarding_list_tile_material_test.dart
@@ -3,9 +3,13 @@ import 'package:dualmate/common/data/preferences/preferences_access.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
 import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/service/mannheim/mannheim_course_scraper.dart';
+import 'package:dualmate/ui/onboarding/viewmodels/mannheim_view_model.dart';
 import 'package:dualmate/ui/onboarding/viewmodels/onboarding_view_model_base.dart';
 import 'package:dualmate/ui/onboarding/viewmodels/select_canteen_location_view_model.dart';
 import 'package:dualmate/ui/onboarding/viewmodels/select_source_view_model.dart';
+import 'package:dualmate/ui/onboarding/widgets/mannheim_page.dart';
 import 'package:dualmate/ui/onboarding/widgets/select_canteen_location_page.dart';
 import 'package:dualmate/ui/onboarding/widgets/select_source_page.dart';
 import 'package:flutter/material.dart';
@@ -59,6 +63,31 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets(
+    'Mannheim course tiles keep visible material effects under color',
+    (tester) async {
+      final viewModel = MannheimViewModel(
+        _FakeScheduleSourceProvider(),
+        loadCoursesFromSource: () async => [
+          Course(
+            'WWI23A',
+            'https://example.com/mannheim.ics',
+            'Wirtschaftsinformatik',
+            'wwi23a',
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        _OnboardingTileHarness(viewModel: viewModel, child: MannheimPage()),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('WWI23A'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
 }
 
 class _OnboardingTileHarness extends StatelessWidget {
@@ -88,4 +117,9 @@ class _OnboardingTileHarness extends StatelessWidget {
       ),
     );
   }
+}
+
+class _FakeScheduleSourceProvider implements ScheduleSourceProvider {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/ui/onboarding/onboarding_list_tile_material_test.dart
+++ b/test/ui/onboarding/onboarding_list_tile_material_test.dart
@@ -1,0 +1,91 @@
+import 'package:dualmate/canteen/business/canteen_location_service.dart';
+import 'package:dualmate/common/data/preferences/preferences_access.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/ui/onboarding/viewmodels/onboarding_view_model_base.dart';
+import 'package:dualmate/ui/onboarding/viewmodels/select_canteen_location_view_model.dart';
+import 'package:dualmate/ui/onboarding/viewmodels/select_source_view_model.dart';
+import 'package:dualmate/ui/onboarding/widgets/select_canteen_location_page.dart';
+import 'package:dualmate/ui/onboarding/widgets/select_source_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:property_change_notifier/property_change_notifier.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets(
+    'schedule source radios keep visible material effects under color',
+    (tester) async {
+      final preferencesProvider = PreferencesProvider(
+        PreferencesAccess(),
+        SecureStorageAccess(),
+      );
+
+      await tester.pumpWidget(
+        _OnboardingTileHarness(
+          viewModel: SelectSourceViewModel(preferencesProvider),
+          child: const SelectSourcePage(),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'canteen location radios keep visible material effects under color',
+    (tester) async {
+      final preferencesProvider = PreferencesProvider(
+        PreferencesAccess(),
+        SecureStorageAccess(),
+      );
+
+      await tester.pumpWidget(
+        _OnboardingTileHarness(
+          viewModel: SelectCanteenLocationViewModel(
+            CanteenLocationService(preferencesProvider),
+          ),
+          child: const SelectCanteenLocationPage(),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+}
+
+class _OnboardingTileHarness extends StatelessWidget {
+  const _OnboardingTileHarness({required this.viewModel, required this.child});
+
+  final OnboardingStepViewModel viewModel;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      localizationsDelegates: const [
+        LocalizationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('de')],
+      home: Scaffold(
+        body: ColoredBox(
+          color: Colors.white,
+          child: PropertyChangeProvider<OnboardingStepViewModel, String>(
+            value: viewModel,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Wrap onboarding `ListTile` and `RadioListTile` entries in transparent `Material` surfaces so ink and selection effects render correctly during animated transitions.
- Apply the fix to Mannheim course selection, schedule source selection, and canteen location selection pages.
- Add a widget regression test that pumps the onboarding pages under a `ColoredBox` and verifies no Flutter framework exception is emitted.
- Document the Sentry-reported issue and the resolution in `docs/solutions/ui-bugs/`.

## Testing
- `flutter test test/ui/onboarding/onboarding_list_tile_material_test.dart`
- `flutter test test/ui/onboarding/onboarding_list_tile_material_test.dart test/ui/onboarding/onboarding_required_canteen_step_test.dart`
- `flutter analyze lib/ui/onboarding/widgets/select_source_page.dart lib/ui/onboarding/widgets/select_canteen_location_page.dart lib/ui/onboarding/widgets/mannheim_page.dart test/ui/onboarding/onboarding_list_tile_material_test.dart test/ui/onboarding/onboarding_required_canteen_step_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated onboarding page UI widget composition for improved rendering consistency.

* **Tests**
  * Added tests to validate onboarding interface behavior and material effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->