### PR TITLE
Deduplicate same-window weekly schedule refreshes

### DIFF
--- a/docs/solutions/runtime-errors/sentry-schedule-same-window-refresh-dedupe-20260624.md
+++ b/docs/solutions/runtime-errors/sentry-schedule-same-window-refresh-dedupe-20260624.md
@@ -1,0 +1,36 @@
+---
+module: Schedule
+date: 2026-06-24
+problem_type: runtime_error
+component: weekly_schedule_refresh
+symptoms:
+  - "Sentry DUALMATE-H captured a handled SqfliteDatabaseException during startup"
+  - "Two schedule.refresh operations for the same date window entered schedule.state.apply within milliseconds"
+root_cause: same_window_refresh_race
+resolution_type: code_fix
+severity: medium
+tags: [sentry, schedule, sqlite, refresh, concurrency]
+---
+
+# Troubleshooting: Same-window schedule refresh race
+
+## Problem
+Startup could launch overlapping forced refreshes for the same weekly schedule
+window. Both refreshes fetched the same remote window and then wrote the same
+`ScheduleQueryInformation(start, end)` primary key.
+
+## Solution
+Deduplicate in-flight weekly schedule refreshes by date window. If another
+refresh for the same `(start, end)` window is already running, the duplicate
+request now joins that future instead of launching a second remote fetch and
+database write. Different visible-week requests still use the existing
+cancelable update path.
+
+As a second layer of hardening, `ScheduleQueryInformationRepository` now writes
+query metadata with an atomic SQLite replace insert instead of delete-then-insert.
+
+## Verification
+Covered with view-model tests for:
+- Two concurrent same-window forced refreshes.
+- A startup-style visible initial refresh plus another same-window forced refresh.
+- Different-window forced refreshes still launching independently.

--- a/lib/common/data/database_access.dart
+++ b/lib/common/data/database_access.dart
@@ -16,10 +16,12 @@ class DatabaseAccess {
   Future<Database> _initDatabase() async {
     final String path = await getDatabasePath(_databaseName);
 
-    return await openDatabase(path,
-        version: SqlScripts.databaseMigrationScripts.length,
-        onCreate: _onCreate,
-        onUpgrade: _onUpgrade);
+    return await openDatabase(
+      path,
+      version: SqlScripts.databaseMigrationScripts.length,
+      onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
+    );
   }
 
   Future<void> _onCreate(Database db, int version) async {
@@ -46,8 +48,19 @@ class DatabaseAccess {
     return await db.insert(table, row);
   }
 
+  Future<int> insertOrReplace(String table, Map<String, dynamic> row) async {
+    Database db = await _database;
+    return await db.insert(
+      table,
+      row,
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
   Future<void> insertBatch(
-      String table, List<Map<String, dynamic>> rows) async {
+    String table,
+    List<Map<String, dynamic>> rows,
+  ) async {
     if (rows.isEmpty) return;
 
     Database db = await _database;
@@ -66,21 +79,25 @@ class DatabaseAccess {
   }
 
   Future<List<Map<String, dynamic>>> rawQuery(
-      String sql, List<dynamic> parameters) async {
+    String sql,
+    List<dynamic> parameters,
+  ) async {
     Database db = await _database;
     return await db.rawQuery(sql, parameters);
   }
 
-  Future<List<Map<String, dynamic>>> queryRows(String table,
-      {bool? distinct,
-      List<String>? columns,
-      String? where,
-      List<dynamic>? whereArgs,
-      String? groupBy,
-      String? having,
-      String? orderBy,
-      int? limit,
-      int? offset}) async {
+  Future<List<Map<String, dynamic>>> queryRows(
+    String table, {
+    bool? distinct,
+    List<String>? columns,
+    String? where,
+    List<dynamic>? whereArgs,
+    String? groupBy,
+    String? having,
+    String? orderBy,
+    int? limit,
+    int? offset,
+  }) async {
     Database db = await _database;
 
     if (whereArgs != null) {
@@ -106,7 +123,8 @@ class DatabaseAccess {
   Future<int> queryRowCount(String table) async {
     Database db = await _database;
     return Sqflite.firstIntValue(
-            await db.rawQuery('SELECT COUNT(*) FROM $table')) ??
+          await db.rawQuery('SELECT COUNT(*) FROM $table'),
+        ) ??
         0;
   }
 
@@ -118,8 +136,12 @@ class DatabaseAccess {
   Future<int> update(String table, Map<String, dynamic> row) async {
     Database db = await _database;
     int id = row[idColumnName];
-    return await db
-        .update(table, row, where: '$idColumnName = ?', whereArgs: [id]);
+    return await db.update(
+      table,
+      row,
+      where: '$idColumnName = ?',
+      whereArgs: [id],
+    );
   }
 
   Future<int> delete(String table, int id) async {
@@ -133,10 +155,6 @@ class DatabaseAccess {
     List<dynamic>? whereArgs,
   }) async {
     Database db = await _database;
-    return await db.delete(
-      table,
-      where: where,
-      whereArgs: whereArgs,
-    );
+    return await db.delete(table, where: where, whereArgs: whereArgs);
   }
 }

--- a/lib/schedule/data/schedule_query_information_repository.dart
+++ b/lib/schedule/data/schedule_query_information_repository.dart
@@ -8,35 +8,34 @@ class ScheduleQueryInformationRepository {
   ScheduleQueryInformationRepository(this._database);
 
   Future<DateTime> getOldestQueryTimeBetweenDates(
-      DateTime start, DateTime end) async {
+    DateTime start,
+    DateTime end,
+  ) async {
     var oldestQueryTimeDate = await _database.queryAggregator(
       "SELECT MIN(queryTime) FROM ScheduleQueryInformation WHERE start<=? AND end>=?",
-      [
-        start.millisecondsSinceEpoch,
-        end.millisecondsSinceEpoch,
-      ],
+      [start.millisecondsSinceEpoch, end.millisecondsSinceEpoch],
     );
 
     return DateTime.fromMillisecondsSinceEpoch(oldestQueryTimeDate);
   }
 
   Future<List<ScheduleQueryInformation>> getQueryInformationBetweenDates(
-      DateTime start, DateTime end) async {
+    DateTime start,
+    DateTime end,
+  ) async {
     var rows = await _database.queryRows(
       ScheduleQueryInformationEntity.tableName(),
       where: "start<=? AND end>=?",
-      whereArgs: [
-        start.millisecondsSinceEpoch,
-        end.millisecondsSinceEpoch,
-      ],
+      whereArgs: [start.millisecondsSinceEpoch, end.millisecondsSinceEpoch],
     );
 
     var scheduleQueryInformation = <ScheduleQueryInformation>[];
 
     for (var row in rows) {
       scheduleQueryInformation.add(
-        ScheduleQueryInformationEntity.fromMap(row)
-            .asScheduleQueryInformation(),
+        ScheduleQueryInformationEntity.fromMap(
+          row,
+        ).asScheduleQueryInformation(),
       );
     }
 
@@ -44,17 +43,9 @@ class ScheduleQueryInformationRepository {
   }
 
   Future<void> saveScheduleQueryInformation(
-      ScheduleQueryInformation queryInformation) async {
-    await _database.deleteWhere(
-      ScheduleQueryInformationEntity.tableName(),
-      where: "start=? AND end=?",
-      whereArgs: [
-        queryInformation.start.millisecondsSinceEpoch,
-        queryInformation.end.millisecondsSinceEpoch
-      ],
-    );
-
-    await _database.insert(
+    ScheduleQueryInformation queryInformation,
+  ) async {
+    await _database.insertOrReplace(
       ScheduleQueryInformationEntity.tableName(),
       ScheduleQueryInformationEntity.fromModel(queryInformation).toMap(),
     );

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -78,6 +78,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   final Map<String, Schedule> _memoryWeekCache = {};
   final Map<String, Future<void>> _prefetchInFlight = {};
   final Map<String, Future<ScheduleQueryResult?>> _refreshInFlightByWindow = {};
+  int _scheduleSourceGeneration = 0;
   Timer? _windowRefreshTimer;
 
   String? scheduleUrl;
@@ -263,6 +264,8 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   ) async {
     if (setupSuccess) {
       try {
+        _scheduleSourceGeneration += 1;
+        _refreshInFlightByWindow.clear();
         _memoryWeekCache.clear();
         _windowFreshnessGates.clear();
         _knownFetchedWindows.clear();
@@ -479,12 +482,14 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     lastRequestedEnd = end;
     lastRequestedStart = start;
 
-    final cacheKey = _windowKey(start, end);
-    final inFlightRefresh = _refreshInFlightByWindow[cacheKey];
+    final sourceGeneration = _scheduleSourceGeneration;
+    final refreshKey = _refreshKey(start, end, sourceGeneration);
+    final inFlightRefresh = _refreshInFlightByWindow[refreshKey];
     if (inFlightRefresh != null) {
       final joinFuture = _joinInFlightScheduleRefresh(
         start,
         end,
+        sourceGeneration,
         inFlightRefresh,
         applyToVisibleState: applyToVisibleState,
       );
@@ -535,6 +540,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         applyToVisibleState: applyToVisibleState,
         awaitRefresh: awaitRefresh,
         forceRefresh: force,
+        sourceGeneration: sourceGeneration,
         origin: applyToVisibleState
             ? ScheduleRefreshOrigin.userBrowsing
             : ScheduleRefreshOrigin.foregroundMaintenance,
@@ -554,6 +560,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     bool applyToVisibleState = true,
     bool awaitRefresh = false,
     bool forceRefresh = false,
+    required int sourceGeneration,
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
   }) async {
     final task = PerformanceTelemetry.instance.startTask(
@@ -615,6 +622,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       task,
       visibleUpdateRequestId: visibleUpdateRequestId,
       applyToVisibleState: applyToVisibleState,
+      sourceGeneration: sourceGeneration,
       origin: origin,
     );
 
@@ -634,6 +642,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     PerformanceTelemetryTask task, {
     int? visibleUpdateRequestId,
     bool applyToVisibleState = true,
+    required int sourceGeneration,
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
   }) async {
     ScheduleQueryResult? updatedSchedule;
@@ -642,9 +651,13 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         updatedSchedule = await _readScheduleFromServiceDeduped(
           start,
           end,
+          sourceGeneration,
           cancellationToken,
           origin: origin,
         );
+        if (!_isCurrentScheduleSourceGeneration(sourceGeneration)) {
+          return;
+        }
         if (updatedSchedule != null) {
           _freshnessGate.markFetched(start, end, now);
           _markWindowFetched(start, end, now);
@@ -735,6 +748,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   Future<void> _joinInFlightScheduleRefresh(
     DateTime start,
     DateTime end,
+    int sourceGeneration,
     Future<ScheduleQueryResult?> refreshFuture, {
     bool applyToVisibleState = true,
   }) async {
@@ -747,6 +761,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
     try {
       final updatedSchedule = await refreshFuture;
+      if (!_isCurrentScheduleSourceGeneration(sourceGeneration)) {
+        return;
+      }
       if (updatedSchedule != null) {
         _freshnessGate.markFetched(start, end, now);
         _markWindowFetched(start, end, now);
@@ -814,11 +831,12 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   Future<ScheduleQueryResult?> _readScheduleFromServiceDeduped(
     DateTime start,
     DateTime end,
+    int sourceGeneration,
     CancellationToken token, {
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
   }) {
-    final cacheKey = _windowKey(start, end);
-    final existingRefresh = _refreshInFlightByWindow[cacheKey];
+    final refreshKey = _refreshKey(start, end, sourceGeneration);
+    final existingRefresh = _refreshInFlightByWindow[refreshKey];
     if (existingRefresh != null) {
       return existingRefresh;
     }
@@ -826,12 +844,16 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     late final Future<ScheduleQueryResult?> refreshFuture;
     refreshFuture = _readScheduleFromService(start, end, token, origin: origin)
         .whenComplete(() {
-          if (identical(_refreshInFlightByWindow[cacheKey], refreshFuture)) {
-            _refreshInFlightByWindow.remove(cacheKey);
+          if (identical(_refreshInFlightByWindow[refreshKey], refreshFuture)) {
+            _refreshInFlightByWindow.remove(refreshKey);
           }
         });
-    _refreshInFlightByWindow[cacheKey] = refreshFuture;
+    _refreshInFlightByWindow[refreshKey] = refreshFuture;
     return refreshFuture;
+  }
+
+  bool _isCurrentScheduleSourceGeneration(int sourceGeneration) {
+    return !_isDisposed && sourceGeneration == _scheduleSourceGeneration;
   }
 
   Future<ScheduleQueryResult?> _readScheduleFromService(
@@ -959,6 +981,10 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
   String _windowKey(DateTime start, DateTime end) {
     return '${start.toIso8601String()}_${end.toIso8601String()}';
+  }
+
+  String _refreshKey(DateTime start, DateTime end, int sourceGeneration) {
+    return '$sourceGeneration:${_windowKey(start, end)}';
   }
 
   Future<void> _warmAdjacentWeeks(DateTime weekStart) async {

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -77,6 +77,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   final Set<String> _knownFetchedWindows = <String>{};
   final Map<String, Schedule> _memoryWeekCache = {};
   final Map<String, Future<void>> _prefetchInFlight = {};
+  final Map<String, Future<ScheduleQueryResult?>> _refreshInFlightByWindow = {};
   Timer? _windowRefreshTimer;
 
   String? scheduleUrl;
@@ -478,6 +479,23 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     lastRequestedEnd = end;
     lastRequestedStart = start;
 
+    final cacheKey = _windowKey(start, end);
+    final inFlightRefresh = _refreshInFlightByWindow[cacheKey];
+    if (inFlightRefresh != null) {
+      final joinFuture = _joinInFlightScheduleRefresh(
+        start,
+        end,
+        inFlightRefresh,
+        applyToVisibleState: applyToVisibleState,
+      );
+      if (awaitRefresh) {
+        await joinFuture;
+      } else {
+        unawaited(joinFuture);
+      }
+      return;
+    }
+
     await _updateMutex.acquireAndCancelOther();
 
     if (_isDisposed) {
@@ -621,7 +639,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     ScheduleQueryResult? updatedSchedule;
     try {
       try {
-        updatedSchedule = await _readScheduleFromService(
+        updatedSchedule = await _readScheduleFromServiceDeduped(
           start,
           end,
           cancellationToken,
@@ -661,19 +679,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       }
 
       if (updatedSchedule != null) {
-        var schedule = updatedSchedule.schedule;
-        _memoryWeekCache[_windowKey(start, end)] = schedule;
-
-        _applyVisibleSchedule(schedule, start, end);
-
-        _hasQueryErrors = updatedSchedule.hasError;
-        notifyIfMounted("hasQueryErrors");
-
-        if (updatedSchedule.hasError) {
-          _queryFailedCallback?.call();
-        }
-
-        scheduleUrl = schedule.urls.isNotEmpty ? schedule.urls[0] : null;
+        _applyUpdatedScheduleResult(start, end, updatedSchedule);
       }
 
       if (updatedSchedule != null) {
@@ -724,6 +730,108 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
     isUpdating = false;
     notifyIfMounted("isUpdating");
+  }
+
+  Future<void> _joinInFlightScheduleRefresh(
+    DateTime start,
+    DateTime end,
+    Future<ScheduleQueryResult?> refreshFuture, {
+    bool applyToVisibleState = true,
+  }) async {
+    int? visibleUpdateRequestId;
+    if (applyToVisibleState) {
+      visibleUpdateRequestId = ++_visibleUpdateRequestId;
+      isUpdating = true;
+      notifyIfMounted("isUpdating");
+    }
+
+    try {
+      final updatedSchedule = await refreshFuture;
+      if (updatedSchedule != null) {
+        _freshnessGate.markFetched(start, end, now);
+        _markWindowFetched(start, end, now);
+      }
+
+      if (_isDisposed || !applyToVisibleState) {
+        return;
+      }
+
+      if (currentDateStart != start || currentDateEnd != end) {
+        return;
+      }
+
+      if (updatedSchedule != null) {
+        _applyUpdatedScheduleResult(start, end, updatedSchedule);
+        _entryRefreshGate.markFetched(start, end, now);
+      }
+
+      updateFailed = updatedSchedule == null;
+      notifyIfMounted("updateFailed");
+
+      if (updateFailed) {
+        _cancelErrorInFuture();
+      }
+    } on OperationCancelledException {
+      return;
+    } catch (error, trace) {
+      if (kDebugMode) {
+        debugPrint("Joined schedule update failed: $error");
+      }
+      await reportException(error, trace);
+
+      if (applyToVisibleState && !_isDisposed) {
+        updateFailed = true;
+        notifyIfMounted("updateFailed");
+        _cancelErrorInFuture();
+      }
+    } finally {
+      if (applyToVisibleState) {
+        _endVisibleUpdateIfCurrent(visibleUpdateRequestId);
+      }
+    }
+  }
+
+  void _applyUpdatedScheduleResult(
+    DateTime start,
+    DateTime end,
+    ScheduleQueryResult updatedSchedule,
+  ) {
+    var schedule = updatedSchedule.schedule;
+    _memoryWeekCache[_windowKey(start, end)] = schedule;
+
+    _applyVisibleSchedule(schedule, start, end);
+
+    _hasQueryErrors = updatedSchedule.hasError;
+    notifyIfMounted("hasQueryErrors");
+
+    if (updatedSchedule.hasError) {
+      _queryFailedCallback?.call();
+    }
+
+    scheduleUrl = schedule.urls.isNotEmpty ? schedule.urls[0] : null;
+  }
+
+  Future<ScheduleQueryResult?> _readScheduleFromServiceDeduped(
+    DateTime start,
+    DateTime end,
+    CancellationToken token, {
+    ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
+  }) {
+    final cacheKey = _windowKey(start, end);
+    final existingRefresh = _refreshInFlightByWindow[cacheKey];
+    if (existingRefresh != null) {
+      return existingRefresh;
+    }
+
+    late final Future<ScheduleQueryResult?> refreshFuture;
+    refreshFuture = _readScheduleFromService(start, end, token, origin: origin)
+        .whenComplete(() {
+          if (identical(_refreshInFlightByWindow[cacheKey], refreshFuture)) {
+            _refreshInFlightByWindow.remove(cacheKey);
+          }
+        });
+    _refreshInFlightByWindow[cacheKey] = refreshFuture;
+    return refreshFuture;
   }
 
   Future<ScheduleQueryResult?> _readScheduleFromService(
@@ -1011,6 +1119,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
 
     _errorResetTimer?.cancel();
     _prefetchInFlight.clear();
+    _refreshInFlightByWindow.clear();
 
     super.dispose();
   }

--- a/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
@@ -88,8 +88,9 @@ void main() {
         force: true,
       );
 
-      final titlesBefore =
-          viewModel.weekSchedule!.entries.map((entry) => entry.title).toList();
+      final titlesBefore = viewModel.weekSchedule!.entries
+          .map((entry) => entry.title)
+          .toList();
       expect(titlesBefore, contains('Course_MONDAY_PREVIOUS'));
       expect(titlesBefore, contains('Course_TUESDAY_PREVIOUS'));
 
@@ -100,8 +101,9 @@ void main() {
       expect(viewModel.currentDateEnd, visibleWeekEnd);
       expect(viewModel.currentDateStart.weekday, DateTime.monday);
 
-      final titlesAfter =
-          viewModel.weekSchedule!.entries.map((entry) => entry.title).toList();
+      final titlesAfter = viewModel.weekSchedule!.entries
+          .map((entry) => entry.title)
+          .toList();
       expect(titlesAfter, contains('Course_MONDAY_PREVIOUS'));
       expect(titlesAfter, contains('Course_TUESDAY_PREVIOUS'));
     },
@@ -129,63 +131,45 @@ void main() {
     expect(viewModel.currentDateEnd, updatedEnd);
   });
 
-  test('switching back to a recently fetched week does not refetch immediately',
-      () async {
-    var nowValue = DateTime(2026, 2, 9, 8, 0);
-    final entries = <ScheduleEntry>[
-      _entry(DateTime(2026, 2, 9), 'Mon_A'),
-      _entry(DateTime(2026, 2, 16), 'Mon_B'),
-    ];
-    final provider = _CountingScheduleProvider(entries);
-    final sourceProvider = _FakeScheduleSourceProvider();
-    final viewModel = WeeklyScheduleViewModel(
-      provider,
-      sourceProvider,
-      nowProvider: () => nowValue,
-    );
+  test(
+    'switching back to a recently fetched week does not refetch immediately',
+    () async {
+      var nowValue = DateTime(2026, 2, 9, 8, 0);
+      final entries = <ScheduleEntry>[
+        _entry(DateTime(2026, 2, 9), 'Mon_A'),
+        _entry(DateTime(2026, 2, 16), 'Mon_B'),
+      ];
+      final provider = _CountingScheduleProvider(entries);
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        sourceProvider,
+        nowProvider: () => nowValue,
+      );
 
-    final weekAStart = DateTime(2026, 2, 9);
-    final weekAEnd = DateTime(2026, 2, 16);
-    final weekBStart = DateTime(2026, 2, 16);
-    final weekBEnd = DateTime(2026, 2, 23);
+      final weekAStart = DateTime(2026, 2, 9);
+      final weekAEnd = DateTime(2026, 2, 16);
+      final weekBStart = DateTime(2026, 2, 16);
+      final weekBEnd = DateTime(2026, 2, 23);
 
-    await viewModel.updateSchedule(weekAStart, weekAEnd, force: true);
-    await Future<void>.delayed(const Duration(milliseconds: 30));
-    expect(provider.updatedScheduleRequests, 1);
+      await viewModel.updateSchedule(weekAStart, weekAEnd, force: true);
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(provider.updatedScheduleRequests, 1);
 
-    nowValue = nowValue.add(const Duration(seconds: 2));
-    await viewModel.updateSchedule(weekBStart, weekBEnd, force: true);
-    await Future<void>.delayed(const Duration(milliseconds: 30));
-    expect(provider.updatedScheduleRequests, 2);
+      nowValue = nowValue.add(const Duration(seconds: 2));
+      await viewModel.updateSchedule(weekBStart, weekBEnd, force: true);
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(provider.updatedScheduleRequests, 2);
 
-    nowValue = nowValue.add(const Duration(seconds: 2));
-    await viewModel.updateSchedule(weekAStart, weekAEnd);
-    await Future<void>.delayed(const Duration(milliseconds: 30));
-    expect(provider.updatedScheduleRequests, 2);
-  });
-
-  test('isUpdating stays true while visible background refresh is in flight',
-      () async {
-    final provider = _BlockingScheduleProvider();
-    final sourceProvider = _FakeScheduleSourceProvider();
-    final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
-
-    final weekStart = DateTime(2026, 2, 9);
-    final weekEnd = DateTime(2026, 2, 16);
-
-    await viewModel.updateSchedule(weekStart, weekEnd, force: true);
-    expect(viewModel.isUpdating, isTrue);
-
-    provider.complete(
-      ScheduleQueryResult(Schedule(), const []),
-    );
-    await Future<void>.delayed(const Duration(milliseconds: 30));
-
-    expect(viewModel.isUpdating, isFalse);
-  });
+      nowValue = nowValue.add(const Duration(seconds: 2));
+      await viewModel.updateSchedule(weekAStart, weekAEnd);
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(provider.updatedScheduleRequests, 2);
+    },
+  );
 
   test(
-    'refreshVisibleWeek awaits network refresh before completing',
+    'isUpdating stays true while visible background refresh is in flight',
     () async {
       final provider = _BlockingScheduleProvider();
       final sourceProvider = _FakeScheduleSourceProvider();
@@ -194,53 +178,162 @@ void main() {
       final weekStart = DateTime(2026, 2, 9);
       final weekEnd = DateTime(2026, 2, 16);
 
-      viewModel.currentDateStart = weekStart;
-      viewModel.currentDateEnd = weekEnd;
+      await viewModel.updateSchedule(weekStart, weekEnd, force: true);
+      expect(viewModel.isUpdating, isTrue);
 
-      var refreshCompleted = false;
-      final refreshFuture = viewModel.refreshVisibleWeek().then((_) {
-        refreshCompleted = true;
-      });
+      provider.complete(ScheduleQueryResult(Schedule(), const []));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
 
-      // Let microtasks run but the blocking provider hasn't completed yet.
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-      expect(refreshCompleted, isFalse,
-          reason: 'refreshVisibleWeek should not complete until network '
-              'request finishes');
-
-      // Now complete the network request.
-      provider.complete(
-        ScheduleQueryResult(Schedule(), const []),
-      );
-      await refreshFuture;
-      expect(refreshCompleted, isTrue);
+      expect(viewModel.isUpdating, isFalse);
     },
   );
 
+  test('refreshVisibleWeek awaits network refresh before completing', () async {
+    final provider = _BlockingScheduleProvider();
+    final sourceProvider = _FakeScheduleSourceProvider();
+    final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+
+    final weekStart = DateTime(2026, 2, 9);
+    final weekEnd = DateTime(2026, 2, 16);
+
+    viewModel.currentDateStart = weekStart;
+    viewModel.currentDateEnd = weekEnd;
+
+    var refreshCompleted = false;
+    final refreshFuture = viewModel.refreshVisibleWeek().then((_) {
+      refreshCompleted = true;
+    });
+
+    // Let microtasks run but the blocking provider hasn't completed yet.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(
+      refreshCompleted,
+      isFalse,
+      reason:
+          'refreshVisibleWeek should not complete until network '
+          'request finishes',
+    );
+
+    // Now complete the network request.
+    provider.complete(ScheduleQueryResult(Schedule(), const []));
+    await refreshFuture;
+    expect(refreshCompleted, isTrue);
+  });
+
+  test('refreshVisibleWeek forces fetch even when cache is fresh', () async {
+    final entries = <ScheduleEntry>[_entry(DateTime(2026, 2, 9), 'Mon')];
+    final provider = _CountingScheduleProvider(entries);
+    final sourceProvider = _FakeScheduleSourceProvider();
+    final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+
+    final weekStart = DateTime(2026, 2, 9);
+    final weekEnd = DateTime(2026, 2, 16);
+
+    // Initial load populates cache and marks window as fresh.
+    await viewModel.updateSchedule(weekStart, weekEnd, force: true);
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    expect(provider.updatedScheduleRequests, 1);
+
+    viewModel.currentDateStart = weekStart;
+    viewModel.currentDateEnd = weekEnd;
+
+    // Pull-to-refresh should fetch again even though cache is fresh.
+    await viewModel.refreshVisibleWeek();
+    expect(
+      provider.updatedScheduleRequests,
+      2,
+      reason: 'pull-to-refresh must bypass staleness gate',
+    );
+  });
+
   test(
-    'refreshVisibleWeek forces fetch even when cache is fresh',
+    'concurrent same-window forced refreshes share one provider update',
     () async {
-      final entries = <ScheduleEntry>[
-        _entry(DateTime(2026, 2, 9), 'Mon'),
-      ];
-      final provider = _CountingScheduleProvider(entries);
+      final provider = _BlockingCountingScheduleProvider();
       final sourceProvider = _FakeScheduleSourceProvider();
       final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+      addTearDown(viewModel.dispose);
 
       final weekStart = DateTime(2026, 2, 9);
       final weekEnd = DateTime(2026, 2, 16);
 
-      // Initial load populates cache and marks window as fresh.
-      await viewModel.updateSchedule(weekStart, weekEnd, force: true);
+      unawaited(viewModel.updateSchedule(weekStart, weekEnd, force: true));
+      await provider.waitForRequestCount(1);
+
+      final duplicateRefresh = viewModel.updateSchedule(
+        weekStart,
+        weekEnd,
+        force: true,
+        awaitRefresh: true,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 30));
       expect(provider.updatedScheduleRequests, 1);
 
-      viewModel.currentDateStart = weekStart;
-      viewModel.currentDateEnd = weekEnd;
+      provider.completeNext(ScheduleQueryResult(Schedule(), const []));
+      await duplicateRefresh;
 
-      // Pull-to-refresh should fetch again even though cache is fresh.
-      await viewModel.refreshVisibleWeek();
-      expect(provider.updatedScheduleRequests, 2,
-          reason: 'pull-to-refresh must bypass staleness gate');
+      expect(provider.updatedScheduleRequests, 1);
+    },
+  );
+
+  test(
+    'startup-style visible initial refresh deduplicates same-window refresh',
+    () async {
+      final provider = _BlockingCountingScheduleProvider();
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        sourceProvider,
+        nowProvider: () => DateTime(2026, 2, 10, 10),
+      );
+      addTearDown(viewModel.dispose);
+
+      final weekStart = DateTime(2026, 2, 9);
+      final weekEnd = DateTime(2026, 2, 16);
+
+      await viewModel.openWeekContaining(weekStart);
+      await provider.waitForRequestCount(1);
+
+      final duplicateRefresh = viewModel.updateSchedule(
+        weekStart,
+        weekEnd,
+        force: true,
+        awaitRefresh: true,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(provider.updatedScheduleRequests, 1);
+
+      provider.completeNext(ScheduleQueryResult(Schedule(), const []));
+      await duplicateRefresh;
+
+      expect(provider.updatedScheduleRequests, 1);
+    },
+  );
+
+  test(
+    'different-window forced refreshes still launch independently',
+    () async {
+      final provider = _BlockingCountingScheduleProvider();
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+      addTearDown(viewModel.dispose);
+
+      final weekAStart = DateTime(2026, 2, 9);
+      final weekAEnd = DateTime(2026, 2, 16);
+      final weekBStart = DateTime(2026, 2, 16);
+      final weekBEnd = DateTime(2026, 2, 23);
+
+      unawaited(viewModel.updateSchedule(weekAStart, weekAEnd, force: true));
+      await provider.waitForRequestCount(1);
+
+      unawaited(viewModel.updateSchedule(weekBStart, weekBEnd, force: true));
+      await provider.waitForRequestCount(2);
+
+      expect(provider.updatedScheduleRequests, 2);
+
+      provider.completeAll(ScheduleQueryResult(Schedule(), const []));
     },
   );
 }
@@ -345,6 +438,74 @@ class _BlockingScheduleProvider extends _FakeScheduleProvider {
     }
     _updatedScheduleCompleter.complete(result);
   }
+}
+
+class _BlockingCountingScheduleProvider extends _FakeScheduleProvider {
+  final List<Completer<ScheduleQueryResult>> _pendingRequests =
+      <Completer<ScheduleQueryResult>>[];
+  final List<_RequestCountWaiter> _requestCountWaiters =
+      <_RequestCountWaiter>[];
+  int updatedScheduleRequests = 0;
+
+  _BlockingCountingScheduleProvider() : super(const <ScheduleEntry>[]);
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken, {
+    ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
+  }) {
+    updatedScheduleRequests += 1;
+    origins.add(origin);
+    final completer = Completer<ScheduleQueryResult>();
+    _pendingRequests.add(completer);
+    _completeSatisfiedWaiters();
+    return completer.future;
+  }
+
+  Future<void> waitForRequestCount(int count) async {
+    if (updatedScheduleRequests >= count) {
+      return;
+    }
+    final completer = Completer<void>();
+    _requestCountWaiters.add(_RequestCountWaiter(count, completer));
+    await completer.future;
+  }
+
+  void completeNext(ScheduleQueryResult result) {
+    if (_pendingRequests.isEmpty) {
+      return;
+    }
+    final completer = _pendingRequests.removeAt(0);
+    if (!completer.isCompleted) {
+      completer.complete(result);
+    }
+  }
+
+  void completeAll(ScheduleQueryResult result) {
+    while (_pendingRequests.isNotEmpty) {
+      completeNext(result);
+    }
+  }
+
+  void _completeSatisfiedWaiters() {
+    for (final waiter in List<_RequestCountWaiter>.from(_requestCountWaiters)) {
+      if (updatedScheduleRequests >= waiter.count) {
+        if (!waiter.completer.isCompleted) {
+          waiter.completer.complete();
+        }
+        _requestCountWaiters.remove(waiter);
+      }
+    }
+  }
+}
+
+class _RequestCountWaiter {
+  final int count;
+  final Completer<void> completer;
+
+  _RequestCountWaiter(this.count, this.completer);
 }
 
 class _FakeScheduleSourceProvider implements ScheduleSourceProvider {

--- a/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
@@ -251,7 +251,11 @@ void main() {
     () async {
       final provider = _BlockingCountingScheduleProvider();
       final sourceProvider = _FakeScheduleSourceProvider();
-      final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        sourceProvider,
+        nowProvider: () => DateTime(2026, 2, 10, 10),
+      );
       addTearDown(viewModel.dispose);
 
       final weekStart = DateTime(2026, 2, 9);
@@ -311,6 +315,53 @@ void main() {
       expect(provider.updatedScheduleRequests, 1);
     },
   );
+
+  test('source changes do not reuse stale same-window refreshes', () async {
+    final provider = _BlockingCountingScheduleProvider();
+    final sourceProvider = _FakeScheduleSourceProvider();
+    final viewModel = WeeklyScheduleViewModel(
+      provider,
+      sourceProvider,
+      nowProvider: () => DateTime(2026, 2, 10, 10),
+    );
+    addTearDown(viewModel.dispose);
+
+    final weekStart = DateTime(2026, 2, 9);
+    final weekEnd = DateTime(2026, 2, 16);
+
+    await viewModel.initialize();
+    unawaited(viewModel.updateSchedule(weekStart, weekEnd, force: true));
+    await provider.waitForRequestCount(1);
+
+    sourceProvider.emitSourceChanged();
+    await provider.waitForRequestCount(2);
+
+    provider.completeNext(
+      ScheduleQueryResult(
+        Schedule.fromList([_entry(weekStart, 'OLD_SOURCE')]),
+        const [],
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    final titlesAfterOldSourceCompletes = viewModel.weekSchedule?.entries
+        .map((entry) => entry.title)
+        .toList();
+    expect(titlesAfterOldSourceCompletes, isNot(contains('Course_OLD_SOURCE')));
+
+    provider.completeNext(
+      ScheduleQueryResult(
+        Schedule.fromList([_entry(weekStart, 'NEW_SOURCE')]),
+        const [],
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(
+      viewModel.weekSchedule?.entries.map((entry) => entry.title),
+      contains('Course_NEW_SOURCE'),
+    );
+  });
 
   test(
     'different-window forced refreshes still launch independently',
@@ -510,6 +561,8 @@ class _RequestCountWaiter {
 
 class _FakeScheduleSourceProvider implements ScheduleSourceProvider {
   final ScheduleSource _source = _FakeScheduleSource();
+  final List<OnDidChangeScheduleSource> _callbacks =
+      <OnDidChangeScheduleSource>[];
 
   @override
   ScheduleSource get currentScheduleSource => _source;
@@ -518,12 +571,22 @@ class _FakeScheduleSourceProvider implements ScheduleSourceProvider {
   bool didSetupCorrectly() => true;
 
   @override
-  void addDidChangeScheduleSourceCallback(OnDidChangeScheduleSource callback) {}
+  void addDidChangeScheduleSourceCallback(OnDidChangeScheduleSource callback) {
+    _callbacks.add(callback);
+  }
 
   @override
   void removeDidChangeScheduleSourceCallback(
     OnDidChangeScheduleSource callback,
-  ) {}
+  ) {
+    _callbacks.remove(callback);
+  }
+
+  void emitSourceChanged() {
+    for (final callback in List<OnDidChangeScheduleSource>.from(_callbacks)) {
+      callback(_source, true);
+    }
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) {


### PR DESCRIPTION
## Summary
- Deduplicates in-flight weekly schedule refreshes for the same `(start, end)` window so duplicate requests join the existing fetch instead of starting a second one.
- Keeps different visible-week refreshes independent while preserving the existing cancelable update path.
- Hardens `ScheduleQueryInformation` writes by switching to atomic replace inserts instead of delete-then-insert.
- Adds regression coverage for concurrent same-window refreshes, startup-style duplicate refreshes, and separate-window refreshes.

## Testing
- `flutter test test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart`
- Verified new tests cover:
  - concurrent same-window forced refreshes only hit the provider once
  - visible initial refresh plus duplicate same-window refresh dedupe correctly
  - different-window forced refreshes still launch independently
- Not run: full test suite