### PR TITLE
Suppress expected fetch/http failures from Sentry

### DIFF
--- a/docs/solutions/integration-issues/sentry-suppress-expected-schedule-fetch-failures-20260630.md
+++ b/docs/solutions/integration-issues/sentry-suppress-expected-schedule-fetch-failures-20260630.md
@@ -1,33 +1,26 @@
 ---
-module: Schedule
+module: App
 date: 2026-06-30
 problem_type: integration_issue
 component: sentry_reporting
 symptoms:
   - "Sentry Issues flooded with ServiceRequestFailed: Http request failed!"
   - "Sentry Issues flooded with ScheduleQueryFailedException for expected network outages"
-  - "Expected external schedule fetch failures escalated to Sentry Issues"
+  - "Expected external schedule/canteen/dualis fetch failures escalated to Sentry Issues"
 root_cause: expected_network_failures_reported_as_issues
 resolution_type: code_fix
 severity: medium
-tags: [sentry, diagnostics, schedule, network, telemetry]
+tags: [sentry, diagnostics, schedule, canteen, dualis, network, telemetry]
 ---
 
-# Suppress expected schedule fetch failures from Sentry Issues
+# Suppress expected external fetch failures from Sentry Issues
 
 ## Problem
 
-Expected external network/request failures from schedule refresh flows
-(`ServiceRequestFailed`, `ScheduleQueryFailedException` wrapping
-`ServiceRequestFailed`) were creating noisy Sentry Issues. These are not app
-bugs—they represent transient connectivity loss or source unavailability—but
-they consumed Sentry quota and obscured real regressions.
-
-`ErrorReportScheduleSourceDecorator` already tried to suppress connectivity
-errors by rethrowing `ScheduleQueryFailedException(ServiceRequestFailed)`
-without reporting. However, downstream catch blocks (notably
-`WeeklyScheduleViewModel._refreshScheduleInBackground`) called
-`reportException(e, stack)` on the rethrown exception, undoing the suppression.
+Expected external network/request failures from schedule, canteen, and dualis
+fetch flows were creating noisy Sentry Issues. These are not app bugs—they
+represent transient connectivity loss or source unavailability—but they
+consumed Sentry quota and obscured real regressions.
 
 ## Solution
 
@@ -46,29 +39,44 @@ bool isExpectedScheduleFetchFailure(Object error) {
 }
 ```
 
-This classifies failures by typed exception hierarchy—not message strings—so
-it remains robust against redacted or localized messages.
+Classifies failures by typed exception hierarchy, not message strings.
 
-### Centralized suppression in refresh paths
+### Schedule refresh paths
 
 - `WeeklyScheduleViewModel._refreshScheduleInBackground` and
   `_joinInFlightScheduleRefresh`: skip `reportException` when
-  `isExpectedScheduleFetchFailure(e)` is true, but still set
-  `task.setCoarseStatus('network_error')`, call `task.fail(...)`, and set
-  `updateFailed = true`.
-- `_readScheduleFromService`: no longer swallows
-  `ScheduleQueryFailedException` into `null`. Exceptions propagate so the
-  catch-all can classify them, update telemetry, and decide reporting.
-- `BackgroundScheduleUpdate.updateSchedule`: wraps its
-  `reportCaughtException` call in the same `isExpectedScheduleFetchFailure`
-  guard.
+  `isExpectedScheduleFetchFailure(e)` is true, but still set telemetry status
+  and `updateFailed`.
+- `_readScheduleFromService`: propagates exceptions instead of swallowing all
+  `ScheduleQueryFailedException` into `null`.
+- `BackgroundScheduleUpdate.updateSchedule`: guards its
+  `reportCaughtException` call.
+- `ErrorReportScheduleSourceDecorator`: rethrows all
+  `ScheduleQueryFailedException` without reporting (callers own the decision).
 
-### Decorator simplification
+### Canteen paths
 
-`ErrorReportScheduleSourceDecorator` now rethrows all
-`ScheduleQueryFailedException` variants without reporting. The calling refresh
-path owns the Sentry Issue decision. This eliminates double-reporting for
-unexpected `ScheduleQueryFailedException` variants.
+- `CanteenScraper._makeRequest` and `DhbwAppCanteenSource`: now throw typed
+  `ServiceRequestFailed` instead of generic `Exception` for HTTP failures.
+- `BackgroundCanteenUpdate.updateCanteen`: guards its
+  `reportCaughtException` call with `isExpectedScheduleFetchFailure`.
+- `RootPage._runCanteenPrewarm`: guards its canteen prewarm report.
+
+### Dualis paths
+
+- `StudyGradesViewModel` (`loadStudyGrades`, `loadAllModules`,
+  `loadSemesterByName`, `loadSemesterNamesForCurrentSelection`): swallow
+  expected network failures via `isExpectedScheduleFetchFailure` so they
+  don't propagate as unhandled async exceptions. Unexpected errors still
+  rethrow.
+- `DualisLoginViewModel.testCredentials`: guards `reportException` call.
+- `MannheimViewModel.loadCourses`: guards `reportException` call.
+
+### Global error handler
+
+- `main.dart` `FlutterError.onError`: guards `reportException` with
+  `isExpectedScheduleFetchFailure` so unhandled expected network failures
+  don't create Sentry Issues.
 
 ## What still goes to Sentry
 
@@ -76,28 +84,27 @@ unexpected `ScheduleQueryFailedException` variants.
   regressions) via `ScheduleProvider.getUpdatedSchedule` error forwarding.
 - Non-network `ScheduleQueryFailedException` (e.g. wrapping `StateError`).
 - Database/cache/state errors, null errors, lifecycle errors.
-- Any unexpected exception during refresh.
+- Any unexpected exception in any feature path.
 
 ## What is suppressed (telemetry only)
 
-- `ServiceRequestFailed` (HTTP request failures).
+- `ServiceRequestFailed` (HTTP request failures) from any feature.
 - `ScheduleQueryFailedException` where `innerException is ServiceRequestFailed`.
 
-These still:
-- Set `updateFailed = true` in the view model.
-- Mark the performance task with `network_error` coarse status.
-- Fail/finish the telemetry task/span.
-- Allow retry on the next refresh cycle (freshness gates not marked fetched).
+These still update UI failure state, mark telemetry tasks, and allow retry.
 
 ## Privacy
 
-No changes to `sentry_scrubber.dart`. No raw URLs, schedule titles, rooms,
-credentials, or user-identifying values are added to Sentry. Existing
-scrubbing behavior is fully preserved.
+No changes to `sentry_scrubber.dart`. Existing scrubbing fully preserved.
 
 ## Verification
 
 - `test/schedule/ui/viewmodels/weekly_schedule_sentry_suppression_test.dart`
-  covers all five required scenarios.
-- Full schedule, background, date_management, and logging test suites pass
-  (322 tests total).
+  (12 tests)
+- `test/canteen/background/background_canteen_update_sentry_suppression_test.dart`
+  (2 tests)
+- `test/canteen/service/dhbw_app_canteen_source_test.dart` (added
+  ServiceRequestFailed type assertion)
+- `test/dualis/ui/viewmodels/study_grades_view_model_test.dart` (added 4
+  swallow/rethrow tests)
+- Full suite: 329 tests pass.

--- a/docs/solutions/integration-issues/sentry-suppress-expected-schedule-fetch-failures-20260630.md
+++ b/docs/solutions/integration-issues/sentry-suppress-expected-schedule-fetch-failures-20260630.md
@@ -1,0 +1,103 @@
+---
+module: Schedule
+date: 2026-06-30
+problem_type: integration_issue
+component: sentry_reporting
+symptoms:
+  - "Sentry Issues flooded with ServiceRequestFailed: Http request failed!"
+  - "Sentry Issues flooded with ScheduleQueryFailedException for expected network outages"
+  - "Expected external schedule fetch failures escalated to Sentry Issues"
+root_cause: expected_network_failures_reported_as_issues
+resolution_type: code_fix
+severity: medium
+tags: [sentry, diagnostics, schedule, network, telemetry]
+---
+
+# Suppress expected schedule fetch failures from Sentry Issues
+
+## Problem
+
+Expected external network/request failures from schedule refresh flows
+(`ServiceRequestFailed`, `ScheduleQueryFailedException` wrapping
+`ServiceRequestFailed`) were creating noisy Sentry Issues. These are not app
+bugs—they represent transient connectivity loss or source unavailability—but
+they consumed Sentry quota and obscured real regressions.
+
+`ErrorReportScheduleSourceDecorator` already tried to suppress connectivity
+errors by rethrowing `ScheduleQueryFailedException(ServiceRequestFailed)`
+without reporting. However, downstream catch blocks (notably
+`WeeklyScheduleViewModel._refreshScheduleInBackground`) called
+`reportException(e, stack)` on the rethrown exception, undoing the suppression.
+
+## Solution
+
+### Typed classifier
+
+Added `isExpectedScheduleFetchFailure(Object error)` to
+`lib/schedule/service/schedule_source.dart`:
+
+```dart
+bool isExpectedScheduleFetchFailure(Object error) {
+  if (error is ServiceRequestFailed) return true;
+  if (error is ScheduleQueryFailedException) {
+    return error.innerException is ServiceRequestFailed;
+  }
+  return false;
+}
+```
+
+This classifies failures by typed exception hierarchy—not message strings—so
+it remains robust against redacted or localized messages.
+
+### Centralized suppression in refresh paths
+
+- `WeeklyScheduleViewModel._refreshScheduleInBackground` and
+  `_joinInFlightScheduleRefresh`: skip `reportException` when
+  `isExpectedScheduleFetchFailure(e)` is true, but still set
+  `task.setCoarseStatus('network_error')`, call `task.fail(...)`, and set
+  `updateFailed = true`.
+- `_readScheduleFromService`: no longer swallows
+  `ScheduleQueryFailedException` into `null`. Exceptions propagate so the
+  catch-all can classify them, update telemetry, and decide reporting.
+- `BackgroundScheduleUpdate.updateSchedule`: wraps its
+  `reportCaughtException` call in the same `isExpectedScheduleFetchFailure`
+  guard.
+
+### Decorator simplification
+
+`ErrorReportScheduleSourceDecorator` now rethrows all
+`ScheduleQueryFailedException` variants without reporting. The calling refresh
+path owns the Sentry Issue decision. This eliminates double-reporting for
+unexpected `ScheduleQueryFailedException` variants.
+
+## What still goes to Sentry
+
+- Parse exceptions (`ElementNotFoundParseException`, HTML/ICS structure
+  regressions) via `ScheduleProvider.getUpdatedSchedule` error forwarding.
+- Non-network `ScheduleQueryFailedException` (e.g. wrapping `StateError`).
+- Database/cache/state errors, null errors, lifecycle errors.
+- Any unexpected exception during refresh.
+
+## What is suppressed (telemetry only)
+
+- `ServiceRequestFailed` (HTTP request failures).
+- `ScheduleQueryFailedException` where `innerException is ServiceRequestFailed`.
+
+These still:
+- Set `updateFailed = true` in the view model.
+- Mark the performance task with `network_error` coarse status.
+- Fail/finish the telemetry task/span.
+- Allow retry on the next refresh cycle (freshness gates not marked fetched).
+
+## Privacy
+
+No changes to `sentry_scrubber.dart`. No raw URLs, schedule titles, rooms,
+credentials, or user-identifying values are added to Sentry. Existing
+scrubbing behavior is fully preserved.
+
+## Verification
+
+- `test/schedule/ui/viewmodels/weekly_schedule_sentry_suppression_test.dart`
+  covers all five required scenarios.
+- Full schedule, background, date_management, and logging test suites pass
+  (322 tests total).

--- a/lib/canteen/background/background_canteen_update.dart
+++ b/lib/canteen/background/background_canteen_update.dart
@@ -4,6 +4,7 @@ import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/common/util/date_utils.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 
 class BackgroundCanteenUpdate extends TaskCallback {
   static const String name = 'BackgroundCanteenUpdate';
@@ -28,15 +29,17 @@ class BackgroundCanteenUpdate extends TaskCallback {
       print(exception);
       print(trace);
       try {
-        await AppDiagnostics.instance.reportCaughtException(
-          exception,
-          trace,
-          message: 'Background canteen update failed',
-          tags: {'feature': 'canteen'},
-          contexts: {
-            'canteen_update': {'task': name},
-          },
-        );
+        if (!isExpectedScheduleFetchFailure(exception)) {
+          await AppDiagnostics.instance.reportCaughtException(
+            exception,
+            trace,
+            message: 'Background canteen update failed',
+            tags: {'feature': 'canteen'},
+            contexts: {
+              'canteen_update': {'task': name},
+            },
+          );
+        }
       } catch (reportError, reportTrace) {
         print("Failed to report exception:");
         print(reportError);
@@ -44,7 +47,8 @@ class BackgroundCanteenUpdate extends TaskCallback {
       }
       print("Background canteen update status: failure");
       print(
-          "Background canteen update next: retry in ${_retryInterval.inHours}h");
+        "Background canteen update next: retry in ${_retryInterval.inHours}h",
+      );
       return;
     }
 
@@ -64,11 +68,7 @@ class BackgroundCanteenUpdate extends TaskCallback {
 
   @override
   Future<void> schedule() async {
-    await _scheduler.schedulePeriodic(
-      _retryInterval,
-      getName(),
-      true,
-    );
+    await _scheduler.schedulePeriodic(_retryInterval, getName(), true);
   }
 
   @override

--- a/lib/canteen/service/canteen_scraper.dart
+++ b/lib/canteen/service/canteen_scraper.dart
@@ -3,6 +3,7 @@ import 'dart:isolate';
 import 'package:dualmate/canteen/model/daily_menu.dart';
 import 'package:dualmate/canteen/service/canteen_parser.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:http/http.dart';
 import 'package:http_client_helper/http_client_helper.dart' as http;
 
@@ -49,8 +50,9 @@ class CanteenScraper {
   int _isoWeekNumber(DateTime date) {
     var thursday = date.add(Duration(days: 4 - date.weekday));
     var firstThursday = DateTime(thursday.year, 1, 4);
-    var firstWeekStart =
-        firstThursday.subtract(Duration(days: firstThursday.weekday - 1));
+    var firstWeekStart = firstThursday.subtract(
+      Duration(days: firstThursday.weekday - 1),
+    );
 
     return 1 + (thursday.difference(firstWeekStart).inDays / 7).floor();
   }
@@ -67,11 +69,13 @@ class CanteenScraper {
         requestCancellationToken.cancel();
       });
 
-      var response = await http.HttpClientHelper.get(uri,
-          cancelToken: requestCancellationToken);
+      var response = await http.HttpClientHelper.get(
+        uri,
+        cancelToken: requestCancellationToken,
+      );
 
       if (response == null && !requestCancellationToken.isCanceled) {
-        throw Exception("Http request failed!");
+        throw ServiceRequestFailed("Http request failed!");
       }
 
       if (response == null) {

--- a/lib/canteen/service/dhbw_app_canteen_source.dart
+++ b/lib/canteen/service/dhbw_app_canteen_source.dart
@@ -5,6 +5,7 @@ import 'package:dualmate/canteen/model/meal.dart';
 import 'package:dualmate/canteen/model/meal_type.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/common/util/date_utils.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http_client_helper/http_client_helper.dart' as http;
 
@@ -119,7 +120,7 @@ class DhbwAppCanteenSource {
         if (requestCancellationToken.isCanceled) {
           throw OperationCancelledException();
         }
-        throw Exception('DHBW.app canteen request failed');
+        throw ServiceRequestFailed('DHBW.app canteen request failed');
       }
 
       return compute(

--- a/lib/date_management/business/rapla_important_events_provider.dart
+++ b/lib/date_management/business/rapla_important_events_provider.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/logging/crash_reporting.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/date_management/model/important_event.dart';
@@ -48,7 +51,10 @@ class RaplaImportantEventsProvider {
       return updatedSchedule;
     } on OperationCancelledException {
       return null;
-    } on ScheduleQueryFailedException {
+    } on ScheduleQueryFailedException catch (e, trace) {
+      if (!isExpectedScheduleFetchFailure(e)) {
+        unawaited(reportException(e, trace));
+      }
       return null;
     }
   }
@@ -94,7 +100,8 @@ class RaplaImportantEventsProvider {
   }
 
   static List<ImportantEvent> mergeImportantEntries(
-      List<ScheduleEntry> entries) {
+    List<ScheduleEntry> entries,
+  ) {
     if (entries.isEmpty) return [];
 
     var grouped = <String, List<ScheduleEntry>>{};
@@ -114,13 +121,15 @@ class RaplaImportantEventsProvider {
       });
       if (groupEntries.first.type == ScheduleEntryType.Exam) {
         for (var entry in groupEntries) {
-          mergedEntries.add(ImportantEvent(
-            title: entry.title,
-            start: entry.start,
-            end: entry.end,
-            professor: entry.professor,
-            type: entry.type,
-          ));
+          mergedEntries.add(
+            ImportantEvent(
+              title: entry.title,
+              start: entry.start,
+              end: entry.end,
+              professor: entry.professor,
+              type: entry.type,
+            ),
+          );
         }
         return;
       }
@@ -132,12 +141,14 @@ class RaplaImportantEventsProvider {
       var currentEventEnd = groupEntries.first.end;
 
       void flushCurrent() {
-        mergedEntries.add(ImportantEvent(
-          title: currentTitle,
-          start: currentEventStart,
-          end: currentEventEnd,
-          type: currentType,
-        ));
+        mergedEntries.add(
+          ImportantEvent(
+            title: currentTitle,
+            start: currentEventStart,
+            end: currentEventEnd,
+            type: currentType,
+          ),
+        );
       }
 
       for (var i = 1; i < groupEntries.length; i++) {

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/logging/app_diagnostics.dart';
+import 'package:dualmate/common/logging/crash_reporting.dart';
 import 'package:dualmate/common/ui/viewmodels/base_view_model.dart';
 import 'package:dualmate/common/util/cancelable_mutex.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
@@ -691,7 +692,10 @@ class DateManagementViewModel extends BaseViewModel {
       return importantEvents;
     } on OperationCancelledException {
       return null;
-    } on ScheduleQueryFailedException {
+    } on ScheduleQueryFailedException catch (e, trace) {
+      if (!isExpectedScheduleFetchFailure(e)) {
+        unawaited(reportException(e, trace));
+      }
       return null;
     }
   }

--- a/lib/dualis/ui/viewmodels/study_grades_view_model.dart
+++ b/lib/dualis/ui/viewmodels/study_grades_view_model.dart
@@ -74,6 +74,7 @@ class StudyGradesViewModel extends BaseViewModel {
   bool _pageActivationInFlight = false;
   bool _refreshInFlight = false;
   bool _autoRestoreSuppressed = false;
+  bool _refreshHadNetworkError = false;
 
   StudyGradesViewModel(this._preferencesProvider, this._dualisService);
 
@@ -193,7 +194,11 @@ class StudyGradesViewModel extends BaseViewModel {
       });
     } on OperationCancelledException catch (_) {
     } catch (e) {
-      if (!isExpectedScheduleFetchFailure(e)) rethrow;
+      if (isExpectedScheduleFetchFailure(e)) {
+        _refreshHadNetworkError = true;
+      } else {
+        rethrow;
+      }
     } finally {
       _studyGradesCancellationToken.release();
       if (epoch != _studyGradesLoadEpoch) {
@@ -234,7 +239,11 @@ class StudyGradesViewModel extends BaseViewModel {
       });
     } on OperationCancelledException catch (_) {
     } catch (e) {
-      if (!isExpectedScheduleFetchFailure(e)) rethrow;
+      if (isExpectedScheduleFetchFailure(e)) {
+        _refreshHadNetworkError = true;
+      } else {
+        rethrow;
+      }
     } finally {
       _allModulesCancellationToken.release();
       if (epoch != _allModulesLoadEpoch) {
@@ -296,7 +305,11 @@ class StudyGradesViewModel extends BaseViewModel {
       });
     } on OperationCancelledException catch (_) {
     } catch (e) {
-      if (!isExpectedScheduleFetchFailure(e)) rethrow;
+      if (isExpectedScheduleFetchFailure(e)) {
+        _refreshHadNetworkError = true;
+      } else {
+        rethrow;
+      }
     } finally {
       _currentSemesterCancellationToken.release();
       if (epoch != _currentSemesterLoadEpoch) {
@@ -346,7 +359,11 @@ class StudyGradesViewModel extends BaseViewModel {
       });
     } on OperationCancelledException catch (_) {
     } catch (e) {
-      if (!isExpectedScheduleFetchFailure(e)) rethrow;
+      if (isExpectedScheduleFetchFailure(e)) {
+        _refreshHadNetworkError = true;
+      } else {
+        rethrow;
+      }
     } finally {
       _semesterNamesCancellationToken.release();
       if (epoch != _semesterNamesLoadEpoch) {
@@ -372,6 +389,7 @@ class StudyGradesViewModel extends BaseViewModel {
     }
 
     _refreshInFlight = true;
+    _refreshHadNetworkError = false;
     try {
       if (force) {
         _dualisService.clearCache();
@@ -387,7 +405,9 @@ class StudyGradesViewModel extends BaseViewModel {
         ),
       ]);
 
-      await _preferencesProvider.setDualisLastRefreshAt(DateTime.now());
+      if (!_refreshHadNetworkError) {
+        await _preferencesProvider.setDualisLastRefreshAt(DateTime.now());
+      }
     } finally {
       _refreshInFlight = false;
     }

--- a/lib/dualis/ui/viewmodels/study_grades_view_model.dart
+++ b/lib/dualis/ui/viewmodels/study_grades_view_model.dart
@@ -11,6 +11,7 @@ import 'package:dualmate/dualis/model/semester.dart';
 import 'package:dualmate/dualis/model/study_grades.dart';
 import 'package:dualmate/dualis/service/dualis_service.dart';
 import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:flutter/foundation.dart';
 
 enum LoginState {
@@ -191,6 +192,8 @@ class StudyGradesViewModel extends BaseViewModel {
         _studyGrades = loadedStudyGrades;
       });
     } on OperationCancelledException catch (_) {
+    } catch (e) {
+      if (!isExpectedScheduleFetchFailure(e)) rethrow;
     } finally {
       _studyGradesCancellationToken.release();
       if (epoch != _studyGradesLoadEpoch) {
@@ -230,6 +233,8 @@ class StudyGradesViewModel extends BaseViewModel {
         _allModules = loadedModules;
       });
     } on OperationCancelledException catch (_) {
+    } catch (e) {
+      if (!isExpectedScheduleFetchFailure(e)) rethrow;
     } finally {
       _allModulesCancellationToken.release();
       if (epoch != _allModulesLoadEpoch) {
@@ -290,6 +295,8 @@ class StudyGradesViewModel extends BaseViewModel {
         _currentSemester = loadedSemester;
       });
     } on OperationCancelledException catch (_) {
+    } catch (e) {
+      if (!isExpectedScheduleFetchFailure(e)) rethrow;
     } finally {
       _currentSemesterCancellationToken.release();
       if (epoch != _currentSemesterLoadEpoch) {
@@ -338,6 +345,8 @@ class StudyGradesViewModel extends BaseViewModel {
         _semesterNames = loadedSemesterNames;
       });
     } on OperationCancelledException catch (_) {
+    } catch (e) {
+      if (!isExpectedScheduleFetchFailure(e)) rethrow;
     } finally {
       _semesterNamesCancellationToken.release();
       if (epoch != _semesterNamesLoadEpoch) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/logging/crash_reporting.dart';
 import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/logging/sentry_configuration.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -39,7 +40,9 @@ Future<void> main() async {
   );
   FlutterError.onError = (FlutterErrorDetails details) {
     FlutterError.dumpErrorToConsole(details);
-    reportException(details.exception, details.stack ?? StackTrace.current);
+    if (!isExpectedScheduleFetchFailure(details.exception)) {
+      reportException(details.exception, details.stack ?? StackTrace.current);
+    }
   };
 
   final rootApp = RootPage(startupStopwatch: _startupStopwatch);
@@ -76,4 +79,3 @@ Future<void> main() async {
     }
   }());
 }
-

--- a/lib/schedule/background/background_schedule_update.dart
+++ b/lib/schedule/background/background_schedule_update.dart
@@ -45,21 +45,24 @@ class BackgroundScheduleUpdate extends TaskCallback {
       print("Background schedule update failed");
       print(e.innerException.toString());
       print(trace);
-      await AppDiagnostics.instance.reportCaughtException(
-        e,
-        trace,
-        message: 'Background schedule update failed',
-        tags: {'feature': 'schedule'},
-        contexts: {
-          'schedule_update': {
-            'origin': ScheduleRefreshOrigin.backgroundPeriodic.name,
-            'kind': 'query_failed',
+      if (!isExpectedScheduleFetchFailure(e)) {
+        await AppDiagnostics.instance.reportCaughtException(
+          e,
+          trace,
+          message: 'Background schedule update failed',
+          tags: {'feature': 'schedule'},
+          contexts: {
+            'schedule_update': {
+              'origin': ScheduleRefreshOrigin.backgroundPeriodic.name,
+              'kind': 'query_failed',
+            },
           },
-        },
-      );
+        );
+      }
       print("Background schedule update status: failure");
       print(
-          "Background schedule update next: retry in ${_updateInterval.inHours}h");
+        "Background schedule update next: retry in ${_updateInterval.inHours}h",
+      );
       return;
     } catch (e, trace) {
       print("Background schedule update unexpected failure");
@@ -79,7 +82,8 @@ class BackgroundScheduleUpdate extends TaskCallback {
       );
       print("Background schedule update status: failure");
       print(
-          "Background schedule update next: retry in ${_updateInterval.inHours}h");
+        "Background schedule update next: retry in ${_updateInterval.inHours}h",
+      );
       return;
     }
 
@@ -129,11 +133,7 @@ class BackgroundScheduleUpdate extends TaskCallback {
 
   @override
   Future<void> schedule() async {
-    await scheduler.schedulePeriodic(
-      _updateInterval,
-      getName(),
-      true,
-    );
+    await scheduler.schedulePeriodic(_updateInterval, getName(), true);
   }
 
   @override

--- a/lib/schedule/service/error_report_schedule_source_decorator.dart
+++ b/lib/schedule/service/error_report_schedule_source_decorator.dart
@@ -9,8 +9,11 @@ class ErrorReportScheduleSourceDecorator extends ScheduleSource {
   ErrorReportScheduleSourceDecorator(this._scheduleSource);
 
   @override
-  Future<ScheduleQueryResult> querySchedule(DateTime from, DateTime to,
-      [CancellationToken? cancellationToken]) async {
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]) async {
     try {
       var schedule = await _scheduleSource.querySchedule(
         from,
@@ -21,15 +24,15 @@ class ErrorReportScheduleSourceDecorator extends ScheduleSource {
       return schedule;
     } catch (ex, trace) {
       if (ex is OperationCancelledException) rethrow;
-      if (ex is ScheduleQueryFailedException) {
-        // Do not log connectivity exceptions
-        if (ex.innerException is ServiceRequestFailed) rethrow;
 
-        await reportException(ex, ex.trace ?? StackTrace.current);
-      } else {
-        await reportException(ex, trace);
-      }
+      // ScheduleQueryFailedException (both expected network failures and
+      // unexpected ones) is handled by the calling refresh path, which uses
+      // [isExpectedScheduleFetchFailure] to decide whether to report. This
+      // avoids double-reporting and lets the UI/telemetry layers stay in
+      // control of the Sentry Issue decision.
+      if (ex is ScheduleQueryFailedException) rethrow;
 
+      await reportException(ex, trace);
       rethrow;
     }
   }

--- a/lib/schedule/service/schedule_source.dart
+++ b/lib/schedule/service/schedule_source.dart
@@ -9,8 +9,11 @@ abstract class ScheduleSource {
   /// Returns a future which gives the updated schedule or throws an exception
   /// if an error happened or the operation was cancelled
   ///
-  Future<ScheduleQueryResult> querySchedule(DateTime from, DateTime to,
-      [CancellationToken? cancellationToken]);
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]);
 
   bool canQuery();
 }
@@ -23,7 +26,9 @@ class ScheduleQueryFailedException implements Exception {
 
   @override
   String toString() {
-    return (innerException?.toString() ?? "") + "\n" + (trace?.toString() ?? "");
+    return (innerException?.toString() ?? "") +
+        "\n" +
+        (trace?.toString() ?? "");
   }
 }
 
@@ -39,3 +44,17 @@ class ServiceRequestFailed implements Exception {
 }
 
 class EndpointUrlInvalid implements Exception {}
+
+/// Whether [error] represents an expected external network/request failure
+/// that should be tracked as telemetry but not escalated into a Sentry Issue.
+///
+/// This intentionally only matches the typed network/request subtype so that
+/// parse regressions, database/cache errors, and other unexpected exceptions
+/// keep flowing to Sentry.
+bool isExpectedScheduleFetchFailure(Object error) {
+  if (error is ServiceRequestFailed) return true;
+  if (error is ScheduleQueryFailedException) {
+    return error.innerException is ServiceRequestFailed;
+  }
+  return false;
+}

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -669,7 +669,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
           debugPrint("Schedule update failed: $e");
         }
         task.setCoarseStatus('network_error');
-        await reportException(e, stack);
+        if (!isExpectedScheduleFetchFailure(e)) {
+          await reportException(e, stack);
+        }
         await task.fail(e, includeErrorMessage: false);
       }
 
@@ -794,7 +796,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       if (kDebugMode) {
         debugPrint("Joined schedule update failed: $error");
       }
-      await reportException(error, trace);
+      if (!isExpectedScheduleFetchFailure(error)) {
+        await reportException(error, trace);
+      }
 
       if (applyToVisibleState && !_isDisposed) {
         updateFailed = true;
@@ -861,17 +865,17 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     DateTime end,
     CancellationToken token, {
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
-  }) async {
-    try {
-      return await scheduleProvider.getUpdatedSchedule(
-        start,
-        end,
-        token,
-        origin: origin,
-      );
-    } on ScheduleQueryFailedException {
-      return null;
-    }
+  }) {
+    // Exceptions (including ScheduleQueryFailedException) are intentionally
+    // allowed to propagate so that the refresh catch-all can classify them
+    // via [isExpectedScheduleFetchFailure], update UI/telemetry state, and
+    // decide whether to create a Sentry Issue.
+    return scheduleProvider.getUpdatedSchedule(
+      start,
+      end,
+      token,
+      origin: origin,
+    );
   }
 
   void _cancelErrorInFuture() {

--- a/lib/ui/onboarding/viewmodels/dualis_login_view_model.dart
+++ b/lib/ui/onboarding/viewmodels/dualis_login_view_model.dart
@@ -4,6 +4,7 @@ import 'package:dualmate/common/logging/crash_reporting.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/dualis/model/credentials.dart';
 import 'package:dualmate/dualis/service/dualis_service.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:dualmate/ui/onboarding/viewmodels/onboarding_view_model_base.dart';
 
 class DualisLoginViewModel extends OnboardingStepViewModel {
@@ -40,7 +41,9 @@ class DualisLoginViewModel extends OnboardingStepViewModel {
     } catch (ex, trace) {
       setIsValid(false);
       _passwordOrUsernameWrong = true;
-      unawaited(reportException(ex, trace));
+      if (!isExpectedScheduleFetchFailure(ex)) {
+        unawaited(reportException(ex, trace));
+      }
     } finally {
       _isLoading = false;
     }
@@ -54,9 +57,6 @@ class DualisLoginViewModel extends OnboardingStepViewModel {
 
     // To improve the onboarding experience we do not await this call because
     // it may take a few seconds
-    preferencesProvider.storeDualisCredentials(Credentials(
-      username,
-      password,
-    ));
+    preferencesProvider.storeDualisCredentials(Credentials(username, password));
   }
 }

--- a/lib/ui/onboarding/viewmodels/mannheim_view_model.dart
+++ b/lib/ui/onboarding/viewmodels/mannheim_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dualmate/common/logging/crash_reporting.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/service/mannheim/mannheim_course_scraper.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:dualmate/ui/onboarding/viewmodels/onboarding_view_model_base.dart';
 
 typedef MannheimCourseLoader = Future<List<Course>> Function();
@@ -42,7 +43,9 @@ class MannheimViewModel extends OnboardingStepViewModel {
     } catch (ex, trace) {
       _courses = [];
       _loadingState = LoadCoursesState.Failed;
-      unawaited(reportException(ex, trace));
+      if (!isExpectedScheduleFetchFailure(ex)) {
+        unawaited(reportException(ex, trace));
+      }
     }
 
     notifyListeners("loadingState");

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -14,6 +14,7 @@ import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/util/launch_intent.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:kiwi/kiwi.dart';
 import 'package:flutter/services.dart';
@@ -511,17 +512,19 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
       await prewarmCanteenIfStale();
     } catch (error, trace) {
       _debugRootError("Root init: canteen prewarm failed", error, trace);
-      unawaited(
-        AppDiagnostics.instance.reportCaughtException(
-          error,
-          trace,
-          message: 'Root init: canteen prewarm failed',
-          tags: {'feature': 'canteen'},
-          contexts: {
-            'canteen': {'phase': 'startup_prewarm'},
-          },
-        ),
-      );
+      if (!isExpectedScheduleFetchFailure(error)) {
+        unawaited(
+          AppDiagnostics.instance.reportCaughtException(
+            error,
+            trace,
+            message: 'Root init: canteen prewarm failed',
+            tags: {'feature': 'canteen'},
+            contexts: {
+              'canteen': {'phase': 'startup_prewarm'},
+            },
+          ),
+        );
+      }
     }
   }
 

--- a/test/canteen/background/background_canteen_update_sentry_suppression_test.dart
+++ b/test/canteen/background/background_canteen_update_sentry_suppression_test.dart
@@ -1,0 +1,85 @@
+import 'package:dualmate/canteen/background/background_canteen_update.dart';
+import 'package:dualmate/canteen/business/canteen_provider.dart';
+import 'package:dualmate/canteen/model/daily_menu.dart';
+import 'package:dualmate/common/background/task_callback.dart';
+import 'package:dualmate/common/background/work_scheduler_service.dart';
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'expected network failure does not crash and completes the update',
+    () async {
+      final update = BackgroundCanteenUpdate(
+        _ThrowingCanteenProvider(ServiceRequestFailed('Http request failed!')),
+        _FakeWorkSchedulerService(),
+      );
+
+      await expectLater(update.updateCanteen(), completes);
+    },
+  );
+
+  test('unexpected error does not crash and completes the update', () async {
+    final update = BackgroundCanteenUpdate(
+      _ThrowingCanteenProvider(StateError('unexpected canteen failure')),
+      _FakeWorkSchedulerService(),
+    );
+
+    await expectLater(update.updateCanteen(), completes);
+  });
+}
+
+class _ThrowingCanteenProvider implements CanteenProvider {
+  final Object _error;
+
+  _ThrowingCanteenProvider(this._error);
+
+  @override
+  Future<List<DailyMenu>> refreshWeek(
+    DateTime date, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    throw _error;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError('Unexpected CanteenProvider call: $invocation');
+  }
+}
+
+class _FakeWorkSchedulerService implements WorkSchedulerService {
+  @override
+  Future<void> cancelTask(String id) async {}
+
+  @override
+  Future<void> scheduleOneShotTaskAt(
+    DateTime date,
+    String id,
+    String name,
+  ) async {}
+
+  @override
+  Future<void> scheduleOneShotTaskIn(
+    Duration delay,
+    String id,
+    String name,
+  ) async {}
+
+  @override
+  Future<void> schedulePeriodic(
+    Duration delay,
+    String id, [
+    bool needsNetwork = false,
+  ]) async {}
+
+  @override
+  void registerTask(TaskCallback task) {}
+
+  @override
+  Future<void> executeTask(String id) async {}
+
+  @override
+  bool isSchedulingAvailable() => true;
+}

--- a/test/canteen/service/dhbw_app_canteen_source_test.dart
+++ b/test/canteen/service/dhbw_app_canteen_source_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:dualmate/canteen/service/dhbw_app_canteen_source.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -98,6 +99,20 @@ void main() {
     expect(requestWasCanceled, isTrue);
     expect(requestCount, 1);
   });
+
+  test(
+    'null response throws ServiceRequestFailed for Sentry suppression',
+    () async {
+      final source = DhbwAppCanteenSource(
+        loadSitePayloadResponse: (_, __) async => null,
+      );
+
+      await expectLater(
+        source.loadWeek('MA', 7, DateTime(2026, 6, 1)),
+        throwsA(isA<ServiceRequestFailed>()),
+      );
+    },
+  );
 
   test('evicts failed payload fetches so the next request can retry', () async {
     var requestCount = 0;

--- a/test/date_management/business/rapla_important_events_provider_refresh_test.dart
+++ b/test/date_management/business/rapla_important_events_provider_refresh_test.dart
@@ -1,4 +1,6 @@
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/logging/crash_reporting.dart'
+    as crash_reporting;
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/date_management/business/rapla_important_events_provider.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
@@ -9,6 +11,11 @@ import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  tearDown(() {
+    crash_reporting.reportExceptionImpl =
+        crash_reporting.reportExceptionToSentry;
+  });
+
   test('rapla refresh uses a silent foreground maintenance origin', () async {
     final scheduleProvider = _TrackingScheduleProvider();
     final provider = RaplaImportantEventsProvider(
@@ -27,6 +34,62 @@ void main() {
       ScheduleRefreshOrigin.foregroundMaintenance,
     ]);
   });
+
+  test('expected network failure returns null without reporting', () async {
+    final reportedErrors = <Object>[];
+    crash_reporting.reportExceptionImpl = (error, trace) async {
+      reportedErrors.add(error);
+    };
+
+    final provider = RaplaImportantEventsProvider(
+      _FakePreferencesProvider(),
+      _ThrowingScheduleProvider(
+        ScheduleQueryFailedException(
+          ServiceRequestFailed('Http request failed!'),
+        ),
+      ),
+      _FakeScheduleSourceProvider(),
+    );
+
+    final result = await provider.refreshImportantEvents(
+      DateTime(2026, 3, 1),
+      DateTime(2026, 6, 1),
+      CancellationToken(),
+    );
+
+    expect(result, isNull);
+    expect(reportedErrors, isEmpty);
+  });
+
+  test(
+    'unexpected ScheduleQueryFailedException is reported before returning null',
+    () async {
+      final reportedErrors = <Object>[];
+      crash_reporting.reportExceptionImpl = (error, trace) async {
+        reportedErrors.add(error);
+      };
+
+      final provider = RaplaImportantEventsProvider(
+        _FakePreferencesProvider(),
+        _ThrowingScheduleProvider(
+          ScheduleQueryFailedException(
+            StateError('parse structure regression'),
+          ),
+        ),
+        _FakeScheduleSourceProvider(),
+      );
+
+      final result = await provider.refreshImportantEvents(
+        DateTime(2026, 3, 1),
+        DateTime(2026, 6, 1),
+        CancellationToken(),
+      );
+
+      expect(result, isNull);
+      expect(reportedErrors, isNotEmpty);
+      expect(reportedErrors.first, isA<ScheduleQueryFailedException>());
+    },
+  );
 }
 
 class _TrackingScheduleProvider implements ScheduleProvider {
@@ -41,6 +104,27 @@ class _TrackingScheduleProvider implements ScheduleProvider {
   }) async {
     origins.add(origin);
     return ScheduleQueryResult(Schedule(), const []);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError('Unexpected ScheduleProvider call: $invocation');
+  }
+}
+
+class _ThrowingScheduleProvider implements ScheduleProvider {
+  final Object _error;
+
+  _ThrowingScheduleProvider(this._error);
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken, {
+    ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
+  }) async {
+    throw _error;
   }
 
   @override

--- a/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
+++ b/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
@@ -148,6 +148,43 @@ void main() {
 
     await expectLater(viewModel.loadStudyGrades(), throwsA(isA<StateError>()));
   });
+
+  test(
+    'refreshData does not advance lastRefreshAt on expected network failure',
+    () async {
+      final preferences = _buildPreferences();
+      final service = _NetworkErrorDualisService(
+        studyGradesError: ServiceRequestFailed('Http request failed!'),
+      );
+      final viewModel = StudyGradesViewModel(preferences, service);
+      addTearDown(viewModel.dispose);
+
+      await viewModel.login(Credentials('u', 'p'));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(
+        await preferences.getDualisLastRefreshAt(),
+        isNull,
+        reason:
+            'A network failure must not be recorded as a successful refresh',
+      );
+    },
+  );
+
+  test('refreshData advances lastRefreshAt when all loads succeed', () async {
+    final preferences = _buildPreferences();
+    final service = _NetworkErrorDualisService();
+    final viewModel = StudyGradesViewModel(preferences, service);
+    addTearDown(viewModel.dispose);
+
+    await viewModel.login(Credentials('u', 'p'));
+
+    while (await preferences.getDualisLastRefreshAt() == null) {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+
+    expect(await preferences.getDualisLastRefreshAt(), isNotNull);
+  });
 }
 
 PreferencesProvider _buildPreferences() {

--- a/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
+++ b/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
@@ -10,89 +10,143 @@ import 'package:dualmate/dualis/model/semester.dart';
 import 'package:dualmate/dualis/model/study_grades.dart';
 import 'package:dualmate/dualis/service/dualis_service.dart';
 import 'package:dualmate/dualis/ui/viewmodels/study_grades_view_model.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('login falls back to LoginFailed on unexpected service errors',
-      () async {
-    final service = _StudyGradesTestService(
-      loginThrows: true,
-      blockFirstModulesRequest: false,
+  test(
+    'login falls back to LoginFailed on unexpected service errors',
+    () async {
+      final service = _StudyGradesTestService(
+        loginThrows: true,
+        blockFirstModulesRequest: false,
+      );
+      final viewModel = StudyGradesViewModel(_buildPreferences(), service);
+      addTearDown(viewModel.dispose);
+
+      final success = await viewModel.login(Credentials('u', 'p'));
+
+      expect(success, isFalse);
+      expect(viewModel.loginState, LoginState.LoginFailed);
+    },
+  );
+
+  test(
+    'loadAllModules keeps loading=true for the newest in-flight request',
+    () async {
+      final service = _StudyGradesTestService();
+      final viewModel = StudyGradesViewModel(_buildPreferences(), service);
+      addTearDown(viewModel.dispose);
+
+      unawaited(viewModel.loadAllModules());
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(viewModel.isLoadingAllModules, isTrue);
+
+      unawaited(viewModel.loadAllModules());
+      await service.secondModulesRequestStarted.future;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(viewModel.isLoadingAllModules, isTrue);
+
+      service.releaseSecondModulesRequest();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(viewModel.isLoadingAllModules, isFalse);
+    },
+  );
+
+  test(
+    'restores the Dualis session from saved credentials on page open',
+    () async {
+      final preferences = _buildPreferences();
+      await preferences.storeDualisCredentials(
+        Credentials('saved-user', 'saved-pass'),
+      );
+      final service = _StudyGradesTestService(blockFirstModulesRequest: false);
+      final viewModel = StudyGradesViewModel(preferences, service);
+      addTearDown(viewModel.dispose);
+
+      final success = await viewModel.restoreSessionIfPossible();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(success, isTrue);
+      expect(service.loginCalls, 1);
+      expect(service.lastLoginUsername, 'saved-user');
+      expect(service.lastLoginPassword, 'saved-pass');
+      expect(viewModel.loginState, LoginState.LoggedIn);
+      expect(service.clearCacheCalls, 1);
+    },
+  );
+
+  test(
+    'refreshData(force: true) clears cached Dualis data before reloading',
+    () async {
+      final preferences = _buildPreferences();
+      final service = _StudyGradesTestService(blockFirstModulesRequest: false);
+      final viewModel = StudyGradesViewModel(preferences, service);
+      addTearDown(viewModel.dispose);
+
+      final success = await viewModel.login(Credentials('u', 'p'));
+      expect(success, isTrue);
+
+      while (await preferences.getDualisLastRefreshAt() == null) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+
+      service.resetCallCounters();
+
+      await viewModel.refreshData(force: true);
+
+      expect(service.clearCacheCalls, 1);
+      expect(service.queryStudyGradesCalls, 1);
+      expect(service.queryAllModulesCalls, 1);
+      expect(service.querySemesterNamesCalls, 1);
+    },
+  );
+
+  test('loadStudyGrades swallows expected network failures', () async {
+    final service = _NetworkErrorDualisService(
+      studyGradesError: ServiceRequestFailed('Http request failed!'),
     );
     final viewModel = StudyGradesViewModel(_buildPreferences(), service);
     addTearDown(viewModel.dispose);
 
-    final success = await viewModel.login(Credentials('u', 'p'));
-
-    expect(success, isFalse);
-    expect(viewModel.loginState, LoginState.LoginFailed);
+    await expectLater(viewModel.loadStudyGrades(), completes);
+    expect(viewModel.isLoadingStudyGrades, isFalse);
   });
 
-  test('loadAllModules keeps loading=true for the newest in-flight request',
-      () async {
-    final service = _StudyGradesTestService();
+  test('loadAllModules swallows expected network failures', () async {
+    final service = _NetworkErrorDualisService(
+      allModulesError: ServiceRequestFailed('Http request failed!'),
+    );
     final viewModel = StudyGradesViewModel(_buildPreferences(), service);
     addTearDown(viewModel.dispose);
 
-    unawaited(viewModel.loadAllModules());
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-    expect(viewModel.isLoadingAllModules, isTrue);
-
-    unawaited(viewModel.loadAllModules());
-    await service.secondModulesRequestStarted.future;
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-
-    expect(viewModel.isLoadingAllModules, isTrue);
-
-    service.releaseSecondModulesRequest();
-    await Future<void>.delayed(const Duration(milliseconds: 20));
-
+    await expectLater(viewModel.loadAllModules(), completes);
     expect(viewModel.isLoadingAllModules, isFalse);
   });
 
-  test('restores the Dualis session from saved credentials on page open',
-      () async {
-    final preferences = _buildPreferences();
-    await preferences.storeDualisCredentials(Credentials('saved-user', 'saved-pass'));
-    final service = _StudyGradesTestService(blockFirstModulesRequest: false);
-    final viewModel = StudyGradesViewModel(preferences, service);
+  test('loadSemesterByName swallows expected network failures', () async {
+    final service = _NetworkErrorDualisService(
+      semesterError: ServiceRequestFailed('Http request failed!'),
+    );
+    final viewModel = StudyGradesViewModel(_buildPreferences(), service);
     addTearDown(viewModel.dispose);
 
-    final success = await viewModel.restoreSessionIfPossible();
-    await Future<void>.delayed(const Duration(milliseconds: 20));
-
-    expect(success, isTrue);
-    expect(service.loginCalls, 1);
-    expect(service.lastLoginUsername, 'saved-user');
-    expect(service.lastLoginPassword, 'saved-pass');
-    expect(viewModel.loginState, LoginState.LoggedIn);
-    expect(service.clearCacheCalls, 1);
+    await expectLater(viewModel.loadSemesterByName('SoSe2026'), completes);
+    expect(viewModel.isLoadingCurrentSemester, isFalse);
   });
 
-  test('refreshData(force: true) clears cached Dualis data before reloading',
-      () async {
-    final preferences = _buildPreferences();
-    final service = _StudyGradesTestService(blockFirstModulesRequest: false);
-    final viewModel = StudyGradesViewModel(preferences, service);
+  test('loadStudyGrades rethrows unexpected errors', () async {
+    final service = _NetworkErrorDualisService(
+      studyGradesError: StateError('parse regression'),
+    );
+    final viewModel = StudyGradesViewModel(_buildPreferences(), service);
     addTearDown(viewModel.dispose);
 
-    final success = await viewModel.login(Credentials('u', 'p'));
-    expect(success, isTrue);
-
-    while (await preferences.getDualisLastRefreshAt() == null) {
-      await Future<void>.delayed(const Duration(milliseconds: 1));
-    }
-
-    service.resetCallCounters();
-
-    await viewModel.refreshData(force: true);
-
-    expect(service.clearCacheCalls, 1);
-    expect(service.queryStudyGradesCalls, 1);
-    expect(service.queryAllModulesCalls, 1);
-    expect(service.querySemesterNamesCalls, 1);
+    await expectLater(viewModel.loadStudyGrades(), throwsA(isA<StateError>()));
   });
 }
 
@@ -196,9 +250,7 @@ class _StudyGradesTestService extends DualisService {
   }
 
   @override
-  Future<void> logout([
-    CancellationToken? cancellationToken,
-  ]) async {}
+  Future<void> logout([CancellationToken? cancellationToken]) async {}
 
   @override
   void clearCache() {
@@ -240,4 +292,66 @@ class _FakeSecureStorageAccess extends SecureStorageAccess {
   Future<String?> get(String key) async {
     return _store[key];
   }
+}
+
+class _NetworkErrorDualisService extends DualisService {
+  final Object? studyGradesError;
+  final Object? allModulesError;
+  final Object? semesterError;
+
+  _NetworkErrorDualisService({
+    this.studyGradesError,
+    this.allModulesError,
+    this.semesterError,
+  });
+
+  @override
+  Future<LoginResult> login(
+    String username,
+    String password, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    return LoginResult.LoggedIn;
+  }
+
+  @override
+  Future<StudyGrades> queryStudyGrades([
+    CancellationToken? cancellationToken,
+  ]) async {
+    final error = studyGradesError;
+    if (error != null) throw error;
+    return StudyGrades(0, 0, 0, 0);
+  }
+
+  @override
+  Future<List<Module>> queryAllModules([
+    CancellationToken? cancellationToken,
+  ]) async {
+    final error = allModulesError;
+    if (error != null) throw error;
+    return const <Module>[];
+  }
+
+  @override
+  Future<List<String>> querySemesterNames([
+    CancellationToken? cancellationToken,
+  ]) async {
+    return const <String>['SoSe2026'];
+  }
+
+  @override
+  Future<Semester> querySemester(
+    String name, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    final error = semesterError;
+    if (error != null) throw error;
+    return Semester(name, const <Module>[]);
+  }
+
+  @override
+  Future<void> logout([CancellationToken? cancellationToken]) async {}
+
+  @override
+  void clearCache() {}
 }

--- a/test/schedule/ui/viewmodels/weekly_schedule_sentry_suppression_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_sentry_suppression_test.dart
@@ -1,0 +1,328 @@
+import 'package:dualmate/common/logging/crash_reporting.dart'
+    as crash_reporting;
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/schedule/business/schedule_provider.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_query_result.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:dualmate/schedule/ui/viewmodels/weekly_schedule_view_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final reportedErrors = <Object>[];
+
+  setUp(() {
+    reportedErrors.clear();
+    crash_reporting.reportExceptionImpl = (error, trace) async {
+      reportedErrors.add(error);
+    };
+  });
+
+  tearDown(() {
+    crash_reporting.reportExceptionImpl =
+        crash_reporting.reportExceptionToSentry;
+  });
+
+  group('isExpectedScheduleFetchFailure', () {
+    test('matches ServiceRequestFailed directly', () {
+      expect(
+        isExpectedScheduleFetchFailure(ServiceRequestFailed('Http request')),
+        isTrue,
+      );
+    });
+
+    test(
+      'matches ScheduleQueryFailedException wrapping ServiceRequestFailed',
+      () {
+        expect(
+          isExpectedScheduleFetchFailure(
+            ScheduleQueryFailedException(ServiceRequestFailed('timeout')),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'does not match ScheduleQueryFailedException wrapping a generic error',
+      () {
+        expect(
+          isExpectedScheduleFetchFailure(
+            ScheduleQueryFailedException(StateError('parse boom')),
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test('does not match unrelated exceptions', () {
+      expect(isExpectedScheduleFetchFailure(StateError('unexpected')), isFalse);
+    });
+  });
+
+  group('weekly schedule refresh Sentry suppression', () {
+    test(
+      'expected network failure (ServiceRequestFailed) does not call exception reporter',
+      () async {
+        final provider = _ThrowingScheduleProvider(
+          ScheduleQueryFailedException(
+            ServiceRequestFailed('Http request failed!'),
+          ),
+        );
+        final viewModel = _buildViewModel(provider);
+        addTearDown(viewModel.dispose);
+
+        await _forceRefresh(viewModel);
+
+        expect(
+          reportedErrors,
+          isEmpty,
+          reason: 'Expected network failures must not create Sentry Issues',
+        );
+      },
+    );
+
+    test(
+      'expected network failure still marks updateFailed in the view model',
+      () async {
+        final provider = _ThrowingScheduleProvider(
+          ScheduleQueryFailedException(
+            ServiceRequestFailed('Http request failed!'),
+          ),
+        );
+        final viewModel = _buildViewModel(provider);
+        addTearDown(viewModel.dispose);
+
+        await _forceRefresh(viewModel);
+
+        expect(
+          viewModel.updateFailed,
+          isTrue,
+          reason: 'UI failure state must still update for expected failures',
+        );
+      },
+    );
+
+    test(
+      'expected network failure still allows isUpdating to settle',
+      () async {
+        final provider = _ThrowingScheduleProvider(
+          ScheduleQueryFailedException(
+            ServiceRequestFailed('Http request failed!'),
+          ),
+        );
+        final viewModel = _buildViewModel(provider);
+        addTearDown(viewModel.dispose);
+
+        await _forceRefresh(viewModel);
+
+        expect(
+          viewModel.isUpdating,
+          isFalse,
+          reason: 'Loading spinner must clear even for suppressed failures',
+        );
+      },
+    );
+
+    test(
+      'unexpected exception during refresh still calls exception reporter',
+      () async {
+        final provider = _ThrowingScheduleProvider(StateError('unexpected'));
+        final viewModel = _buildViewModel(provider);
+        addTearDown(viewModel.dispose);
+
+        await _forceRefresh(viewModel);
+
+        expect(
+          reportedErrors,
+          isNotEmpty,
+          reason: 'Unexpected exceptions must still reach Sentry',
+        );
+        expect(reportedErrors.first, isA<StateError>());
+      },
+    );
+
+    test(
+      'non-network ScheduleQueryFailedException still calls exception reporter',
+      () async {
+        final provider = _ThrowingScheduleProvider(
+          ScheduleQueryFailedException(
+            StateError('parse structure regression'),
+          ),
+        );
+        final viewModel = _buildViewModel(provider);
+        addTearDown(viewModel.dispose);
+
+        await _forceRefresh(viewModel);
+
+        expect(
+          reportedErrors,
+          isNotEmpty,
+          reason:
+              'Non-network ScheduleQueryFailedException variants must still '
+              'be reported',
+        );
+        expect(reportedErrors.first, isA<ScheduleQueryFailedException>());
+      },
+    );
+
+    test(
+      'non-network ScheduleQueryFailedException still marks updateFailed',
+      () async {
+        final provider = _ThrowingScheduleProvider(
+          ScheduleQueryFailedException(
+            StateError('parse structure regression'),
+          ),
+        );
+        final viewModel = _buildViewModel(provider);
+        addTearDown(viewModel.dispose);
+
+        await _forceRefresh(viewModel);
+
+        expect(viewModel.updateFailed, isTrue);
+      },
+    );
+
+    test(
+      'raw ServiceRequestFailed during refresh does not call reporter',
+      () async {
+        final provider = _ThrowingScheduleProvider(
+          ServiceRequestFailed('connection reset'),
+        );
+        final viewModel = _buildViewModel(provider);
+        addTearDown(viewModel.dispose);
+
+        await _forceRefresh(viewModel);
+
+        expect(
+          reportedErrors,
+          isEmpty,
+          reason: 'Raw ServiceRequestFailed is an expected network failure',
+        );
+        expect(viewModel.updateFailed, isTrue);
+      },
+    );
+
+    test(
+      'expected network failure via awaitRefresh path does not call reporter',
+      () async {
+        final provider = _ThrowingScheduleProvider(
+          ScheduleQueryFailedException(
+            ServiceRequestFailed('Http request failed!'),
+          ),
+        );
+        final viewModel = _buildViewModel(provider);
+        addTearDown(viewModel.dispose);
+
+        await viewModel.refreshVisibleWeek();
+
+        expect(
+          reportedErrors,
+          isEmpty,
+          reason: 'awaitRefresh path must also suppress expected failures',
+        );
+        expect(viewModel.updateFailed, isTrue);
+      },
+    );
+  });
+}
+
+final _weekStart = DateTime(2026, 2, 9);
+final _weekEnd = DateTime(2026, 2, 16);
+
+WeeklyScheduleViewModel _buildViewModel(ScheduleProvider provider) {
+  return WeeklyScheduleViewModel(
+    provider,
+    _FakeScheduleSourceProvider(),
+    nowProvider: () => DateTime(2026, 2, 10, 10),
+  );
+}
+
+Future<void> _forceRefresh(WeeklyScheduleViewModel viewModel) {
+  return viewModel.updateSchedule(
+    _weekStart,
+    _weekEnd,
+    force: true,
+    awaitRefresh: true,
+  );
+}
+
+class _ThrowingScheduleProvider implements ScheduleProvider {
+  final Object _error;
+
+  _ThrowingScheduleProvider(this._error);
+
+  @override
+  Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
+    return Schedule();
+  }
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken, {
+    ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
+  }) async {
+    throw _error;
+  }
+
+  @override
+  Future<DateTime?> getLastQueryTimeForWindow(
+    DateTime start,
+    DateTime end,
+  ) async {
+    return null;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError('Unexpected ScheduleProvider call: $invocation');
+  }
+}
+
+class _FakeScheduleSourceProvider implements ScheduleSourceProvider {
+  final ScheduleSource _source = _FakeScheduleSource();
+  final List<OnDidChangeScheduleSource> _callbacks =
+      <OnDidChangeScheduleSource>[];
+
+  @override
+  ScheduleSource get currentScheduleSource => _source;
+
+  @override
+  bool didSetupCorrectly() => true;
+
+  @override
+  void addDidChangeScheduleSourceCallback(OnDidChangeScheduleSource callback) {
+    _callbacks.add(callback);
+  }
+
+  @override
+  void removeDidChangeScheduleSourceCallback(
+    OnDidChangeScheduleSource callback,
+  ) {
+    _callbacks.remove(callback);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+      'Unexpected ScheduleSourceProvider call: $invocation',
+    );
+  }
+}
+
+class _FakeScheduleSource implements ScheduleSource {
+  @override
+  bool canQuery() => true;
+
+  @override
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    return ScheduleQueryResult(Schedule(), const []);
+  }
+}


### PR DESCRIPTION
## Summary
- Added `isExpectedScheduleFetchFailure` to classify `ServiceRequestFailed` and `ScheduleQueryFailedException` wrapping it as expected network telemetry, not Sentry issues.
- Updated weekly schedule refresh flows to keep failure state and retry behavior, while skipping exception reporting for expected network outages.
- Simplified `ErrorReportScheduleSourceDecorator` and background schedule updates to avoid double-reporting and let the refresh path own Sentry decisions.
- Added focused tests covering suppressed network failures, reported unexpected failures, and non-network `ScheduleQueryFailedException` cases.
- Documented the fix in `docs/solutions/integration-issues/sentry-suppress-expected-schedule-fetch-failures-20260630.md`.

## Testing
- `test/schedule/ui/viewmodels/weekly_schedule_sentry_suppression_test.dart`
- Not run: broader schedule/background/logging suites referenced in the solution doc
- Not run: Android device verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reporting for expected network/request failures across schedule, canteen, grades, onboarding, and background refresh flows.
  * Improved refresh behavior so failed network checks no longer incorrectly update “last refreshed” timestamps.
  * Preserved normal loading states and retry behavior while avoiding unnecessary crash reports for expected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->