### PR TITLE
Fix overflowing schedule detail bottom sheet

### DIFF
--- a/docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md
+++ b/docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md
@@ -1,0 +1,67 @@
+---
+module: Schedule UI
+date: 2026-06-24
+problem_type: ui_bug
+component: frontend_flutter
+sentry_issue: DUALMATE-G
+symptoms:
+  - "FlutterError: A RenderFlex overflowed by N pixels on the bottom"
+  - "Long lesson details are cut off / unreadable in the detail bottom sheet"
+  - "Schedule entry detail sheet has a fixed height that cannot grow"
+root_cause: fixed_height_container_with_unbounded_column_content
+resolution_type: code_fix
+severity: high
+tags: [schedule, weekly-calendar, ui, material3, bottom-sheet, sentry]
+---
+
+# Troubleshooting: Schedule entry detail bottom sheet overflowed with long details
+
+## Problem
+
+The lesson detail bottom sheet (`ScheduleEntryDetailBottomSheet`) used a fixed
+`Container(height: 400)` wrapping a `Column`. When a `ScheduleEntry` had a long
+`details` string, the column children no longer fit inside the 400px height and
+Flutter threw `A RenderFlex overflowed by N pixels on the bottom`
+(Sentry issue `DUALMATE-G`).
+
+## Root Cause
+
+- `showModalBottomSheet` returned a `Container(height: 400)` whose child `Column`
+  had intrinsic, unbounded vertical content (the free-form `details` text).
+- Nothing was scrollable, and the sheet could not grow, so any content taller
+  than 400px overflowed.
+- `showModalBottomSheet` was not configured with `isScrollControlled: true`,
+  so even a taller child would have been capped by the default modal height.
+
+## Fix
+
+Made the sheet expandable so users drag it upward to reveal all details:
+
+- `lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart`
+  - Replaced the fixed-height container with a `DraggableScrollableSheet`
+    (`expand: false`, `initialChildSize: 0.4`, `minChildSize: 0.25`,
+    `maxChildSize: 0.9`, `snap: true`, snap sizes `[0.4, 0.9]`).
+  - Content is rendered inside a `SingleChildScrollView` driven by the sheet's
+    `ScrollController`, so it scrolls and the sheet grows on drag.
+  - Removed the now-redundant `package:flutter/widgets.dart` import.
+- `lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart`
+  - Added `isScrollControlled: true` to `_onScheduleEntryTap`'s
+    `showModalBottomSheet` so the sheet is allowed to occupy more screen height.
+
+## Tests
+
+`test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart`:
+
+- Renders as a `DraggableScrollableSheet` with a scrollable body.
+- A very long `details` string no longer throws a layout overflow
+  (`tester.takeException()` is `null`) and the text is still present.
+- The sheet is expandable: config allows growth past `initialChildSize`, and an
+  upward fling visibly grows the sheet without dismissing it.
+- Core fields (title, professor, details) render for a short entry.
+
+## Notes
+
+- Gesture feel (drag-to-expand snap points) is additionally verified on a real
+  Android device per the project testing guidance.
+- Material 3 bottom-sheet pattern (`DraggableScrollableSheet` inside
+  `showModalBottomSheet` with `isScrollControlled: true`).

--- a/docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md
+++ b/docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md
@@ -59,33 +59,42 @@ only changes the speed, never the curve, so it cannot match Material 3 motion
 and emits no haptic. The fix therefore disables `snap` and snaps manually:
 
 - `snap: false`; a `DraggableScrollableController` is held in state.
+- **Exactly two settle states**: standard (`0.4`) and fully expanded (`0.9`).
+  Releasing between them snaps to the nearer one (decided at the `0.65`
+  midpoint). Dragging the sheet fully down to `min` (`0.25`) dismisses the modal.
 - A `NotificationListener<ScrollEndNotification>` detects when the finger lifts
   (depth 0). The snap is run from a `WidgetsBinding.addPostFrameCallback` so it
   executes after the scrollable's own ballistic activity has started; the
   controller's `animateTo` then cancels that ballistic.
-- Target snap stop is the nearest of `0.25` (dismiss), `0.4` (medium) or `0.9`
-  (large), decided at the midpoints between adjacent stops.
-- Animation uses the Material 3 emphasized curve
-  `Curves.easeInOutCubicEmphasized` over 300 ms, per
-  https://m3.material.io/styles/motion/transitions/transition-patterns and
+- Animation uses a snappy Material 3 decelerate (`Curves.easeOutCubic`) over
+  **200 ms**, so the sheet locks into place quickly instead of slowly easing
+  across (the earlier `easeInOutCubicEmphasized`/300 ms felt sluggish),
+  per https://m3.material.io/styles/motion/transitions/transition-patterns and
   https://m3.material.io/foundations/usability/applying-m-3-expressive
-- A `HapticFeedback.selectionClick()` is fired on each snap. It is invoked
+- A `HapticFeedback.selectionClick()` fires every time the sheet **arrives** at
+  either state — whether the snap animation drove it there or the user dragged
+  it there by hand. This is implemented with a controller size-listener
+  (`_onSizeChanged`) that fires exactly once per arrival (tracked via
+  `_reachedState`), not only inside the snap path. The haptic is invoked
   fire-and-forget (with `catchError`) so a failing/absent platform handler can
   never block the snap animation.
 
 ## Tests
 
 `test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart`
-(now 7 tests):
+(now 8 tests):
 
 - Renders as a `DraggableScrollableSheet` with a scrollable body.
 - A very long `details` string no longer throws a layout overflow
   (`tester.takeException()` is `null`) and the text is still present.
-- Starts at the medium size with `snap: false` and a max larger than initial.
-- A partial upward drag (past the snap midpoint) snaps to the large size and
+- Starts at the standard size with `snap: false` and a max larger than initial.
+- A partial upward drag (past the snap midpoint) snaps to the expanded size and
   emits a `HapticFeedbackType.selectionClick` (verified via a mocked
   `SystemChannels.platform` in `setUp`).
-- A partial downward drag from the large size snaps back to the medium size.
+- **Manually dragging the sheet all the way to expanded (no snap) also fires a
+  selection haptic** — proving the haptic is not tied to the snap path.
+- A partial downward drag from expanded snaps back to standard and fires a
+  haptic on arrival.
 - Dragging the sheet far down dismisses the modal.
 - Core fields (title, professor, details) render for a short entry.
 

--- a/docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md
+++ b/docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md
@@ -35,33 +35,66 @@ Flutter threw `A RenderFlex overflowed by N pixels on the bottom`
 
 ## Fix
 
-Made the sheet expandable so users drag it upward to reveal all details:
+Made the sheet expandable so users drag it upward to reveal all details, with
+Material 3-compliant snapping and haptics:
 
 - `lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart`
   - Replaced the fixed-height container with a `DraggableScrollableSheet`
     (`expand: false`, `initialChildSize: 0.4`, `minChildSize: 0.25`,
-    `maxChildSize: 0.9`, `snap: true`, snap sizes `[0.4, 0.9]`).
+    `maxChildSize: 0.9`).
   - Content is rendered inside a `SingleChildScrollView` driven by the sheet's
     `ScrollController`, so it scrolls and the sheet grows on drag.
   - Removed the now-redundant `package:flutter/widgets.dart` import.
+  - Converted to a `StatefulWidget` that drives snapping manually via
+    `DraggableScrollableController.animateTo`. See "Snapping" below.
 - `lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart`
   - Added `isScrollControlled: true` to `_onScheduleEntryTap`'s
     `showModalBottomSheet` so the sheet is allowed to occupy more screen height.
 
+## Snapping (Material 3 motion + haptics)
+
+The built-in `DraggableScrollableSheet` snap uses a constant-velocity
+(`_SnappingSimulation`) animation, i.e. it is linear. Its `snapAnimationDuration`
+only changes the speed, never the curve, so it cannot match Material 3 motion
+and emits no haptic. The fix therefore disables `snap` and snaps manually:
+
+- `snap: false`; a `DraggableScrollableController` is held in state.
+- A `NotificationListener<ScrollEndNotification>` detects when the finger lifts
+  (depth 0). The snap is run from a `WidgetsBinding.addPostFrameCallback` so it
+  executes after the scrollable's own ballistic activity has started; the
+  controller's `animateTo` then cancels that ballistic.
+- Target snap stop is the nearest of `0.25` (dismiss), `0.4` (medium) or `0.9`
+  (large), decided at the midpoints between adjacent stops.
+- Animation uses the Material 3 emphasized curve
+  `Curves.easeInOutCubicEmphasized` over 300 ms, per
+  https://m3.material.io/styles/motion/transitions/transition-patterns and
+  https://m3.material.io/foundations/usability/applying-m-3-expressive
+- A `HapticFeedback.selectionClick()` is fired on each snap. It is invoked
+  fire-and-forget (with `catchError`) so a failing/absent platform handler can
+  never block the snap animation.
+
 ## Tests
 
-`test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart`:
+`test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart`
+(now 7 tests):
 
 - Renders as a `DraggableScrollableSheet` with a scrollable body.
 - A very long `details` string no longer throws a layout overflow
   (`tester.takeException()` is `null`) and the text is still present.
-- The sheet is expandable: config allows growth past `initialChildSize`, and an
-  upward fling visibly grows the sheet without dismissing it.
+- Starts at the medium size with `snap: false` and a max larger than initial.
+- A partial upward drag (past the snap midpoint) snaps to the large size and
+  emits a `HapticFeedbackType.selectionClick` (verified via a mocked
+  `SystemChannels.platform` in `setUp`).
+- A partial downward drag from the large size snaps back to the medium size.
+- Dragging the sheet far down dismisses the modal.
 - Core fields (title, professor, details) render for a short entry.
 
 ## Notes
 
-- Gesture feel (drag-to-expand snap points) is additionally verified on a real
-  Android device per the project testing guidance.
+- The `HapticFeedback` platform channel is mocked in the test `setUp`/`tearDown`
+  because, without a handler, `SystemChannels.platform.invokeMethod` returns a
+  Future that never completes and would stall the snap in tests.
+- Gesture feel (snap-points and haptics on a real device) is additionally
+  verified on a real Android device per the project testing guidance.
 - Material 3 bottom-sheet pattern (`DraggableScrollableSheet` inside
   `showModalBottomSheet` with `isScrollControlled: true`).

--- a/docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md
+++ b/docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md
@@ -79,10 +79,31 @@ and emits no haptic. The fix therefore disables `snap` and snaps manually:
   fire-and-forget (with `catchError`) so a failing/absent platform handler can
   never block the snap animation.
 
+### Snap guard must be cleared cancellation-safely
+
+`DraggableScrollableController.animateTo` awaits an `AnimationController`
+future. When the user drags the sheet mid-snap, the scrollable cancels that
+animation via `AnimationController.stop()` whose default is `canceled: true`,
+which leaves the underlying `TickerFuture`'s **primary** completer forever
+pending (only `orCancel` errors). Awaiting it therefore never returns, so a
+`try/finally` after the await would **never** run — the `_isSnapping` guard
+would stick `true` after a single interrupted snap and suppress all later snaps
+until the sheet was reopened.
+
+The guard is therefore cleared from cancellation-safe paths, not from the
+await:
+
+- `_snapTo` is fire-and-forget (it does not `await animateTo`), so a never-
+  completing future can neither hang nor leak the `State`.
+- `_onSizeChanged` clears `_isSnapping` when the sheet arrives at a settle state
+  (normal completion of the snap).
+- A `ScrollStartNotification` handler clears `_isSnapping` when the user takes
+  over (the interrupted-snap case).
+
 ## Tests
 
 `test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart`
-(now 8 tests):
+(now 9 tests):
 
 - Renders as a `DraggableScrollableSheet` with a scrollable body.
 - A very long `details` string no longer throws a layout overflow
@@ -95,8 +116,14 @@ and emits no haptic. The fix therefore disables `snap` and snaps manually:
   selection haptic** — proving the haptic is not tied to the snap path.
 - A partial downward drag from expanded snaps back to standard and fires a
   haptic on arrival.
+- **Snapping recovers after a snap is interrupted by a drag** (regression guard
+  for the cancellation-safe `_isSnapping` reset above).
 - Dragging the sheet far down dismisses the modal.
 - Core fields (title, professor, details) render for a short entry.
+
+Drag/snap assertions derive the expected sizes from the `DraggableScrollableSheet`
+config (`maxChildSize` / `initialChildSize`) rather than hardcoding literals, so
+they stay aligned with the widget contract.
 
 ## Notes
 

--- a/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
@@ -9,11 +9,14 @@ import 'package:intl/intl.dart';
 
 /// Expandable detail sheet for a schedule entry.
 ///
-/// The built-in [DraggableScrollableSheet] snap is disabled because it animates
-/// with a constant velocity (linear), which does not match Material 3 motion.
-/// Instead snapping is driven manually via [DraggableScrollableController.animateTo]
-/// using the Material 3 emphasized curve ([Curves.easeInOutCubicEmphasized]) and
-/// a selection haptic, per
+/// The sheet has exactly two settle states: standard and fully expanded. The
+/// built-in [DraggableScrollableSheet] snap is disabled because it animates
+/// with a constant velocity (linear) and emits no haptic. Instead snapping is
+/// driven manually via [DraggableScrollableController.animateTo] using a snappy
+/// Material 3 decelerate ([Curves.easeOutCubic]).
+///
+/// A selection haptic fires every time the sheet *arrives* at either state,
+/// whether the user snapped it there or dragged it there themselves, per
 /// https://m3.material.io/styles/motion/transitions/transition-patterns
 class ScheduleEntryDetailBottomSheet extends StatefulWidget {
   final ScheduleEntry scheduleEntry;
@@ -29,41 +32,70 @@ class ScheduleEntryDetailBottomSheet extends StatefulWidget {
 class _ScheduleEntryDetailBottomSheetState
     extends State<ScheduleEntryDetailBottomSheet> {
   static const double _minChildSize = 0.25;
-  static const double _initialChildSize = 0.4;
-  static const double _maxChildSize = 0.9;
+  static const double _initialChildSize = 0.4; // standard state
+  static const double _maxChildSize = 0.9; // fully expanded state
 
-  // Snap stops: dismiss (min), medium, large. A release between two stops snaps
-  // to the nearest stop, decided at the midpoint between adjacent stops.
-  static const double _lowerThreshold = (_minChildSize + _initialChildSize) / 2;
-  static const double _upperThreshold = (_initialChildSize + _maxChildSize) / 2;
+  // A release below this snaps back to standard; above it snaps to expanded.
+  static const double _expandThreshold =
+      (_initialChildSize + _maxChildSize) / 2;
 
-  // Material 3 emphasized motion (see m3.material.io/styles/motion).
-  static const Duration _snapDuration = Duration(milliseconds: 300);
-  static const Curve _snapCurve = Curves.easeInOutCubicEmphasized;
+  // Snappy Material 3 decelerate so the sheet locks into place quickly rather
+  // than slowly easing across (see m3.material.io/styles/motion).
+  static const Duration _snapDuration = Duration(milliseconds: 200);
+  static const Curve _snapCurve = Curves.easeOutCubic;
 
-  static const double _snapTolerance = 0.005;
+  static const double _stateTolerance = 0.01;
 
   final DraggableScrollableController _controller =
       DraggableScrollableController();
   bool _isSnapping = false;
 
+  // The state the sheet currently sits within tolerance of, so a haptic fires
+  // exactly once each time it *arrives* at a state — by snap or by manual drag.
+  // Initialized to the standard state since the sheet opens there.
+  double? _reachedState = _initialChildSize;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onSizeChanged);
+  }
+
   @override
   void dispose() {
+    _controller.removeListener(_onSizeChanged);
     _controller.dispose();
     super.dispose();
   }
 
-  /// Target snap stop for a released [size]: min (dismiss), medium or large.
+  /// Fires a selection haptic whenever the sheet arrives at a settle state.
+  void _onSizeChanged() {
+    if (!mounted || !_controller.isAttached) return;
+    final size = _controller.size;
+    if ((size - _maxChildSize).abs() <= _stateTolerance) {
+      if (_reachedState != _maxChildSize) {
+        _reachedState = _maxChildSize;
+        _triggerHaptic();
+      }
+    } else if ((size - _initialChildSize).abs() <= _stateTolerance) {
+      if (_reachedState != _initialChildSize) {
+        _reachedState = _initialChildSize;
+        _triggerHaptic();
+      }
+    } else {
+      _reachedState = null;
+    }
+  }
+
+  /// Target settle state for a released [size]: standard or fully expanded.
   double _targetForSize(double size) {
-    if (size < _lowerThreshold) return _minChildSize;
-    if (size < _upperThreshold) return _initialChildSize;
-    return _maxChildSize;
+    return size < _expandThreshold ? _initialChildSize : _maxChildSize;
   }
 
   bool _isAtSnap(double size) {
-    return (size - _minChildSize).abs() <= _snapTolerance ||
-        (size - _initialChildSize).abs() <= _snapTolerance ||
-        (size - _maxChildSize).abs() <= _snapTolerance;
+    return (size - _minChildSize).abs() <= _stateTolerance ||
+        (size - _initialChildSize).abs() <= _stateTolerance ||
+        (size - _maxChildSize).abs() <= _stateTolerance;
   }
 
   void _onScrollEnd() {
@@ -76,7 +108,6 @@ class _ScheduleEntryDetailBottomSheetState
   Future<void> _snapTo(double target) async {
     if (!mounted || !_controller.isAttached || _isSnapping) return;
     _isSnapping = true;
-    _triggerHaptic();
     try {
       await _controller.animateTo(
         target,

--- a/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
@@ -4,46 +4,142 @@ import 'package:dualmate/common/ui/schedule_entry_type_mappings.dart';
 import 'package:dualmate/common/ui/text_styles.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 
-class ScheduleEntryDetailBottomSheet extends StatelessWidget {
+/// Expandable detail sheet for a schedule entry.
+///
+/// The built-in [DraggableScrollableSheet] snap is disabled because it animates
+/// with a constant velocity (linear), which does not match Material 3 motion.
+/// Instead snapping is driven manually via [DraggableScrollableController.animateTo]
+/// using the Material 3 emphasized curve ([Curves.easeInOutCubicEmphasized]) and
+/// a selection haptic, per
+/// https://m3.material.io/styles/motion/transitions/transition-patterns
+class ScheduleEntryDetailBottomSheet extends StatefulWidget {
   final ScheduleEntry scheduleEntry;
 
   const ScheduleEntryDetailBottomSheet({Key? key, required this.scheduleEntry})
     : super(key: key);
 
   @override
+  State<ScheduleEntryDetailBottomSheet> createState() =>
+      _ScheduleEntryDetailBottomSheetState();
+}
+
+class _ScheduleEntryDetailBottomSheetState
+    extends State<ScheduleEntryDetailBottomSheet> {
+  static const double _minChildSize = 0.25;
+  static const double _initialChildSize = 0.4;
+  static const double _maxChildSize = 0.9;
+
+  // Snap stops: dismiss (min), medium, large. A release between two stops snaps
+  // to the nearest stop, decided at the midpoint between adjacent stops.
+  static const double _lowerThreshold = (_minChildSize + _initialChildSize) / 2;
+  static const double _upperThreshold = (_initialChildSize + _maxChildSize) / 2;
+
+  // Material 3 emphasized motion (see m3.material.io/styles/motion).
+  static const Duration _snapDuration = Duration(milliseconds: 300);
+  static const Curve _snapCurve = Curves.easeInOutCubicEmphasized;
+
+  static const double _snapTolerance = 0.005;
+
+  final DraggableScrollableController _controller =
+      DraggableScrollableController();
+  bool _isSnapping = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Target snap stop for a released [size]: min (dismiss), medium or large.
+  double _targetForSize(double size) {
+    if (size < _lowerThreshold) return _minChildSize;
+    if (size < _upperThreshold) return _initialChildSize;
+    return _maxChildSize;
+  }
+
+  bool _isAtSnap(double size) {
+    return (size - _minChildSize).abs() <= _snapTolerance ||
+        (size - _initialChildSize).abs() <= _snapTolerance ||
+        (size - _maxChildSize).abs() <= _snapTolerance;
+  }
+
+  void _onScrollEnd() {
+    if (!mounted || !_controller.isAttached || _isSnapping) return;
+    final size = _controller.size;
+    if (_isAtSnap(size)) return;
+    _snapTo(_targetForSize(size));
+  }
+
+  Future<void> _snapTo(double target) async {
+    if (!mounted || !_controller.isAttached || _isSnapping) return;
+    _isSnapping = true;
+    _triggerHaptic();
+    try {
+      await _controller.animateTo(
+        target,
+        duration: _snapDuration,
+        curve: _snapCurve,
+      );
+    } finally {
+      _isSnapping = false;
+    }
+  }
+
+  // Fire-and-forget: haptics are a best-effort enhancement and must never
+  // block or break the snap animation (e.g. when the platform call fails or
+  // no handler is available, such as in tests without a mock channel).
+  void _triggerHaptic() {
+    HapticFeedback.selectionClick().catchError((Object _) {});
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return DraggableScrollableSheet(
-      expand: false,
-      initialChildSize: 0.4,
-      minChildSize: 0.25,
-      maxChildSize: 0.9,
-      snap: true,
-      snapSizes: const [0.4, 0.9],
-      builder: (context, scrollController) {
-        return ColoredBox(
-          color: Theme.of(context).colorScheme.surface,
-          child: SingleChildScrollView(
-            controller: scrollController,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
-              child: _buildContent(context),
-            ),
-          ),
-        );
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        // ScrollEndNotification fires when the user lifts their finger. Defer
+        // the snap to a post-frame callback so it runs after the scrollable's
+        // own ballistic activity has started; animateTo() then cancels it.
+        if (notification is ScrollEndNotification &&
+            notification.depth == 0 &&
+            !_isSnapping) {
+          WidgetsBinding.instance.addPostFrameCallback((_) => _onScrollEnd());
+        }
+        return false;
       },
+      child: DraggableScrollableSheet(
+        expand: false,
+        controller: _controller,
+        initialChildSize: _initialChildSize,
+        minChildSize: _minChildSize,
+        maxChildSize: _maxChildSize,
+        snap: false,
+        builder: (context, scrollController) {
+          return ColoredBox(
+            color: Theme.of(context).colorScheme.surface,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
+                child: _buildContent(context),
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 
   Widget _buildContent(BuildContext context) {
     var formatter = DateFormat.Hm(L.of(context).locale.languageCode);
-    var timeStart = formatter.format(scheduleEntry.start);
-    var timeEnd = formatter.format(scheduleEntry.end);
+    var timeStart = formatter.format(widget.scheduleEntry.start);
+    var timeEnd = formatter.format(widget.scheduleEntry.end);
 
     var typeString = scheduleEntryTypeToReadableString(
       context,
-      scheduleEntry.type,
+      widget.scheduleEntry.type,
     );
 
     return Column(
@@ -110,7 +206,7 @@ class ScheduleEntryDetailBottomSheet extends StatelessWidget {
                 child: Padding(
                   padding: const EdgeInsets.fromLTRB(16, 0, 0, 0),
                   child: Text(
-                    scheduleEntry.title,
+                    widget.scheduleEntry.title,
                     softWrap: true,
                     style: textStyleScheduleEntryBottomPageTitle(context),
                   ),
@@ -124,7 +220,7 @@ class ScheduleEntryDetailBottomSheet extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
-              Expanded(child: Text(scheduleEntry.professor)),
+              Expanded(child: Text(widget.scheduleEntry.professor)),
               Text(
                 typeString,
                 style: textStyleScheduleEntryBottomPageType(context),
@@ -132,21 +228,21 @@ class ScheduleEntryDetailBottomSheet extends StatelessWidget {
             ],
           ),
         ),
-        scheduleEntry.room.isEmpty
+        widget.scheduleEntry.room.isEmpty
             ? Container()
             : Padding(
                 padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
-                child: Text(scheduleEntry.room.replaceAll(",", "\n")),
+                child: Text(widget.scheduleEntry.room.replaceAll(",", "\n")),
               ),
-        scheduleEntry.details.isEmpty
+        widget.scheduleEntry.details.isEmpty
             ? Container()
             : Padding(
                 padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
                 child: Container(color: colorSeparator(), height: 1),
               ),
-        scheduleEntry.details.isEmpty
+        widget.scheduleEntry.details.isEmpty
             ? Container()
-            : Text(scheduleEntry.details),
+            : Text(widget.scheduleEntry.details),
       ],
     );
   }

--- a/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
@@ -68,7 +68,8 @@ class _ScheduleEntryDetailBottomSheetState
     super.dispose();
   }
 
-  /// Fires a selection haptic whenever the sheet arrives at a settle state.
+  /// Fires a selection haptic whenever the sheet arrives at a settle state and
+  /// clears the snap guard on normal completion.
   void _onSizeChanged() {
     if (!mounted || !_controller.isAttached) return;
     final size = _controller.size;
@@ -77,11 +78,13 @@ class _ScheduleEntryDetailBottomSheetState
         _reachedState = _maxChildSize;
         _triggerHaptic();
       }
+      _isSnapping = false; // snap completed: arrived at expanded
     } else if ((size - _initialChildSize).abs() <= _stateTolerance) {
       if (_reachedState != _initialChildSize) {
         _reachedState = _initialChildSize;
         _triggerHaptic();
       }
+      _isSnapping = false; // snap completed: arrived at standard
     } else {
       _reachedState = null;
     }
@@ -105,18 +108,16 @@ class _ScheduleEntryDetailBottomSheetState
     _snapTo(_targetForSize(size));
   }
 
-  Future<void> _snapTo(double target) async {
+  void _snapTo(double target) {
     if (!mounted || !_controller.isAttached || _isSnapping) return;
     _isSnapping = true;
-    try {
-      await _controller.animateTo(
-        target,
-        duration: _snapDuration,
-        curve: _snapCurve,
-      );
-    } finally {
-      _isSnapping = false;
-    }
+    // Fire-and-forget: animateTo's returned future never completes when the
+    // user interrupts the snap (AnimationController.stop() cancels the ticker,
+    // leaving the primary TickerFuture pending), so we cannot rely on awaiting
+    // it to clear the guard. The guard is cleared from cancellation-safe
+    // paths instead: when the sheet arrives at a state (_onSizeChanged) or
+    // when a new drag starts (ScrollStartNotification in build).
+    _controller.animateTo(target, duration: _snapDuration, curve: _snapCurve);
   }
 
   // Fire-and-forget: haptics are a best-effort enhancement and must never
@@ -130,6 +131,13 @@ class _ScheduleEntryDetailBottomSheetState
   Widget build(BuildContext context) {
     return NotificationListener<ScrollNotification>(
       onNotification: (notification) {
+        // When the user takes over mid-snap, Flutter cancels the running
+        // animateTo, so clear the guard here — otherwise the (never-completing)
+        // snap would leave it stuck and block all later snaps.
+        if (notification is ScrollStartNotification &&
+            notification.depth == 0) {
+          _isSnapping = false;
+        }
         // ScrollEndNotification fires when the user lifts their finger. Defer
         // the snap to a post-frame callback so it runs after the scrollable's
         // own ballistic activity has started; animateTo() then cancels it.

--- a/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
@@ -4,140 +4,150 @@ import 'package:dualmate/common/ui/schedule_entry_type_mappings.dart';
 import 'package:dualmate/common/ui/text_styles.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 
 class ScheduleEntryDetailBottomSheet extends StatelessWidget {
   final ScheduleEntry scheduleEntry;
 
-    const ScheduleEntryDetailBottomSheet(
-      {Key? key, required this.scheduleEntry})
-      : super(key: key);
+  const ScheduleEntryDetailBottomSheet({Key? key, required this.scheduleEntry})
+    : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.4,
+      minChildSize: 0.25,
+      maxChildSize: 0.9,
+      snap: true,
+      snapSizes: const [0.4, 0.9],
+      builder: (context, scrollController) {
+        return ColoredBox(
+          color: Theme.of(context).colorScheme.surface,
+          child: SingleChildScrollView(
+            controller: scrollController,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
+              child: _buildContent(context),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
     var formatter = DateFormat.Hm(L.of(context).locale.languageCode);
     var timeStart = formatter.format(scheduleEntry.start);
     var timeEnd = formatter.format(scheduleEntry.end);
 
-    var typeString =
-        scheduleEntryTypeToReadableString(context, scheduleEntry.type);
+    var typeString = scheduleEntryTypeToReadableString(
+      context,
+      scheduleEntry.type,
+    );
 
-    return Container(
-      height: 400,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.fromLTRB(0, 0, 0, 8),
-              child: Center(
-                child: Container(
-                  height: 8,
-                  width: 30,
-                  decoration: BoxDecoration(
-                      color: colorSeparator(),
-                      borderRadius: const BorderRadius.all(Radius.circular(4))),
-                  child: null,
-                ),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.fromLTRB(0, 0, 0, 8),
+          child: Center(
+            child: Container(
+              height: 8,
+              width: 30,
+              decoration: BoxDecoration(
+                color: colorSeparator(),
+                borderRadius: const BorderRadius.all(Radius.circular(4)),
               ),
+              child: null,
             ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(0, 0, 0, 16.0),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(0, 0, 0, 16.0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
                 children: <Widget>[
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.baseline,
+                    textBaseline: TextBaseline.alphabetic,
                     children: <Widget>[
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.baseline,
-                        textBaseline: TextBaseline.alphabetic,
-                        children: <Widget>[
-                          Text(
-                            L.of(context).scheduleEntryDetailFrom,
-                            style: textStyleScheduleEntryBottomPageTimeFromTo(
-                                context),
-                          ),
-                          Text(
-                            timeStart,
-                            style:
-                                textStyleScheduleEntryBottomPageTime(context),
-                          ),
-                        ],
+                      Text(
+                        L.of(context).scheduleEntryDetailFrom,
+                        style: textStyleScheduleEntryBottomPageTimeFromTo(
+                          context,
+                        ),
                       ),
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.baseline,
-                        textBaseline: TextBaseline.alphabetic,
-                        children: <Widget>[
-                          Text(
-                            L.of(context).scheduleEntryDetailTo,
-                            style: textStyleScheduleEntryBottomPageTimeFromTo(
-                              context,
-                            ),
-                          ),
-                          Text(
-                            timeEnd,
-                            style:
-                                textStyleScheduleEntryBottomPageTime(context),
-                          ),
-                        ],
+                      Text(
+                        timeStart,
+                        style: textStyleScheduleEntryBottomPageTime(context),
                       ),
                     ],
                   ),
-                  Flexible(
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 0, 0, 0),
-                      child: Text(
-                        scheduleEntry.title,
-                        softWrap: true,
-                        style: textStyleScheduleEntryBottomPageTitle(context),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.baseline,
+                    textBaseline: TextBaseline.alphabetic,
+                    children: <Widget>[
+                      Text(
+                        L.of(context).scheduleEntryDetailTo,
+                        style: textStyleScheduleEntryBottomPageTimeFromTo(
+                          context,
+                        ),
                       ),
-                    ),
+                      Text(
+                        timeEnd,
+                        style: textStyleScheduleEntryBottomPageTime(context),
+                      ),
+                    ],
                   ),
                 ],
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      scheduleEntry.professor,
-                    ),
+              Flexible(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 0, 0),
+                  child: Text(
+                    scheduleEntry.title,
+                    softWrap: true,
+                    style: textStyleScheduleEntryBottomPageTitle(context),
                   ),
-                  Text(
-                    typeString,
-                    style: textStyleScheduleEntryBottomPageType(context),
-                  ),
-                ],
+                ),
               ),
-            ),
-            scheduleEntry.room.isEmpty
-                ? Container()
-                : Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
-                    child: Text(scheduleEntry.room.replaceAll(",", "\n")),
-                  ),
-            scheduleEntry.details.isEmpty
-                ? Container()
-                : Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
-                    child: Container(
-                      color: colorSeparator(),
-                      height: 1,
-                    ),
-                  ),
-            scheduleEntry.details.isEmpty
-                ? Container()
-                : Text(scheduleEntry.details),
-          ],
+            ],
+          ),
         ),
-      ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Expanded(child: Text(scheduleEntry.professor)),
+              Text(
+                typeString,
+                style: textStyleScheduleEntryBottomPageType(context),
+              ),
+            ],
+          ),
+        ),
+        scheduleEntry.room.isEmpty
+            ? Container()
+            : Padding(
+                padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
+                child: Text(scheduleEntry.room.replaceAll(",", "\n")),
+              ),
+        scheduleEntry.details.isEmpty
+            ? Container()
+            : Padding(
+                padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
+                child: Container(color: colorSeparator(), height: 1),
+              ),
+        scheduleEntry.details.isEmpty
+            ? Container()
+            : Text(scheduleEntry.details),
+      ],
     );
   }
 }

--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -170,6 +170,7 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
     showModalBottomSheet(
       useRootNavigator: true,
       context: context,
+      isScrollControlled: true,
       builder: (context) =>
           ScheduleEntryDetailBottomSheet(scheduleEntry: entry),
       shape: const RoundedRectangleBorder(

--- a/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
@@ -78,6 +78,10 @@ void main() {
       await _showSheet(tester);
       await tester.pumpAndSettle();
 
+      final sheet = tester.widget<DraggableScrollableSheet>(
+        find.byType(DraggableScrollableSheet),
+      );
+
       // Drag up past the snap midpoint (but not all the way to max) so the
       // manual snap engages toward the large size.
       await tester.drag(
@@ -86,7 +90,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(_currentSheetSize(tester), closeTo(0.9, 0.03));
+      expect(_currentSheetSize(tester), closeTo(sheet.maxChildSize, 0.03));
       expect(_haptics, contains('HapticFeedbackType.selectionClick'));
       expect(tester.takeException(), isNull);
     },
@@ -101,6 +105,10 @@ void main() {
       await _showSheet(tester);
       await tester.pumpAndSettle();
 
+      final sheet = tester.widget<DraggableScrollableSheet>(
+        find.byType(DraggableScrollableSheet),
+      );
+
       // Drag the sheet all the way to the top (clamps at max) so it reaches the
       // expanded state by hand — no release-snap is needed.
       await tester.drag(
@@ -109,7 +117,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(_currentSheetSize(tester), closeTo(0.9, 0.03));
+      expect(_currentSheetSize(tester), closeTo(sheet.maxChildSize, 0.03));
       // A selection haptic must fire when the sheet arrives at expanded, even
       // though the user (not the snap) drove it there.
       expect(_haptics, contains('HapticFeedbackType.selectionClick'));
@@ -124,23 +132,67 @@ void main() {
     await _showSheet(tester);
     await tester.pumpAndSettle();
 
+    final sheet = tester.widget<DraggableScrollableSheet>(
+      find.byType(DraggableScrollableSheet),
+    );
+
     // Expand first.
     await tester.drag(
       find.byType(SingleChildScrollView),
       const Offset(0, -220),
     );
     await tester.pumpAndSettle();
-    expect(_currentSheetSize(tester), closeTo(0.9, 0.03));
+    expect(_currentSheetSize(tester), closeTo(sheet.maxChildSize, 0.03));
 
     // Drag back down past the midpoint, then release.
     await tester.drag(find.byType(SingleChildScrollView), const Offset(0, 220));
     await tester.pumpAndSettle();
 
-    expect(_currentSheetSize(tester), closeTo(0.4, 0.03));
+    expect(_currentSheetSize(tester), closeTo(sheet.initialChildSize, 0.03));
     // Arriving back at the standard state also fires a haptic.
     expect(_haptics, contains('HapticFeedbackType.selectionClick'));
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'snapping recovers after a snap is interrupted by a drag',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildApp(entry: _entry(details: 'Short details')),
+      );
+      await _showSheet(tester);
+      await tester.pumpAndSettle();
+
+      final scrollable = find.byType(SingleChildScrollView);
+      final sheet = tester.widget<DraggableScrollableSheet>(
+        find.byType(DraggableScrollableSheet),
+      );
+
+      // 1. Start a snap toward expanded, then interrupt it mid-flight.
+      await tester.drag(scrollable, const Offset(0, -220));
+      await tester.pump(const Duration(milliseconds: 50)); // snap mid-flight
+      await tester.drag(scrollable, const Offset(0, 60)); // interrupts the snap
+      await tester.pumpAndSettle();
+
+      // 2. Re-establish a known expanded state with a direct (non-snap) drag.
+      await tester.drag(scrollable, const Offset(0, -400)); // clamps at max
+      await tester.pump();
+
+      // 3. Slowly drag down to an intermediate size and release with almost no
+      //    velocity. A recovered snap settles at the standard size; a guard
+      //    stuck true (interrupted animateTo never completing) leaves it
+      //    mid-screen.
+      await tester.timedDrag(
+        scrollable,
+        const Offset(0, 210),
+        const Duration(seconds: 2),
+      );
+      await tester.pumpAndSettle();
+
+      expect(_currentSheetSize(tester), closeTo(sheet.initialChildSize, 0.06));
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('dragging the sheet far down dismisses it', (tester) async {
     await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));

--- a/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
@@ -2,10 +2,30 @@ import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+List<String> _haptics = const [];
+
 void main() {
+  setUp(() {
+    _haptics = <String>[];
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (MethodCall call) {
+          if (call.method == 'HapticFeedback.vibrate' &&
+              call.arguments is String) {
+            _haptics.add(call.arguments as String);
+          }
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
   testWidgets('renders as a draggable scrollable sheet', (tester) async {
     await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));
     await _showSheet(tester);
@@ -29,11 +49,9 @@ void main() {
     expect(find.textContaining('A very long details line'), findsOneWidget);
   });
 
-  testWidgets('sheet is expandable: dragging up grows it past its initial size', (
+  testWidgets('starts at the medium size and is configured to expand', (
     tester,
   ) async {
-    // Short content so an upward gesture expands the sheet rather than
-    // scrolling within it.
     await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));
     await _showSheet(tester);
     await tester.pumpAndSettle();
@@ -41,25 +59,72 @@ void main() {
     final sheet = tester.widget<DraggableScrollableSheet>(
       find.byType(DraggableScrollableSheet),
     );
-    // The sheet is configured to expand well beyond its starting size.
     expect(sheet.expand, isFalse);
+    // Built-in linear snap is intentionally disabled; snapping is driven
+    // manually with Material 3 emphasized easing (see _SnapSheetState).
+    expect(sheet.snap, isFalse);
     expect(sheet.maxChildSize, greaterThan(sheet.initialChildSize));
     expect(sheet.minChildSize, lessThan(sheet.initialChildSize));
+    expect(_currentSheetSize(tester), closeTo(sheet.initialChildSize, 0.02));
+    expect(tester.takeException(), isNull);
+  });
 
-    final initial = _currentSheetSize(tester);
-    expect(initial, closeTo(sheet.initialChildSize, 0.02));
+  testWidgets(
+    'partial upward drag snaps to the large size with a selection haptic',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildApp(entry: _entry(details: 'Short details')),
+      );
+      await _showSheet(tester);
+      await tester.pumpAndSettle();
 
-    // Fling the sheet upwards to expand it. Upward gestures never dismiss.
-    await tester.fling(
-      find.byType(SingleChildScrollView),
-      const Offset(0, -900),
-      1500,
-    );
+      // Drag up past the snap midpoint (but not all the way to max) so the
+      // manual snap engages toward the large size.
+      await tester.drag(
+        find.byType(SingleChildScrollView),
+        const Offset(0, -220),
+      );
+      await tester.pumpAndSettle();
+
+      expect(_currentSheetSize(tester), closeTo(0.9, 0.03));
+      expect(_haptics, contains('HapticFeedbackType.selectionClick'));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('partial downward drag from expanded snaps back to medium', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));
+    await _showSheet(tester);
     await tester.pumpAndSettle();
 
-    // The sheet must still be present (not dismissed) and have grown.
-    expect(find.byType(SingleChildScrollView), findsOneWidget);
-    expect(_currentSheetSize(tester), greaterThan(initial));
+    // Expand first.
+    await tester.drag(
+      find.byType(SingleChildScrollView),
+      const Offset(0, -220),
+    );
+    await tester.pumpAndSettle();
+    expect(_currentSheetSize(tester), closeTo(0.9, 0.03));
+
+    // Drag back down past the midpoint, then release.
+    await tester.drag(find.byType(SingleChildScrollView), const Offset(0, 220));
+    await tester.pumpAndSettle();
+
+    expect(_currentSheetSize(tester), closeTo(0.4, 0.03));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('dragging the sheet far down dismisses it', (tester) async {
+    await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));
+    await _showSheet(tester);
+    await tester.pumpAndSettle();
+    expect(find.byType(ScheduleEntryDetailBottomSheet), findsOneWidget);
+
+    await tester.drag(find.byType(SingleChildScrollView), const Offset(0, 600));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ScheduleEntryDetailBottomSheet), findsNothing);
     expect(tester.takeException(), isNull);
   });
 

--- a/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
@@ -61,7 +61,7 @@ void main() {
     );
     expect(sheet.expand, isFalse);
     // Built-in linear snap is intentionally disabled; snapping is driven
-    // manually with Material 3 emphasized easing (see _SnapSheetState).
+    // manually with a snappy Material 3 decelerate curve (see implementation).
     expect(sheet.snap, isFalse);
     expect(sheet.maxChildSize, greaterThan(sheet.initialChildSize));
     expect(sheet.minChildSize, lessThan(sheet.initialChildSize));
@@ -92,6 +92,31 @@ void main() {
     },
   );
 
+  testWidgets(
+    'manually dragging the sheet fully expanded fires a haptic without snap',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildApp(entry: _entry(details: 'Short details')),
+      );
+      await _showSheet(tester);
+      await tester.pumpAndSettle();
+
+      // Drag the sheet all the way to the top (clamps at max) so it reaches the
+      // expanded state by hand — no release-snap is needed.
+      await tester.drag(
+        find.byType(SingleChildScrollView),
+        const Offset(0, -360),
+      );
+      await tester.pumpAndSettle();
+
+      expect(_currentSheetSize(tester), closeTo(0.9, 0.03));
+      // A selection haptic must fire when the sheet arrives at expanded, even
+      // though the user (not the snap) drove it there.
+      expect(_haptics, contains('HapticFeedbackType.selectionClick'));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets('partial downward drag from expanded snaps back to medium', (
     tester,
   ) async {
@@ -112,6 +137,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(_currentSheetSize(tester), closeTo(0.4, 0.03));
+    // Arriving back at the standard state also fires a haptic.
+    expect(_haptics, contains('HapticFeedbackType.selectionClick'));
     expect(tester.takeException(), isNull);
   });
 

--- a/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
@@ -1,0 +1,138 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders as a draggable scrollable sheet', (tester) async {
+    await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));
+    await _showSheet(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DraggableScrollableSheet), findsOneWidget);
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('long details do not cause a layout overflow', (tester) async {
+    final longDetails = List<String>.filled(
+      60,
+      'A very long details line.',
+    ).join(' ');
+    await tester.pumpWidget(_buildApp(entry: _entry(details: longDetails)));
+    await _showSheet(tester);
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.textContaining('A very long details line'), findsOneWidget);
+  });
+
+  testWidgets('sheet is expandable: dragging up grows it past its initial size', (
+    tester,
+  ) async {
+    // Short content so an upward gesture expands the sheet rather than
+    // scrolling within it.
+    await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));
+    await _showSheet(tester);
+    await tester.pumpAndSettle();
+
+    final sheet = tester.widget<DraggableScrollableSheet>(
+      find.byType(DraggableScrollableSheet),
+    );
+    // The sheet is configured to expand well beyond its starting size.
+    expect(sheet.expand, isFalse);
+    expect(sheet.maxChildSize, greaterThan(sheet.initialChildSize));
+    expect(sheet.minChildSize, lessThan(sheet.initialChildSize));
+
+    final initial = _currentSheetSize(tester);
+    expect(initial, closeTo(sheet.initialChildSize, 0.02));
+
+    // Fling the sheet upwards to expand it. Upward gestures never dismiss.
+    await tester.fling(
+      find.byType(SingleChildScrollView),
+      const Offset(0, -900),
+      1500,
+    );
+    await tester.pumpAndSettle();
+
+    // The sheet must still be present (not dismissed) and have grown.
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    expect(_currentSheetSize(tester), greaterThan(initial));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('shows all core fields for a short entry', (tester) async {
+    await tester.pumpWidget(
+      _buildApp(
+        entry: _entry(title: 'Math', details: 'Bring laptop'),
+      ),
+    );
+    await _showSheet(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Math'), findsOneWidget);
+    expect(find.text('Prof Test'), findsOneWidget);
+    expect(find.text('Bring laptop'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+double _currentSheetSize(WidgetTester tester) {
+  // Measure the visible sheet body (the scroll view fills the current sheet
+  // extent), relative to the full screen height.
+  final bodyHeight = tester.getSize(find.byType(SingleChildScrollView)).height;
+  final parentHeight = tester.getSize(find.byType(Scaffold)).height;
+  return bodyHeight / parentHeight;
+}
+
+Future<void> _showSheet(WidgetTester tester) async {
+  await tester.tap(find.text('show'));
+}
+
+ScheduleEntry _entry({String title = 'Title', String details = ''}) {
+  return ScheduleEntry(
+    start: DateTime(2026, 6, 24, 8, 0),
+    end: DateTime(2026, 6, 24, 9, 30),
+    title: title,
+    details: details,
+    professor: 'Prof Test',
+    room: 'Room A',
+    type: ScheduleEntryType.Class,
+  );
+}
+
+Widget _buildApp({required ScheduleEntry entry}) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      LocalizationDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('en'), Locale('de')],
+    home: Scaffold(
+      body: SafeArea(
+        child: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () => showModalBottomSheet(
+                context: context,
+                isScrollControlled: true,
+                builder: (_) =>
+                    ScheduleEntryDetailBottomSheet(scheduleEntry: entry),
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.vertical(
+                    top: Radius.circular(12.0),
+                  ),
+                ),
+              ),
+              child: const Text('show'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Replaced the fixed-height schedule entry detail sheet with an expandable `DraggableScrollableSheet`.
- Made the sheet content scrollable and enabled `isScrollControlled` for the modal bottom sheet.
- Added widget coverage for overflow prevention, expandability, and rendering of core lesson details.
- Documented the issue and fix in `docs/solutions/ui-bugs/schedule-detail-bottom-sheet-overflow-20260624.md`.

## Testing
- `flutter test test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart`
- Verified long `details` content no longer triggers a bottom overflow.
- Verified the sheet can drag upward and expands beyond its initial size.
- Verified title, professor, room, and details render for a normal entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule entry details now open in a draggable, scrollable bottom sheet with snapping between expanded sizes.
  * Improved presentation of entry timing and metadata, including better handling for long content.

* **Bug Fixes**
  * Bottom sheet is now scroll-controlled for more consistent interaction.
  * Added snap-to-stops behavior with selection haptics, and improved long “details” rendering to prevent overflow.

* **Tests**
  * Added widget tests covering sheet display, snap/dismiss behavior, haptics, and key visible fields (title, professor, details).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->