### PR TITLE
Fix Dualis source dialog context crash

### DIFF
--- a/docs/solutions/runtime-errors/sentry-dualis-source-dialog-context-20260630.md
+++ b/docs/solutions/runtime-errors/sentry-dualis-source-dialog-context-20260630.md
@@ -1,0 +1,76 @@
+---
+module: Schedule source settings
+date: 2026-06-30
+problem_type: runtime_error
+component: frontend_flutter
+sentry_issue: DUALMATE-M
+root_cause: popped_dialog_context_reused_for_followup_dialog
+resolution_type: code_fix
+severity: medium
+tags: [sentry, dualis, schedule-source, dialog, flutter, android]
+---
+
+# Troubleshooting: Dualis source dialog context crash
+
+## Problem
+
+Sentry issue `DUALMATE-M` reported an unhandled `TypeError: Null check operator
+used on a null value` when selecting Dualis as the schedule source from the
+settings flow. The latest event showed this in-app path:
+
+- `SelectSourceDialog.sourceSelected`
+- `EnterDualisCredentialsDialog.show`
+- Flutter `showDialog`
+- `Navigator.of`
+- `StatefulElement.state`
+
+Users never saw the Dualis credentials dialog because the crash happened while
+Flutter tried to resolve the navigator for the follow-up dialog.
+
+## Root Cause
+
+`SelectSourceDialog` popped its own dialog and then reused that dialog builder's
+`BuildContext` to open the Dualis credentials dialog. After the pop, that context
+belonged to a detached element. Flutter's `showDialog` needs the context to find
+the navigator and capture inherited themes, so the stale context failed inside
+`Navigator.of(context)`.
+
+The same sequencing also committed the selected schedule source before the
+follow-up configuration dialog completed.
+
+## Solution
+
+`SelectSourceDialog.show(context)` now treats the source picker as a value
+selector:
+
+1. show the source dialog and return the selected `ScheduleSourceType`
+2. close only the source dialog from the dialog builder context
+3. after `showDialog` completes, use the original caller context for the
+   follow-up configuration dialog
+4. guard the follow-up with `context.mounted`
+5. commit configured sources only when their setup dialogs save successfully
+
+For Dualis, selecting the radio option now opens the credentials dialog from the
+still-mounted settings/schedule page context. The source is committed only after
+the user confirms credentials and `setupForDualis()` runs.
+
+## Test Coverage
+
+- selecting Dualis opens the credentials dialog without reusing the disposed
+  source dialog context
+- selecting Dualis does not commit the schedule source before credentials are
+  accepted
+- selecting No schedule still closes the source dialog and initializes the empty
+  source
+
+## Commands
+
+```bash
+flutter test test/schedule/ui/widgets/select_source_dialog_test.dart
+flutter test test/ui/settings/settings_page_lifecycle_test.dart
+flutter test test/ui/login_credentials_widget_autofill_test.dart
+flutter analyze \
+  lib/schedule/ui/widgets/select_source_dialog.dart \
+  lib/schedule/ui/widgets/enter_dualis_credentials_dialog.dart \
+  test/schedule/ui/widgets/select_source_dialog_test.dart
+```

--- a/lib/schedule/ui/widgets/select_source_dialog.dart
+++ b/lib/schedule/ui/widgets/select_source_dialog.dart
@@ -17,14 +17,20 @@ class SelectSourceDialog {
 
   SelectSourceDialog(this._preferencesProvider, this._scheduleSourceProvider);
 
-  Future show(BuildContext context) async {
+  Future<void> show(BuildContext context) async {
     var type = await _preferencesProvider.getScheduleSourceType();
     _currentScheduleSource = ScheduleSourceType.values[type];
 
-    await showDialog(
+    final selectedType = await showDialog<ScheduleSourceType>(
       context: context,
       builder: (context) => _buildDialog(context),
     );
+
+    if (selectedType == null || !context.mounted) {
+      return;
+    }
+
+    await _configureSelectedSource(selectedType, context);
   }
 
   SimpleDialog _buildDialog(BuildContext context) {
@@ -32,7 +38,7 @@ class SelectSourceDialog {
       groupValue: _currentScheduleSource,
       onChanged: (value) {
         if (value != null) {
-          sourceSelected(value, context);
+          Navigator.of(context).pop(value);
         }
       },
       child: Column(
@@ -78,16 +84,13 @@ class SelectSourceDialog {
     );
   }
 
-  Future<void> sourceSelected(
+  Future<void> _configureSelectedSource(
     ScheduleSourceType type,
     BuildContext context,
   ) async {
-    _preferencesProvider.setScheduleSourceType(type.index);
-
-    Navigator.of(context).pop();
-
     switch (type) {
       case ScheduleSourceType.None:
+        await _preferencesProvider.setScheduleSourceType(type.index);
         await _scheduleSourceProvider.setupScheduleSource();
         break;
       case ScheduleSourceType.Rapla:

--- a/test/schedule/ui/widgets/select_source_dialog_test.dart
+++ b/test/schedule/ui/widgets/select_source_dialog_test.dart
@@ -1,0 +1,240 @@
+import 'package:dualmate/common/data/preferences/preferences_access.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
+import 'package:dualmate/schedule/data/schedule_query_information_repository.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:dualmate/schedule/ui/widgets/select_source_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kiwi/kiwi.dart';
+
+void main() {
+  late PreferencesProvider preferencesProvider;
+  late _FakeScheduleSourceProvider scheduleSourceProvider;
+
+  setUp(() {
+    KiwiContainer().clear();
+    preferencesProvider = PreferencesProvider(
+      _FakePreferencesAccess(),
+      _FakeSecureStorageAccess(),
+    );
+    scheduleSourceProvider = _FakeScheduleSourceProvider(preferencesProvider);
+    KiwiContainer().registerInstance<ScheduleSourceProvider>(
+      scheduleSourceProvider,
+    );
+  });
+
+  tearDown(() {
+    KiwiContainer().clear();
+  });
+
+  testWidgets(
+    'selecting Dualis opens credentials dialog without reusing disposed source dialog context',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrapWithApp(preferencesProvider, scheduleSourceProvider),
+      );
+
+      await tester.tap(find.text('Open source dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Dualis'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Dualis Login'), findsOneWidget);
+      expect(
+        find.text(
+          'To view the schedule from Dualis you have to log in using your account:',
+        ),
+        findsOneWidget,
+      );
+
+      await tester.enterText(find.byType(TextField).at(0), 'dualis-user');
+      await tester.enterText(find.byType(TextField).at(1), 'dualis-pass');
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      final credentials = await preferencesProvider.loadDualisCredentials();
+      expect(credentials.username, 'dualis-user');
+      expect(credentials.password, 'dualis-pass');
+      expect(scheduleSourceProvider.setupForDualisCalls, 1);
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.Dualis.index,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'selecting Dualis does not commit schedule source before credentials are accepted',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrapWithApp(preferencesProvider, scheduleSourceProvider),
+      );
+
+      await tester.tap(find.text('Open source dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Dualis'));
+      await tester.pumpAndSettle();
+
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.None.index,
+      );
+      expect(scheduleSourceProvider.setupForDualisCalls, 0);
+
+      await tester.enterText(find.byType(TextField).at(0), 'dualis-user');
+      await tester.enterText(find.byType(TextField).at(1), 'dualis-pass');
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(scheduleSourceProvider.setupForDualisCalls, 1);
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.Dualis.index,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'selecting None still closes source dialog and initializes empty source',
+    (tester) async {
+      await preferencesProvider.setScheduleSourceType(
+        ScheduleSourceType.Rapla.index,
+      );
+      await tester.pumpWidget(
+        _wrapWithApp(preferencesProvider, scheduleSourceProvider),
+      );
+
+      await tester.tap(find.text('Open source dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('No schedule'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Schedule'), findsNothing);
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.None.index,
+      );
+      expect(scheduleSourceProvider.setupScheduleSourceCalls, 1);
+      expect(tester.takeException(), isNull);
+    },
+  );
+}
+
+Widget _wrapWithApp(
+  PreferencesProvider preferencesProvider,
+  ScheduleSourceProvider scheduleSourceProvider,
+) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      LocalizationDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('en'), Locale('de')],
+    home: Builder(
+      builder: (context) {
+        return Scaffold(
+          body: Center(
+            child: TextButton(
+              onPressed: () async {
+                await SelectSourceDialog(
+                  preferencesProvider,
+                  scheduleSourceProvider,
+                ).show(context);
+              },
+              child: const Text('Open source dialog'),
+            ),
+          ),
+        );
+      },
+    ),
+  );
+}
+
+class _FakeScheduleSourceProvider extends ScheduleSourceProvider {
+  final PreferencesProvider _preferencesProvider;
+
+  int setupForDualisCalls = 0;
+  int setupScheduleSourceCalls = 0;
+
+  _FakeScheduleSourceProvider(this._preferencesProvider)
+    : super(
+        _preferencesProvider,
+        false,
+        _FakeScheduleEntryRepository(),
+        _FakeScheduleQueryInformationRepository(),
+      );
+
+  @override
+  Future<void> setupForDualis() async {
+    setupForDualisCalls += 1;
+    await _preferencesProvider.setScheduleSourceType(
+      ScheduleSourceType.Dualis.index,
+    );
+  }
+
+  @override
+  Future<bool> setupScheduleSource() async {
+    setupScheduleSourceCalls += 1;
+    return true;
+  }
+}
+
+class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+      'Unexpected ScheduleEntryRepository call: $invocation',
+    );
+  }
+}
+
+class _FakeScheduleQueryInformationRepository
+    implements ScheduleQueryInformationRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+      'Unexpected ScheduleQueryInformationRepository call: $invocation',
+    );
+  }
+}
+
+class _FakePreferencesAccess extends PreferencesAccess {
+  final Map<String, Object?> _store = <String, Object?>{};
+
+  @override
+  Future<void> set<T>(String key, T value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<T?> get<T>(String key) async {
+    return _store[key] as T?;
+  }
+}
+
+class _FakeSecureStorageAccess extends SecureStorageAccess {
+  final Map<String, String?> _store = <String, String?>{};
+
+  @override
+  Future<void> set(String key, String value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<String?> get(String key) async {
+    return _store[key];
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes a crash when choosing Dualis from the schedule source dialog by avoiding reuse of a disposed dialog `BuildContext`.
- Defers follow-up configuration until after the source picker closes, then opens the Dualis credentials dialog from the original mounted context.
- Commits the selected schedule source only after the relevant setup flow completes successfully.
- Adds regression coverage for Dualis selection, source commit timing, and the no-schedule path.
- Documents the runtime error and resolution in `docs/solutions/runtime-errors/`.

## Testing
- `flutter test test/schedule/ui/widgets/select_source_dialog_test.dart`
- Not run: `flutter test test/ui/settings/settings_page_lifecycle_test.dart`
- Not run: `flutter test test/ui/login_credentials_widget_autofill_test.dart`
- Not run: `flutter analyze lib/schedule/ui/widgets/select_source_dialog.dart lib/schedule/ui/widgets/enter_dualis_credentials_dialog.dart test/schedule/ui/widgets/select_source_dialog_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the schedule source selection flow so the chosen option is handled more reliably after the dialog closes.
  * Added safety checks to avoid continuing when no option is selected or when the screen is no longer available.

* **Tests**
  * Added widget coverage for selecting a schedule source, including the login flow, delayed setup until confirmation, and choosing no schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->