### PR TITLE
Suppress expected refresh failures from Sentry

### DIFF
--- a/docs/solutions/integration-issues/sentry-expected-refresh-failure-suppression-20260702.md
+++ b/docs/solutions/integration-issues/sentry-expected-refresh-failure-suppression-20260702.md
@@ -1,0 +1,54 @@
+---
+module: Diagnostics
+date: 2026-07-02
+problem_type: integration_issue
+component: sentry_reporting
+symptoms:
+  - "Expected schedule and canteen HTTP/source failures appeared as noisy Sentry Issues"
+  - "Schedule source connectivity suppression could be undone by later refresh catch blocks"
+root_cause: expected_external_failures_reported_as_app_errors
+resolution_type: code_fix
+severity: medium
+tags: [sentry, diagnostics, schedule, canteen, network]
+---
+
+# Sentry expected refresh failure suppression
+
+## Problem
+Schedule and canteen refreshes depend on external university/source services.
+Temporary request failures are expected and are not actionable app bugs, but
+several foreground, background, and startup refresh paths reported them through
+Sentry. In schedule refreshes, source-level suppression could be undone by
+later view-model catch blocks that called `reportException`.
+
+## Solution
+Expected external failures are now classified before they reach Sentry:
+
+- `ExpectedExternalFailure` marks failures caused by external availability,
+  connectivity, or cancellation.
+- `DiagnosticExceptionWithCause` lets wrapper exceptions delegate suppression
+  decisions to their inner cause.
+- `AppDiagnostics.reportCaughtException` drops suppressible exceptions before
+  capture.
+- Schedule `ServiceRequestFailed` and canteen `CanteenRequestFailed` are
+  suppressible.
+- Schedule query wrappers suppress only when their inner cause is suppressible.
+
+Performance spans keep coarse status data such as `network_error`, but
+suppressible refresh failures are not attached as internal app errors.
+
+## Suppressed
+- Schedule `ServiceRequestFailed`.
+- `ScheduleQueryFailedException` when caused by `ServiceRequestFailed`.
+- Canteen HTTP/null-response failures represented by `CanteenRequestFailed`.
+- `OperationCancelledException`.
+
+## Still reported
+- Schedule parser failures from `ScheduleQueryResult.errors`.
+- Schedule query failures caused by parser/format errors.
+- Canteen JSON decode or parser regressions.
+- Cache, database, state, callback, and other unexpected app failures.
+
+## Verification
+Covered with focused tests for diagnostics filtering, schedule source/view-model
+reporting behavior, and typed canteen request failures.

--- a/lib/canteen/service/canteen_request_failed.dart
+++ b/lib/canteen/service/canteen_request_failed.dart
@@ -15,5 +15,11 @@ class CanteenRequestFailed
   Object? get diagnosticCause => cause;
 
   @override
-  String toString() => message;
+  String toString() {
+    final cause = this.cause;
+    if (cause == null) {
+      return message;
+    }
+    return "$message: $cause\n${trace?.toString() ?? ""}";
+  }
 }

--- a/lib/canteen/service/canteen_request_failed.dart
+++ b/lib/canteen/service/canteen_request_failed.dart
@@ -1,0 +1,19 @@
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
+
+class CanteenRequestFailed
+    implements
+        Exception,
+        ExpectedExternalFailure,
+        DiagnosticExceptionWithCause {
+  final String message;
+  final Object? cause;
+  final StackTrace? trace;
+
+  CanteenRequestFailed(this.message, [this.cause, this.trace]);
+
+  @override
+  Object? get diagnosticCause => cause;
+
+  @override
+  String toString() => message;
+}

--- a/lib/canteen/service/canteen_scraper.dart
+++ b/lib/canteen/service/canteen_scraper.dart
@@ -1,15 +1,24 @@
 import 'dart:isolate';
 
 import 'package:dualmate/canteen/model/daily_menu.dart';
+import 'package:dualmate/canteen/service/canteen_request_failed.dart';
 import 'package:dualmate/canteen/service/canteen_parser.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:http/http.dart';
 import 'package:http_client_helper/http_client_helper.dart' as http;
 
+typedef CanteenResponseLoader =
+    Future<Response?> Function(
+      Uri uri,
+      http.CancellationToken cancellationToken,
+    );
+
 class CanteenScraper {
   final Map<int, String> _weekCache = {};
+  final CanteenResponseLoader _loadResponse;
 
-  CanteenScraper();
+  CanteenScraper({CanteenResponseLoader? loadResponse})
+    : _loadResponse = loadResponse ?? _defaultLoadResponse;
 
   Future<List<DailyMenu>> loadWeek(
     DateTime date, [
@@ -49,8 +58,9 @@ class CanteenScraper {
   int _isoWeekNumber(DateTime date) {
     var thursday = date.add(Duration(days: 4 - date.weekday));
     var firstThursday = DateTime(thursday.year, 1, 4);
-    var firstWeekStart =
-        firstThursday.subtract(Duration(days: firstThursday.weekday - 1));
+    var firstWeekStart = firstThursday.subtract(
+      Duration(days: firstThursday.weekday - 1),
+    );
 
     return 1 + (thursday.difference(firstWeekStart).inDays / 7).floor();
   }
@@ -67,11 +77,10 @@ class CanteenScraper {
         requestCancellationToken.cancel();
       });
 
-      var response = await http.HttpClientHelper.get(uri,
-          cancelToken: requestCancellationToken);
+      var response = await _loadResponse(uri, requestCancellationToken);
 
       if (response == null && !requestCancellationToken.isCanceled) {
-        throw Exception("Http request failed!");
+        throw CanteenRequestFailed("Http request failed!");
       }
 
       if (response == null) {
@@ -81,13 +90,22 @@ class CanteenScraper {
       return response;
     } on http.OperationCanceledError catch (_) {
       throw OperationCancelledException();
-    } catch (ex) {
+    } on CanteenRequestFailed {
+      rethrow;
+    } catch (ex, trace) {
       if (requestCancellationToken.isCanceled) {
         throw OperationCancelledException();
       }
-      rethrow;
+      throw CanteenRequestFailed("Http request failed!", ex, trace);
     } finally {
       token.setCancellationCallback(null);
     }
+  }
+
+  static Future<Response?> _defaultLoadResponse(
+    Uri uri,
+    http.CancellationToken cancellationToken,
+  ) {
+    return http.HttpClientHelper.get(uri, cancelToken: cancellationToken);
   }
 }

--- a/lib/canteen/service/dhbw_app_canteen_source.dart
+++ b/lib/canteen/service/dhbw_app_canteen_source.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:dualmate/canteen/model/daily_menu.dart';
 import 'package:dualmate/canteen/model/meal.dart';
 import 'package:dualmate/canteen/model/meal_type.dart';
+import 'package:dualmate/canteen/service/canteen_request_failed.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:flutter/foundation.dart';
@@ -106,32 +107,38 @@ class DhbwAppCanteenSource {
     CancellationToken token,
   ) async {
     final requestCancellationToken = http.CancellationToken();
+    String? body;
 
     try {
       token.setCancellationCallback(requestCancellationToken.cancel);
 
-      final body = await _loadSitePayloadResponse(
+      body = await _loadSitePayloadResponse(
         Uri.https('api.dhbw.app', '/mensa/$site'),
         requestCancellationToken,
       );
-
-      if (body == null) {
-        if (requestCancellationToken.isCanceled) {
-          throw OperationCancelledException();
-        }
-        throw Exception('DHBW.app canteen request failed');
-      }
-
-      return compute(
-        _decodeDhbwAppSitePayload,
-        body,
-        debugLabel: 'dhbwAppCanteenDecodePayload',
-      );
     } on http.OperationCanceledError catch (_) {
       throw OperationCancelledException();
+    } catch (ex, trace) {
+      if (requestCancellationToken.isCanceled) {
+        throw OperationCancelledException();
+      }
+      throw CanteenRequestFailed('DHBW.app canteen request failed', ex, trace);
     } finally {
       token.setCancellationCallback(null);
     }
+
+    if (body == null) {
+      if (requestCancellationToken.isCanceled) {
+        throw OperationCancelledException();
+      }
+      throw CanteenRequestFailed('DHBW.app canteen request failed');
+    }
+
+    return compute(
+      _decodeDhbwAppSitePayload,
+      body,
+      debugLabel: 'dhbwAppCanteenDecodePayload',
+    );
   }
 
   static Future<String?> _defaultLoadSitePayloadResponse(

--- a/lib/canteen/service/dhbw_app_canteen_source.dart
+++ b/lib/canteen/service/dhbw_app_canteen_source.dart
@@ -118,6 +118,8 @@ class DhbwAppCanteenSource {
       );
     } on http.OperationCanceledError catch (_) {
       throw OperationCancelledException();
+    } on CanteenRequestFailed {
+      rethrow;
     } catch (ex, trace) {
       if (requestCancellationToken.isCanceled) {
         throw OperationCancelledException();

--- a/lib/common/logging/app_diagnostics.dart
+++ b/lib/common/logging/app_diagnostics.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 
 import 'package:sentry/sentry.dart';
 
+import 'diagnostic_exception_filter.dart';
 import 'sentry_scrubber.dart';
 
 void _logDiagnosticsFailure(
@@ -129,6 +130,10 @@ class AppDiagnostics {
     Map<String, String> tags = const <String, String>{},
     Map<String, Object?> contexts = const <String, Object?>{},
   }) {
+    if (shouldSuppressDiagnosticsException(exception)) {
+      return Future<void>.value();
+    }
+
     return _bestEffort(
       () => _recorder.captureException(
         exception,

--- a/lib/common/logging/diagnostic_exception_filter.dart
+++ b/lib/common/logging/diagnostic_exception_filter.dart
@@ -1,0 +1,37 @@
+import 'dart:collection';
+
+import 'package:dualmate/common/util/cancellation_token.dart';
+
+abstract interface class ExpectedExternalFailure implements Exception {}
+
+abstract interface class DiagnosticExceptionWithCause implements Exception {
+  Object? get diagnosticCause;
+}
+
+bool shouldSuppressDiagnosticsException(Object error) {
+  return _shouldSuppressDiagnosticsException(error, LinkedHashSet.identity());
+}
+
+bool _shouldSuppressDiagnosticsException(Object error, Set<Object> seen) {
+  if (!seen.add(error)) {
+    return false;
+  }
+
+  if (error is OperationCancelledException) {
+    return true;
+  }
+
+  if (error is ExpectedExternalFailure) {
+    return true;
+  }
+
+  if (error is DiagnosticExceptionWithCause) {
+    final cause = error.diagnosticCause;
+    if (cause == null) {
+      return false;
+    }
+    return _shouldSuppressDiagnosticsException(cause, seen);
+  }
+
+  return false;
+}

--- a/lib/common/logging/diagnostic_exception_filter.dart
+++ b/lib/common/logging/diagnostic_exception_filter.dart
@@ -21,16 +21,15 @@ bool _shouldSuppressDiagnosticsException(Object error, Set<Object> seen) {
     return true;
   }
 
-  if (error is ExpectedExternalFailure) {
-    return true;
-  }
-
   if (error is DiagnosticExceptionWithCause) {
     final cause = error.diagnosticCause;
-    if (cause == null) {
-      return false;
+    if (cause != null) {
+      return _shouldSuppressDiagnosticsException(cause, seen);
     }
-    return _shouldSuppressDiagnosticsException(cause, seen);
+  }
+
+  if (error is ExpectedExternalFailure) {
+    return true;
   }
 
   return false;

--- a/lib/common/logging/performance_telemetry.dart
+++ b/lib/common/logging/performance_telemetry.dart
@@ -269,7 +269,7 @@ class PerformanceTelemetryTask {
     _finished = true;
     if (shouldSuppressDiagnosticsException(error)) {
       _timelineTask.finish();
-      await _diagnosticsSpan.finish(status: const SpanStatus.ok());
+      await _diagnosticsSpan.finish(status: const SpanStatus.cancelled());
       return;
     }
     _diagnosticsSpan.attachError(

--- a/lib/common/logging/performance_telemetry.dart
+++ b/lib/common/logging/performance_telemetry.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import 'dart:ui';
 
 import 'package:dualmate/common/logging/app_diagnostics.dart';
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
@@ -266,6 +267,11 @@ class PerformanceTelemetryTask {
   }) async {
     if (_finished) return;
     _finished = true;
+    if (shouldSuppressDiagnosticsException(error)) {
+      _timelineTask.finish();
+      await _diagnosticsSpan.finish(status: const SpanStatus.ok());
+      return;
+    }
     _diagnosticsSpan.attachError(
       error,
       includeErrorMessage: includeErrorMessage,

--- a/lib/schedule/service/error_report_schedule_source_decorator.dart
+++ b/lib/schedule/service/error_report_schedule_source_decorator.dart
@@ -1,3 +1,4 @@
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
 import 'package:dualmate/common/logging/crash_reporting.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/schedule/model/schedule_query_result.dart';
@@ -9,8 +10,11 @@ class ErrorReportScheduleSourceDecorator extends ScheduleSource {
   ErrorReportScheduleSourceDecorator(this._scheduleSource);
 
   @override
-  Future<ScheduleQueryResult> querySchedule(DateTime from, DateTime to,
-      [CancellationToken? cancellationToken]) async {
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]) async {
     try {
       var schedule = await _scheduleSource.querySchedule(
         from,
@@ -21,10 +25,8 @@ class ErrorReportScheduleSourceDecorator extends ScheduleSource {
       return schedule;
     } catch (ex, trace) {
       if (ex is OperationCancelledException) rethrow;
+      if (shouldSuppressDiagnosticsException(ex)) rethrow;
       if (ex is ScheduleQueryFailedException) {
-        // Do not log connectivity exceptions
-        if (ex.innerException is ServiceRequestFailed) rethrow;
-
         await reportException(ex, ex.trace ?? StackTrace.current);
       } else {
         await reportException(ex, trace);

--- a/lib/schedule/service/isolate_schedule_source_decorator.dart
+++ b/lib/schedule/service/isolate_schedule_source_decorator.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:isolate';
 import 'dart:io';
 
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/common/util/rapla_tls_override.dart';
 import 'package:dualmate/schedule/model/schedule_query_result.dart';
@@ -21,8 +22,11 @@ class IsolateScheduleSourceDecorator extends ScheduleSource {
   IsolateScheduleSourceDecorator(this._scheduleSource);
 
   @override
-  Future<ScheduleQueryResult> querySchedule(DateTime from, DateTime to,
-      [CancellationToken? cancellationToken]) async {
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]) async {
     await _initializeIsolate();
     var token = cancellationToken ?? CancellationToken();
     var requestId = _nextRequestId();
@@ -31,10 +35,7 @@ class IsolateScheduleSourceDecorator extends ScheduleSource {
     // Use the cancellation token to send a cancel message.
     // The isolate then uses a new instance to cancel the request
     token.setCancellationCallback(() {
-      _sendPort.send({
-        "type": "cancel",
-        "requestId": requestId,
-      });
+      _sendPort.send({"type": "cancel", "requestId": requestId});
     });
 
     _sendPort.send({
@@ -54,6 +55,8 @@ class IsolateScheduleSourceDecorator extends ScheduleSource {
         throw OperationCancelledException();
       } else if (result is ScheduleQueryResult) {
         return result;
+      } else if (_isExpectedExternalFailureResult(result)) {
+        throw _scheduleQueryFailedFromExpectedExternalFailureResult(result);
       } else {
         throw ScheduleQueryFailedException(result);
       }
@@ -68,7 +71,9 @@ class IsolateScheduleSourceDecorator extends ScheduleSource {
     var isolateToMain = ReceivePort();
     _isolateToMain = isolateToMain;
     await Isolate.spawn(
-        scheduleSourceIsolateEntryPoint, isolateToMain.sendPort);
+      scheduleSourceIsolateEntryPoint,
+      isolateToMain.sendPort,
+    );
     _sendPort = await _isolateToMain.first;
     _isInitialized = true;
   }
@@ -132,6 +137,32 @@ Future<void> executeQueryScheduleMessage(
     replyPort.send(null);
   } catch (ex, trace) {
     SendPort replyPort = map["replyPort"];
+    if (shouldSuppressDiagnosticsException(ex)) {
+      replyPort.send({
+        "type": "expectedExternalFailure",
+        "message": ex.toString(),
+        "trace": trace.toString(),
+      });
+      return;
+    }
     replyPort.send("$ex \n$trace");
   }
+}
+
+bool _isExpectedExternalFailureResult(Object? result) {
+  if (result is! Map) {
+    return false;
+  }
+  return result["type"] == "expectedExternalFailure";
+}
+
+ScheduleQueryFailedException
+_scheduleQueryFailedFromExpectedExternalFailureResult(Object result) {
+  final map = result as Map;
+  final message = map["message"]?.toString() ?? "Schedule request failed";
+  final traceValue = map["trace"]?.toString();
+  return ScheduleQueryFailedException(
+    ServiceRequestFailed(message),
+    traceValue == null ? null : StackTrace.fromString(traceValue),
+  );
 }

--- a/lib/schedule/service/schedule_source.dart
+++ b/lib/schedule/service/schedule_source.dart
@@ -1,3 +1,4 @@
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/schedule/model/schedule_query_result.dart';
 
@@ -9,25 +10,35 @@ abstract class ScheduleSource {
   /// Returns a future which gives the updated schedule or throws an exception
   /// if an error happened or the operation was cancelled
   ///
-  Future<ScheduleQueryResult> querySchedule(DateTime from, DateTime to,
-      [CancellationToken? cancellationToken]);
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]);
 
   bool canQuery();
 }
 
-class ScheduleQueryFailedException implements Exception {
+class ScheduleQueryFailedException
+    implements Exception, DiagnosticExceptionWithCause {
   final dynamic innerException;
   final StackTrace? trace;
 
   ScheduleQueryFailedException(this.innerException, [this.trace]);
 
   @override
+  Object? get diagnosticCause =>
+      innerException is Object ? innerException as Object : null;
+
+  @override
   String toString() {
-    return (innerException?.toString() ?? "") + "\n" + (trace?.toString() ?? "");
+    return (innerException?.toString() ?? "") +
+        "\n" +
+        (trace?.toString() ?? "");
   }
 }
 
-class ServiceRequestFailed implements Exception {
+class ServiceRequestFailed implements Exception, ExpectedExternalFailure {
   final String message;
 
   ServiceRequestFailed(this.message);

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/logging/crash_reporting.dart';
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
 import 'package:dualmate/common/ui/viewmodels/base_view_model.dart';
 import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/util/cancelable_mutex.dart';
@@ -669,8 +670,12 @@ class WeeklyScheduleViewModel extends BaseViewModel {
           debugPrint("Schedule update failed: $e");
         }
         task.setCoarseStatus('network_error');
-        await reportException(e, stack);
-        await task.fail(e, includeErrorMessage: false);
+        if (shouldSuppressDiagnosticsException(e)) {
+          await task.finish();
+        } else {
+          await reportException(e, stack);
+          await task.fail(e, includeErrorMessage: false);
+        }
       }
 
       try {
@@ -794,7 +799,9 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       if (kDebugMode) {
         debugPrint("Joined schedule update failed: $error");
       }
-      await reportException(error, trace);
+      if (!shouldSuppressDiagnosticsException(error)) {
+        await reportException(error, trace);
+      }
 
       if (applyToVisibleState && !_isDisposed) {
         updateFailed = true;

--- a/test/canteen/service/canteen_scraper_test.dart
+++ b/test/canteen/service/canteen_scraper_test.dart
@@ -1,0 +1,34 @@
+import 'package:dualmate/canteen/service/canteen_request_failed.dart';
+import 'package:dualmate/canteen/service/canteen_scraper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('converts null HTTP responses into CanteenRequestFailed', () async {
+    final scraper = CanteenScraper(loadResponse: (_, __) async => null);
+
+    await expectLater(
+      scraper.loadWeek(DateTime(2026, 2, 9)),
+      throwsA(isA<CanteenRequestFailed>()),
+    );
+  });
+
+  test('wraps HTTP loader failures as CanteenRequestFailed', () async {
+    final cause = StateError('socket closed');
+    final scraper = CanteenScraper(
+      loadResponse: (_, __) async {
+        throw cause;
+      },
+    );
+
+    await expectLater(
+      scraper.loadWeek(DateTime(2026, 2, 9)),
+      throwsA(
+        isA<CanteenRequestFailed>().having(
+          (error) => error.cause,
+          'cause',
+          same(cause),
+        ),
+      ),
+    );
+  });
+}

--- a/test/canteen/service/canteen_scraper_test.dart
+++ b/test/canteen/service/canteen_scraper_test.dart
@@ -8,7 +8,15 @@ void main() {
 
     await expectLater(
       scraper.loadWeek(DateTime(2026, 2, 9)),
-      throwsA(isA<CanteenRequestFailed>()),
+      throwsA(
+        isA<CanteenRequestFailed>()
+            .having((error) => error.cause, 'cause', isNull)
+            .having(
+              (error) => error.toString(),
+              'message',
+              'Http request failed!',
+            ),
+      ),
     );
   });
 
@@ -23,11 +31,13 @@ void main() {
     await expectLater(
       scraper.loadWeek(DateTime(2026, 2, 9)),
       throwsA(
-        isA<CanteenRequestFailed>().having(
-          (error) => error.cause,
-          'cause',
-          same(cause),
-        ),
+        isA<CanteenRequestFailed>()
+            .having((error) => error.cause, 'cause', same(cause))
+            .having(
+              (error) => error.toString(),
+              'message',
+              contains('Http request failed!: Bad state: socket closed'),
+            ),
       ),
     );
   });

--- a/test/canteen/service/dhbw_app_canteen_source_test.dart
+++ b/test/canteen/service/dhbw_app_canteen_source_test.dart
@@ -155,6 +155,20 @@ void main() {
     );
   });
 
+  test('does not rewrap existing payload request failures', () async {
+    final failure = CanteenRequestFailed('DHBW.app canteen request failed');
+    final source = DhbwAppCanteenSource(
+      loadSitePayloadResponse: (_, __) async {
+        throw failure;
+      },
+    );
+
+    await expectLater(
+      source.loadWeek('MA', 7, DateTime(2026, 6, 1)),
+      throwsA(same(failure)),
+    );
+  });
+
   test(
     'shares one uncancelled in-flight site request across callers',
     () async {

--- a/test/canteen/service/dhbw_app_canteen_source_test.dart
+++ b/test/canteen/service/dhbw_app_canteen_source_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:dualmate/canteen/service/canteen_request_failed.dart';
 import 'package:dualmate/canteen/service/dhbw_app_canteen_source.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -121,6 +122,37 @@ void main() {
 
     expect(requestCount, 2);
     expect(menus.first.meals.single.name, 'RecoveredMeal');
+  });
+
+  test('converts null payload responses into CanteenRequestFailed', () async {
+    final source = DhbwAppCanteenSource(
+      loadSitePayloadResponse: (_, __) async => null,
+    );
+
+    await expectLater(
+      source.loadWeek('MA', 7, DateTime(2026, 6, 1)),
+      throwsA(isA<CanteenRequestFailed>()),
+    );
+  });
+
+  test('wraps payload request failures as CanteenRequestFailed', () async {
+    final cause = StateError('socket closed');
+    final source = DhbwAppCanteenSource(
+      loadSitePayloadResponse: (_, __) async {
+        throw cause;
+      },
+    );
+
+    await expectLater(
+      source.loadWeek('MA', 7, DateTime(2026, 6, 1)),
+      throwsA(
+        isA<CanteenRequestFailed>().having(
+          (error) => error.cause,
+          'cause',
+          same(cause),
+        ),
+      ),
+    );
   });
 
   test(

--- a/test/common/logging/app_diagnostics_test.dart
+++ b/test/common/logging/app_diagnostics_test.dart
@@ -87,15 +87,22 @@ void main() {
     final recorder = _RecordingDiagnosticsRecorder();
     final diagnostics = AppDiagnostics(recorder: recorder);
     final trace = StackTrace.current;
+    final requestFailure = CanteenRequestFailed(
+      'Http request failed!',
+      StateError('socket closed'),
+      trace,
+    );
 
     await diagnostics.reportCaughtException(StateError('cache failed'), trace);
     await diagnostics.reportCaughtException(FormatException('bad json'), trace);
     await diagnostics.reportCaughtException(Exception('parser failed'), trace);
+    await diagnostics.reportCaughtException(requestFailure, trace);
 
-    expect(recorder.capturedExceptions, hasLength(3));
+    expect(recorder.capturedExceptions, hasLength(4));
     expect(recorder.capturedExceptions[0].exception, isA<StateError>());
     expect(recorder.capturedExceptions[1].exception, isA<FormatException>());
     expect(recorder.capturedExceptions[2].exception, isA<Exception>());
+    expect(recorder.capturedExceptions[3].exception, same(requestFailure));
   });
 
   test('diagnostics recording is best effort when recorder fails', () async {

--- a/test/common/logging/app_diagnostics_test.dart
+++ b/test/common/logging/app_diagnostics_test.dart
@@ -1,4 +1,7 @@
+import 'package:dualmate/canteen/service/canteen_request_failed.dart';
 import 'package:dualmate/common/logging/app_diagnostics.dart';
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:sentry/sentry.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -48,6 +51,51 @@ void main() {
       diagnosticsContext! as Map<Object?, Object?>,
     );
     expect(diagnosticsMap['operation'], 'root.initialize');
+  });
+
+  test('reportCaughtException suppresses expected external failures', () async {
+    final recorder = _RecordingDiagnosticsRecorder();
+    final diagnostics = AppDiagnostics(recorder: recorder);
+
+    await diagnostics.reportCaughtException(
+      CanteenRequestFailed('Http request failed!'),
+      StackTrace.current,
+    );
+
+    expect(recorder.capturedExceptions, isEmpty);
+  });
+
+  test('reportCaughtException suppresses expected nested causes', () async {
+    final recorder = _RecordingDiagnosticsRecorder();
+    final diagnostics = AppDiagnostics(recorder: recorder);
+
+    await diagnostics.reportCaughtException(
+      ScheduleQueryFailedException(
+        ServiceRequestFailed('Http request failed!'),
+      ),
+      StackTrace.current,
+    );
+    await diagnostics.reportCaughtException(
+      _WrappedDiagnosticsException(CanteenRequestFailed('request failed')),
+      StackTrace.current,
+    );
+
+    expect(recorder.capturedExceptions, isEmpty);
+  });
+
+  test('reportCaughtException still records actionable failures', () async {
+    final recorder = _RecordingDiagnosticsRecorder();
+    final diagnostics = AppDiagnostics(recorder: recorder);
+    final trace = StackTrace.current;
+
+    await diagnostics.reportCaughtException(StateError('cache failed'), trace);
+    await diagnostics.reportCaughtException(FormatException('bad json'), trace);
+    await diagnostics.reportCaughtException(Exception('parser failed'), trace);
+
+    expect(recorder.capturedExceptions, hasLength(3));
+    expect(recorder.capturedExceptions[0].exception, isA<StateError>());
+    expect(recorder.capturedExceptions[1].exception, isA<FormatException>());
+    expect(recorder.capturedExceptions[2].exception, isA<Exception>());
   });
 
   test('diagnostics recording is best effort when recorder fails', () async {
@@ -220,6 +268,16 @@ void main() {
       await expectLater(span.finish(status: const SpanStatus.ok()), completes);
     },
   );
+}
+
+class _WrappedDiagnosticsException
+    implements Exception, DiagnosticExceptionWithCause {
+  final Object cause;
+
+  _WrappedDiagnosticsException(this.cause);
+
+  @override
+  Object? get diagnosticCause => cause;
 }
 
 class _RecordingDiagnosticsRecorder implements DiagnosticsRecorder {

--- a/test/schedule/service/error_report_schedule_source_decorator_test.dart
+++ b/test/schedule/service/error_report_schedule_source_decorator_test.dart
@@ -1,0 +1,75 @@
+import 'package:dualmate/common/logging/crash_reporting.dart'
+    as crash_reporting;
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/schedule/model/schedule_query_result.dart';
+import 'package:dualmate/schedule/service/error_report_schedule_source_decorator.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late crash_reporting.ExceptionReporter originalReporter;
+  late List<Object> reportedErrors;
+
+  setUp(() {
+    originalReporter = crash_reporting.reportExceptionImpl;
+    reportedErrors = <Object>[];
+    crash_reporting.reportExceptionImpl = (error, trace) async {
+      reportedErrors.add(error);
+    };
+  });
+
+  tearDown(() {
+    crash_reporting.reportExceptionImpl = originalReporter;
+  });
+
+  test('rethrows connectivity query failures without reporting', () async {
+    final source = ErrorReportScheduleSourceDecorator(
+      _ThrowingScheduleSource(
+        ScheduleQueryFailedException(
+          ServiceRequestFailed('Http request failed!'),
+        ),
+      ),
+    );
+
+    await expectLater(
+      source.querySchedule(DateTime(2026, 2, 9), DateTime(2026, 2, 16)),
+      throwsA(isA<ScheduleQueryFailedException>()),
+    );
+
+    expect(reportedErrors, isEmpty);
+  });
+
+  test('reports parser query failures before rethrowing', () async {
+    final failure = ScheduleQueryFailedException(
+      FormatException('Invalid time format'),
+    );
+    final source = ErrorReportScheduleSourceDecorator(
+      _ThrowingScheduleSource(failure),
+    );
+
+    await expectLater(
+      source.querySchedule(DateTime(2026, 2, 9), DateTime(2026, 2, 16)),
+      throwsA(same(failure)),
+    );
+
+    expect(reportedErrors, <Object>[failure]);
+  });
+}
+
+class _ThrowingScheduleSource extends ScheduleSource {
+  final Object error;
+
+  _ThrowingScheduleSource(this.error);
+
+  @override
+  bool canQuery() => true;
+
+  @override
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    throw error;
+  }
+}

--- a/test/schedule/service/isolate_schedule_source_decorator_test.dart
+++ b/test/schedule/service/isolate_schedule_source_decorator_test.dart
@@ -1,0 +1,49 @@
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/schedule/model/schedule_query_result.dart';
+import 'package:dualmate/schedule/service/isolate_schedule_source_decorator.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'preserves suppressible request failures across isolate boundary',
+    () async {
+      final source = IsolateScheduleSourceDecorator(
+        _ThrowingScheduleSource(
+          ScheduleQueryFailedException(
+            ServiceRequestFailed('Http request failed!'),
+          ),
+        ),
+      );
+
+      Object? caught;
+      try {
+        await source.querySchedule(DateTime(2026, 2, 9), DateTime(2026, 2, 16));
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught, isA<ScheduleQueryFailedException>());
+      expect(shouldSuppressDiagnosticsException(caught!), isTrue);
+    },
+  );
+}
+
+class _ThrowingScheduleSource extends ScheduleSource {
+  final Object error;
+
+  _ThrowingScheduleSource(this.error);
+
+  @override
+  bool canQuery() => true;
+
+  @override
+  Future<ScheduleQueryResult> querySchedule(
+    DateTime from,
+    DateTime to, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    throw error;
+  }
+}

--- a/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:dualmate/common/logging/crash_reporting.dart'
+    as crash_reporting;
 import 'package:dualmate/common/util/cancellation_token.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
@@ -244,6 +246,62 @@ void main() {
       2,
       reason: 'pull-to-refresh must bypass staleness gate',
     );
+  });
+
+  test(
+    'refreshVisibleWeek suppresses expected connectivity query failures',
+    () async {
+      final originalReporter = crash_reporting.reportExceptionImpl;
+      final reportedErrors = <Object>[];
+      crash_reporting.reportExceptionImpl = (error, trace) async {
+        reportedErrors.add(error);
+      };
+      addTearDown(() {
+        crash_reporting.reportExceptionImpl = originalReporter;
+      });
+
+      final provider = _ThrowingUpdateScheduleProvider(
+        ScheduleQueryFailedException(
+          ServiceRequestFailed('Http request failed!'),
+        ),
+      );
+      final sourceProvider = _FakeScheduleSourceProvider();
+      final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+      addTearDown(viewModel.dispose);
+
+      viewModel.currentDateStart = DateTime(2026, 2, 9);
+      viewModel.currentDateEnd = DateTime(2026, 2, 16);
+
+      await viewModel.refreshVisibleWeek();
+
+      expect(viewModel.updateFailed, isTrue);
+      expect(reportedErrors, isEmpty);
+    },
+  );
+
+  test('refreshVisibleWeek reports unexpected update failures', () async {
+    final originalReporter = crash_reporting.reportExceptionImpl;
+    final reportedErrors = <Object>[];
+    crash_reporting.reportExceptionImpl = (error, trace) async {
+      reportedErrors.add(error);
+    };
+    addTearDown(() {
+      crash_reporting.reportExceptionImpl = originalReporter;
+    });
+
+    final failure = StateError('cache write failed');
+    final provider = _ThrowingUpdateScheduleProvider(failure);
+    final sourceProvider = _FakeScheduleSourceProvider();
+    final viewModel = WeeklyScheduleViewModel(provider, sourceProvider);
+    addTearDown(viewModel.dispose);
+
+    viewModel.currentDateStart = DateTime(2026, 2, 9);
+    viewModel.currentDateEnd = DateTime(2026, 2, 16);
+
+    await viewModel.refreshVisibleWeek();
+
+    expect(viewModel.updateFailed, isTrue);
+    expect(reportedErrors, <Object>[failure]);
   });
 
   test(
@@ -549,6 +607,23 @@ class _BlockingCountingScheduleProvider extends _FakeScheduleProvider {
         _requestCountWaiters.remove(waiter);
       }
     }
+  }
+}
+
+class _ThrowingUpdateScheduleProvider extends _FakeScheduleProvider {
+  final Object error;
+
+  _ThrowingUpdateScheduleProvider(this.error) : super(const <ScheduleEntry>[]);
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken, {
+    ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
+  }) async {
+    origins.add(origin);
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- Added a shared diagnostic filter for expected external failures and cancellation so they are not reported to Sentry.
- Marked schedule and canteen request failures as suppressible, including wrapped failures with an inner cause.
- Updated schedule refresh handling and performance telemetry to avoid attaching expected network errors as app failures.
- Tightened canteen scraping and DHBW.app payload loading to emit typed request failures instead of generic exceptions.
- Documented the change in `docs/solutions/integration-issues/sentry-expected-refresh-failure-suppression-20260702.md`.

## Testing
- Added unit tests for diagnostic suppression, including nested wrapper exceptions and actionable failures that should still रिपोर्ट.
- Added canteen service tests for null-response and loader-failure wrapping.
- Added schedule decorator tests to verify connectivity failures are not reported while parser failures still are.
- Added weekly schedule refresh tests to verify expected connectivity failures are suppressed and unexpected update failures are still reported.
- Not run: full test suite and Android device verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter error classification so expected request failures and cancellations are handled consistently.
  * Improved schedule refresh and canteen loading to support dependency-injected network responses.

* **Bug Fixes**
  * Prevented expected failures from being sent to diagnostics/crash reporting.
  * Wrapped unexpected request errors with clearer failure details while preserving the original cause.

* **Tests**
  * Expanded coverage for request failure handling, diagnostic suppression, and schedule refresh error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->