### PR TITLE
Add debug onboarding overrides and replay flow

### DIFF
--- a/docs/solutions/developer-experience/skip-and-replay-onboarding-20260702.md
+++ b/docs/solutions/developer-experience/skip-and-replay-onboarding-20260702.md
@@ -52,15 +52,19 @@ Added a "Replay onboarding" tile under **Settings → Developer options** (debug
 
 The cache clear is necessary because the onboarding save path is deferred for fresh installs (`clearCachedEntries: false, setupSource: false`), which would otherwise leave stale entries from the prior configuration.
 
+`OnboardingViewModel.finishOnboarding()` now calls `ScheduleSourceProvider.setupScheduleSource()` after all step saves complete, so the in-memory source is rebuilt from the just-saved preferences immediately — both for first-run and replay. Without this, a replay on an already-initialized app would leave the source stale because the root deferred init (`_onOnboardingStateChanged`) bails once `_backgroundInitStarted` is true.
+
 ## Why This Works
 - `--dart-define` values are compile-time constants (`String.fromEnvironment`/`bool.fromEnvironment`), so they are free at runtime when unset and never ship to release.
 - The override runs after service injection (so `PreferencesProvider` exists) but before preferences are read by the view model.
 - The replay button reuses the existing onboarding route/finish handler, so no duplicated navigation logic.
 - The replay clears the schedule cache so the deferred onboarding save path does not leave stale data behind.
+- `finishOnboarding()` explicitly re-syncs the schedule source after saves, so the source is always current regardless of whether the root deferred init already ran.
 
 ## Tests
 - `test/common/appstart/debug_startup_overrides_test.dart`
 - `test/schedule/business/schedule_source_provider_test.dart`
+- `test/ui/onboarding/onboarding_finish_source_resync_test.dart`
 - `test/ui/settings/settings_developer_replay_onboarding_test.dart`
 
 ## Related Docs

--- a/docs/solutions/developer-experience/skip-and-replay-onboarding-20260702.md
+++ b/docs/solutions/developer-experience/skip-and-replay-onboarding-20260702.md
@@ -30,8 +30,8 @@ Supported defines (debug builds only):
 | `SKIP_ONBOARDING` | `true` | Marks first start as completed. |
 | `SCHEDULE_SOURCE` | `rapla` | Sets source type (`rapla`/`dualis`/`ical`/`mannheim`/`none`). |
 | `RAPLA_URL` | `https://rapla...` | Persists Rapla URL; infers source `rapla` unless `SCHEDULE_SOURCE` is set. |
-| `ICAL_URL` | `https://...ics` | Persists iCal URL; infers source `ical`. |
-| `MANNHEIM_ID` | `course-id` | Persists Mannheim schedule id; infers source `mannheim`. |
+| `ICAL_URL` | `https://...ics` | Persists iCal URL; infers source `ical` (or `mannheim` when `MANNHEIM_ID` is also set). |
+| `MANNHEIM_ID` | `course-id` | Persists Mannheim schedule id. Alone this does **not** select a source (Mannheim is built on the iCal source, so pair with `ICAL_URL` to select `mannheim`). |
 | `CANTEEN_LOCATION_ID` | `karlsruhe_erzbergerstrasse` | Persists canteen location (must be a supported id). |
 
 Example:

--- a/docs/solutions/developer-experience/skip-and-replay-onboarding-20260702.md
+++ b/docs/solutions/developer-experience/skip-and-replay-onboarding-20260702.md
@@ -48,15 +48,19 @@ The whole path is guarded by `kDebugMode` so it is a no-op in release builds.
 
 ### Feature 2: Replay onboarding from Developer Options
 
-Added a "Replay onboarding" tile under **Settings → Developer options** (debug builds only). Tapping it persists `IsFirstStart = true` and navigates to the onboarding route via `pushNamedAndRemoveUntil`, so finishing the flow lands cleanly back on `main`.
+Added a "Replay onboarding" tile under **Settings → Developer options** (debug builds only). Tapping it clears cached schedule entries and query information (via `ScheduleSourceProvider.clearScheduleCache()`), persists `IsFirstStart = true`, and navigates to the onboarding route via `pushNamedAndRemoveUntil`, so finishing the flow lands cleanly back on `main`.
+
+The cache clear is necessary because the onboarding save path is deferred for fresh installs (`clearCachedEntries: false, setupSource: false`), which would otherwise leave stale entries from the prior configuration.
 
 ## Why This Works
 - `--dart-define` values are compile-time constants (`String.fromEnvironment`/`bool.fromEnvironment`), so they are free at runtime when unset and never ship to release.
 - The override runs after service injection (so `PreferencesProvider` exists) but before preferences are read by the view model.
 - The replay button reuses the existing onboarding route/finish handler, so no duplicated navigation logic.
+- The replay clears the schedule cache so the deferred onboarding save path does not leave stale data behind.
 
 ## Tests
 - `test/common/appstart/debug_startup_overrides_test.dart`
+- `test/schedule/business/schedule_source_provider_test.dart`
 - `test/ui/settings/settings_developer_replay_onboarding_test.dart`
 
 ## Related Docs

--- a/docs/solutions/developer-experience/skip-and-replay-onboarding-20260702.md
+++ b/docs/solutions/developer-experience/skip-and-replay-onboarding-20260702.md
@@ -1,0 +1,63 @@
+---
+module: Developer Experience
+date: 2026-07-02
+problem_type: developer_experience
+component: development_workflow
+symptoms:
+  - "Manual onboarding required on every fresh debug install"
+  - "No way to re-trigger onboarding from inside a debug build"
+root_cause: missing_tooling
+resolution_type: feature
+severity: low
+tags: [developer-options, onboarding, dart-define, debug-mode, testing]
+---
+
+# Skip/Replay Onboarding for Debug Builds
+
+## Problem
+Testing required walking through the full onboarding on every fresh install, and once completed there was no in-app way to re-trigger the onboarding flow to verify changes to it.
+
+## Solution
+
+### Feature 1: Skip onboarding + seed settings via `flutter run` (`--dart-define`)
+
+Added `DebugStartupOverrides` (`lib/common/appstart/debug_startup_overrides.dart`) which reads compile-time defines and writes them into the persisted preferences during startup, **before** `RootViewModel.loadFromPreferences()` runs (so onboarding is already marked complete when the root view model decides the initial route).
+
+Supported defines (debug builds only):
+
+| Define | Example | Effect |
+| --- | --- | --- |
+| `SKIP_ONBOARDING` | `true` | Marks first start as completed. |
+| `SCHEDULE_SOURCE` | `rapla` | Sets source type (`rapla`/`dualis`/`ical`/`mannheim`/`none`). |
+| `RAPLA_URL` | `https://rapla...` | Persists Rapla URL; infers source `rapla` unless `SCHEDULE_SOURCE` is set. |
+| `ICAL_URL` | `https://...ics` | Persists iCal URL; infers source `ical`. |
+| `MANNHEIM_ID` | `course-id` | Persists Mannheim schedule id; infers source `mannheim`. |
+| `CANTEEN_LOCATION_ID` | `karlsruhe_erzbergerstrasse` | Persists canteen location (must be a supported id). |
+
+Example:
+
+```sh
+flutter run -d <device> \
+  --dart-define=SKIP_ONBOARDING=true \
+  --dart-define=SCHEDULE_SOURCE=rapla \
+  --dart-define=RAPLA_URL=https://rapla.dhbw.de/... \
+  --dart-define=CANTEEN_LOCATION_ID=karlsruhe_erzbergerstrasse
+```
+
+The whole path is guarded by `kDebugMode` so it is a no-op in release builds.
+
+### Feature 2: Replay onboarding from Developer Options
+
+Added a "Replay onboarding" tile under **Settings → Developer options** (debug builds only). Tapping it persists `IsFirstStart = true` and navigates to the onboarding route via `pushNamedAndRemoveUntil`, so finishing the flow lands cleanly back on `main`.
+
+## Why This Works
+- `--dart-define` values are compile-time constants (`String.fromEnvironment`/`bool.fromEnvironment`), so they are free at runtime when unset and never ship to release.
+- The override runs after service injection (so `PreferencesProvider` exists) but before preferences are read by the view model.
+- The replay button reuses the existing onboarding route/finish handler, so no duplicated navigation logic.
+
+## Tests
+- `test/common/appstart/debug_startup_overrides_test.dart`
+- `test/ui/settings/settings_developer_replay_onboarding_test.dart`
+
+## Related Docs
+- `docs/solutions/developer-experience/developer-options-and-overlay-20260207.md`

--- a/lib/common/appstart/debug_startup_overrides.dart
+++ b/lib/common/appstart/debug_startup_overrides.dart
@@ -12,8 +12,13 @@ import 'package:flutter/foundation.dart';
 /// * `SCHEDULE_SOURCE`           - one of `rapla`, `dualis`, `ical`,
 ///                                  `mannheim`, `none`.
 /// * `RAPLA_URL`                 - Rapla schedule endpoint.
-/// * `ICAL_URL`                  - iCal schedule endpoint.
-/// * `MANNHEIM_ID`               - DHBW Mannheim schedule id.
+/// * `ICAL_URL`                  - iCal schedule endpoint. Also required when
+///                                  using `MANNHEIM_ID`, since the Mannheim
+///                                  source is built on the iCal source.
+/// * `MANNHEIM_ID`               - DHBW Mannheim schedule id. Alone this only
+///                                  stores the id; pair it with `ICAL_URL`
+///                                  (and optionally `SCHEDULE_SOURCE=mannheim`)
+///                                  to select the Mannheim source.
 /// * `CANTEEN_LOCATION_ID`       - one of [CanteenLocations.supported] ids.
 ///
 /// Example:
@@ -78,11 +83,19 @@ class DebugStartupOverrides {
 
   /// Resolves the effective schedule source type, preferring an explicit
   /// `SCHEDULE_SOURCE` define and otherwise inferring it from a URL define.
+  ///
+  /// Mannheim is built on the iCal source (`ScheduleSourceProvider` initializes
+  /// it through `_icalScheduleSource()`, which reads `getIcalUrl()`), so a bare
+  /// `MANNHEIM_ID` without an `ICAL_URL` cannot produce a valid source and is
+  /// therefore not inferred. When both `ICAL_URL` and `MANNHEIM_ID` are
+  /// provided, Mannheim is preferred over Ical.
   ScheduleSourceType? get effectiveScheduleSource {
     if (scheduleSource != null) return scheduleSource;
     if (raplaUrl != null) return ScheduleSourceType.Rapla;
-    if (icalUrl != null) return ScheduleSourceType.Ical;
-    if (mannheimId != null) return ScheduleSourceType.Mannheim;
+    if (icalUrl != null) {
+      if (mannheimId != null) return ScheduleSourceType.Mannheim;
+      return ScheduleSourceType.Ical;
+    }
     return null;
   }
 

--- a/lib/common/appstart/debug_startup_overrides.dart
+++ b/lib/common/appstart/debug_startup_overrides.dart
@@ -1,0 +1,138 @@
+import 'package:dualmate/canteen/model/canteen_location.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:flutter/foundation.dart';
+
+/// Parses `--dart-define` values supplied through `flutter run` so the app can
+/// skip onboarding and seed core settings during development.
+///
+/// Supported defines (all optional, only honored in debug builds):
+///
+/// * `SKIP_ONBOARDING` (`true`)  - marks the first start as completed.
+/// * `SCHEDULE_SOURCE`           - one of `rapla`, `dualis`, `ical`,
+///                                  `mannheim`, `none`.
+/// * `RAPLA_URL`                 - Rapla schedule endpoint.
+/// * `ICAL_URL`                  - iCal schedule endpoint.
+/// * `MANNHEIM_ID`               - DHBW Mannheim schedule id.
+/// * `CANTEEN_LOCATION_ID`       - one of [CanteenLocations.supported] ids.
+///
+/// Example:
+///
+/// ```sh
+/// flutter run -d <device> \
+///   --dart-define=SKIP_ONBOARDING=true \
+///   --dart-define=SCHEDULE_SOURCE=rapla \
+///   --dart-define=RAPLA_URL=https://rapla.dhbw.de/... \
+///   --dart-define=CANTEEN_LOCATION_ID=karlsruhe_erzbergerstrasse
+/// ```
+class DebugStartupOverrides {
+  final bool skipOnboarding;
+  final ScheduleSourceType? scheduleSource;
+  final String? raplaUrl;
+  final String? icalUrl;
+  final String? mannheimId;
+  final String? canteenLocationId;
+
+  const DebugStartupOverrides({
+    this.skipOnboarding = false,
+    this.scheduleSource,
+    this.raplaUrl,
+    this.icalUrl,
+    this.mannheimId,
+    this.canteenLocationId,
+  });
+
+  static const String _kSkipOnboarding = 'SKIP_ONBOARDING';
+  static const String _kScheduleSource = 'SCHEDULE_SOURCE';
+  static const String _kRaplaUrl = 'RAPLA_URL';
+  static const String _kIcalUrl = 'ICAL_URL';
+  static const String _kMannheimId = 'MANNHEIM_ID';
+  static const String _kCanteenLocationId = 'CANTEEN_LOCATION_ID';
+
+  /// Reads the compile-time `--dart-define` values. The result is always
+  /// inactive in release builds because [apply] is guarded by [kDebugMode],
+  /// and defaults to "no overrides" when no defines are provided.
+  factory DebugStartupOverrides.fromEnvironment() {
+    return DebugStartupOverrides(
+      skipOnboarding: const bool.fromEnvironment(_kSkipOnboarding),
+      scheduleSource: _parseScheduleSource(
+        const String.fromEnvironment(_kScheduleSource),
+      ),
+      raplaUrl: _nonEmpty(const String.fromEnvironment(_kRaplaUrl)),
+      icalUrl: _nonEmpty(const String.fromEnvironment(_kIcalUrl)),
+      mannheimId: _nonEmpty(const String.fromEnvironment(_kMannheimId)),
+      canteenLocationId: _nonEmpty(
+        const String.fromEnvironment(_kCanteenLocationId),
+      ),
+    );
+  }
+
+  /// Whether any override was supplied and [apply] should run.
+  bool get isActive =>
+      skipOnboarding ||
+      scheduleSource != null ||
+      raplaUrl != null ||
+      icalUrl != null ||
+      mannheimId != null ||
+      canteenLocationId != null;
+
+  /// Resolves the effective schedule source type, preferring an explicit
+  /// `SCHEDULE_SOURCE` define and otherwise inferring it from a URL define.
+  ScheduleSourceType? get effectiveScheduleSource {
+    if (scheduleSource != null) return scheduleSource;
+    if (raplaUrl != null) return ScheduleSourceType.Rapla;
+    if (icalUrl != null) return ScheduleSourceType.Ical;
+    if (mannheimId != null) return ScheduleSourceType.Mannheim;
+    return null;
+  }
+
+  /// Writes the overrides into the persisted preferences. Should only be
+  /// called from a debug build path.
+  Future<void> apply(PreferencesProvider preferencesProvider) async {
+    if (skipOnboarding) {
+      await preferencesProvider.setIsFirstStart(false);
+    }
+
+    if (raplaUrl != null) {
+      await preferencesProvider.setRaplaUrl(raplaUrl!);
+    }
+    if (icalUrl != null) {
+      await preferencesProvider.setIcalUrl(icalUrl!);
+    }
+    if (mannheimId != null) {
+      await preferencesProvider.setMannheimScheduleId(mannheimId!);
+    }
+
+    final source = effectiveScheduleSource;
+    if (source != null) {
+      await preferencesProvider.setScheduleSourceType(source.index);
+    }
+
+    if (canteenLocationId != null) {
+      final location = CanteenLocations.supportedFromId(canteenLocationId);
+      if (location != null) {
+        await preferencesProvider.setSelectedCanteenLocationId(location.id);
+      }
+    }
+  }
+
+  static String? _nonEmpty(String value) =>
+      value.isEmpty ? null : value;
+
+  static ScheduleSourceType? _parseScheduleSource(String value) {
+    switch (value.toLowerCase()) {
+      case 'rapla':
+        return ScheduleSourceType.Rapla;
+      case 'dualis':
+        return ScheduleSourceType.Dualis;
+      case 'ical':
+        return ScheduleSourceType.Ical;
+      case 'mannheim':
+        return ScheduleSourceType.Mannheim;
+      case 'none':
+        return ScheduleSourceType.None;
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -187,6 +187,7 @@ final de = {
   "settingsDeveloperTitle": "Entwickleroptionen",
   "settingsDeveloperSubtitle": "Tippen, um Debug-Tools zu aktivieren",
   "settingsPerformanceOverlay": "Performance-Overlay anzeigen",
+  "settingsDeveloperReplayOnboarding": "Onboarding wiederholen",
   "selectThemeDialogTitle": "Design auswählen",
   "selectThemeLight": "Hell",
   "selectThemeDark": "Dunkel",

--- a/lib/common/i18n/localization_strings_en.dart
+++ b/lib/common/i18n/localization_strings_en.dart
@@ -178,6 +178,7 @@ final en = {
   "settingsDeveloperTitle": "Developer options",
   "settingsDeveloperSubtitle": "Tap to unlock debugging tools",
   "settingsPerformanceOverlay": "Show performance overlay",
+  "settingsDeveloperReplayOnboarding": "Replay onboarding",
   "selectThemeDialogTitle": "Select theme",
   "selectThemeLight": "Light",
   "selectThemeDark": "Dark",

--- a/lib/common/i18n/localizations.dart
+++ b/lib/common/i18n/localizations.dart
@@ -415,6 +415,9 @@ class L {
   String get settingsPerformanceOverlay =>
       _getValue("settingsPerformanceOverlay");
 
+  String get settingsDeveloperReplayOnboarding =>
+      _getValue("settingsDeveloperReplayOnboarding");
+
   String get selectThemeDialogTitle => _getValue("selectThemeDialogTitle");
   String get selectThemeLight => _getValue("selectThemeLight");
   String get selectThemeDark => _getValue("selectThemeDark");

--- a/lib/schedule/business/schedule_source_provider.dart
+++ b/lib/schedule/business/schedule_source_provider.dart
@@ -219,6 +219,13 @@ class ScheduleSourceProvider {
     await Future.wait([scheduleEntries, queryInformation]);
   }
 
+  /// Clears all cached schedule entries and query information. Used when
+  /// replaying onboarding so stale data from a prior configuration does not
+  /// linger through the deferred onboarding save path.
+  Future<void> clearScheduleCache() async {
+    await _clearEntryCache();
+  }
+
   void fireScheduleSourceChanged() {
     _onDidChangeScheduleSourceCallbacks.forEach((element) {
       element(currentScheduleSource, true);

--- a/lib/ui/onboarding/onboarding_page.dart
+++ b/lib/ui/onboarding/onboarding_page.dart
@@ -28,6 +28,7 @@ class _OnboardingPageState extends State<OnboardingPage>
 
     viewModel = OnboardingViewModel(
       KiwiContainer().resolve(),
+      KiwiContainer().resolve(),
       _onboardingFinished,
     );
 

--- a/lib/ui/onboarding/viewmodels/dualis_login_view_model.dart
+++ b/lib/ui/onboarding/viewmodels/dualis_login_view_model.dart
@@ -52,9 +52,10 @@ class DualisLoginViewModel extends OnboardingStepViewModel {
   Future<void> save() async {
     await preferencesProvider.setStoreDualisCredentials(true);
 
-    // To improve the onboarding experience we do not await this call because
-    // it may take a few seconds
-    preferencesProvider.storeDualisCredentials(Credentials(
+    // Await so that finishOnboarding()'s immediate setupScheduleSource() call
+    // can read the credentials. Without this, the source would be marked
+    // invalid because the secure-storage write hasn't completed yet.
+    await preferencesProvider.storeDualisCredentials(Credentials(
       username,
       password,
     ));

--- a/lib/ui/onboarding/viewmodels/onboarding_view_model.dart
+++ b/lib/ui/onboarding/viewmodels/onboarding_view_model.dart
@@ -1,12 +1,14 @@
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/logging/analytics.dart';
 import 'package:dualmate/common/ui/viewmodels/base_view_model.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/ui/onboarding/onboardin_step.dart';
 
 typedef OnboardingFinished = void Function();
 
 class OnboardingViewModel extends BaseViewModel {
   final PreferencesProvider preferencesProvider;
+  final ScheduleSourceProvider scheduleSourceProvider;
   final OnboardingFinished _onboardingFinished;
 
   final List<String> steps = [
@@ -45,6 +47,7 @@ class OnboardingViewModel extends BaseViewModel {
 
   OnboardingViewModel(
     this.preferencesProvider,
+    this.scheduleSourceProvider,
     this._onboardingFinished,
   ) {
     for (var page in pages.values) {
@@ -104,6 +107,13 @@ class OnboardingViewModel extends BaseViewModel {
         await page.viewModel().save();
       }
     }
+
+    // Rebuild the schedule source from the just-saved preferences. The Rapla
+    // onboarding save path defers source setup (setupSource: false), so
+    // without this explicit call the in-memory source stays stale —
+    // particularly noticeable when replaying onboarding on an
+    // already-initialized app where the deferred startup init won't re-run.
+    await scheduleSourceProvider.setupScheduleSource();
 
     _onboardingFinished.call();
 

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -9,6 +9,7 @@ import 'package:dualmate/common/logging/sentry_scrubber.dart';
 import 'package:dualmate/common/ui/colors.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
 import 'package:dualmate/common/appstart/app_initializer.dart';
+import 'package:dualmate/common/appstart/debug_startup_overrides.dart';
 import 'package:dualmate/common/appstart/locale_preference_sync.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/util/launch_intent.dart';
@@ -211,6 +212,8 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
         args: {'elapsedMs': widget.startupStopwatch.elapsedMilliseconds},
       );
 
+      await _applyDebugStartupOverrides();
+
       if (!mounted) return;
 
       _localePreferenceSync = LocalePreferenceSync(
@@ -277,6 +280,31 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
         attended,
       );
     } catch (_) {}
+  }
+
+  Future<void> _applyDebugStartupOverrides() async {
+    if (!kDebugMode) return;
+
+    final overrides = DebugStartupOverrides.fromEnvironment();
+    if (!overrides.isActive) return;
+
+    try {
+      await overrides.apply(KiwiContainer().resolve<PreferencesProvider>());
+      _debugRootLog("Root init: applied debug startup overrides");
+    } catch (error, trace) {
+      _debugRootError("Root init: debug startup overrides failed", error, trace);
+      unawaited(
+        AppDiagnostics.instance.reportCaughtException(
+          error,
+          trace,
+          message: 'Root init: debug startup overrides failed',
+          tags: {'feature': 'startup'},
+          contexts: {
+            'startup': {'phase': 'debug_overrides'},
+          },
+        ),
+      );
+    }
   }
 
   Future<void> _loadRootPreferences(Stopwatch stopwatch) async {

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -9,8 +9,10 @@ import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
 import 'package:dualmate/common/ui/widgets/title_list_tile.dart';
+import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
+import 'package:dualmate/schedule/ui/schedule_page.dart';
 import 'package:dualmate/schedule/ui/widgets/select_source_dialog.dart';
 import 'package:dualmate/ui/settings/select_theme_dialog.dart';
 import 'package:dualmate/ui/settings/viewmodels/settings_view_model.dart';
@@ -372,6 +374,12 @@ class _SettingsPageState extends State<SettingsPage> {
                       if (scheduleSourceProvider != null) {
                         await scheduleSourceProvider.clearScheduleCache();
                       }
+                      // Invalidate in-memory schedule caches so stale entries
+                      // from the previous configuration don't survive the
+                      // route reset.
+                      _resolveOptional<ScheduleProvider>()
+                          ?.invalidateScheduleCache();
+                      SchedulePage.resetSharedState();
                       final preferencesProvider =
                           KiwiContainer().resolve<PreferencesProvider>();
                       await preferencesProvider.setIsFirstStart(true);

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -9,6 +9,7 @@ import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
 import 'package:dualmate/common/ui/widgets/title_list_tile.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
 import 'package:dualmate/schedule/ui/widgets/select_source_dialog.dart';
 import 'package:dualmate/ui/settings/select_theme_dialog.dart';
@@ -366,10 +367,15 @@ class _SettingsPageState extends State<SettingsPage> {
                   ListTile(
                     title: Text(L.of(context).settingsDeveloperReplayOnboarding),
                     onTap: () async {
+                      final scheduleSourceProvider =
+                          _resolveOptional<ScheduleSourceProvider>();
+                      if (scheduleSourceProvider != null) {
+                        await scheduleSourceProvider.clearScheduleCache();
+                      }
                       final preferencesProvider =
                           KiwiContainer().resolve<PreferencesProvider>();
                       await preferencesProvider.setIsFirstStart(true);
-                      if (!context.mounted) return;
+                      if (!mounted) return;
                       Navigator.of(context).pushNamedAndRemoveUntil(
                         "onboarding",
                         (route) => false,

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -369,7 +369,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       final preferencesProvider =
                           KiwiContainer().resolve<PreferencesProvider>();
                       await preferencesProvider.setIsFirstStart(true);
-                      if (!mounted) return;
+                      if (!context.mounted) return;
                       Navigator.of(context).pushNamedAndRemoveUntil(
                         "onboarding",
                         (route) => false,

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:dualmate/common/application_constants.dart';
 import 'package:dualmate/common/background/task_callback.dart';
 import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/app_theme_enum.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
@@ -361,6 +362,19 @@ class _SettingsPageState extends State<SettingsPage> {
                     title: Text(L.of(context).settingsPerformanceOverlay),
                     onChanged: model.setShowPerformanceOverlay,
                     value: model.showPerformanceOverlay,
+                  ),
+                  ListTile(
+                    title: Text(L.of(context).settingsDeveloperReplayOnboarding),
+                    onTap: () async {
+                      final preferencesProvider =
+                          KiwiContainer().resolve<PreferencesProvider>();
+                      await preferencesProvider.setIsFirstStart(true);
+                      if (!mounted) return;
+                      Navigator.of(context).pushNamedAndRemoveUntil(
+                        "onboarding",
+                        (route) => false,
+                      );
+                    },
                   ),
                 ],
               );

--- a/test/common/appstart/debug_startup_overrides_test.dart
+++ b/test/common/appstart/debug_startup_overrides_test.dart
@@ -52,9 +52,22 @@ void main() {
       expect(overrides.effectiveScheduleSource, ScheduleSourceType.Ical);
     });
 
-    test('mannheim id infers mannheim source', () {
+    test('mannheim id alone does not infer a source', () {
       const overrides = DebugStartupOverrides(mannheimId: 'abc123');
+      expect(overrides.effectiveScheduleSource, isNull);
+    });
+
+    test('mannheim id with ical url infers mannheim source', () {
+      const overrides = DebugStartupOverrides(
+        mannheimId: 'abc123',
+        icalUrl: 'https://ical.example',
+      );
       expect(overrides.effectiveScheduleSource, ScheduleSourceType.Mannheim);
+    });
+
+    test('ical url without mannheim id infers ical source', () {
+      const overrides = DebugStartupOverrides(icalUrl: 'https://ical.example');
+      expect(overrides.effectiveScheduleSource, ScheduleSourceType.Ical);
     });
 
     test('no source clues returns null', () {
@@ -104,15 +117,33 @@ void main() {
       );
     });
 
-    test('persists mannheim id and infers mannheim source type', () async {
+    test('persists mannheim id with ical url and infers mannheim source type', () async {
+      const overrides = DebugStartupOverrides(
+        mannheimId: 'course-42',
+        icalUrl: 'https://ical.example',
+      );
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.getMannheimScheduleId(), 'course-42');
+      expect(await preferencesProvider.getIcalUrl(), 'https://ical.example');
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.Mannheim.index,
+      );
+    });
+
+    test('mannheim id without ical url does not select a source type', () async {
       const overrides = DebugStartupOverrides(mannheimId: 'course-42');
 
       await overrides.apply(preferencesProvider);
 
       expect(await preferencesProvider.getMannheimScheduleId(), 'course-42');
+      // Source type stays at default (None): Mannheim is built on the iCal
+      // source, so a bare course id cannot produce a valid source.
       expect(
         await preferencesProvider.getScheduleSourceType(),
-        ScheduleSourceType.Mannheim.index,
+        ScheduleSourceType.None.index,
       );
     });
 

--- a/test/common/appstart/debug_startup_overrides_test.dart
+++ b/test/common/appstart/debug_startup_overrides_test.dart
@@ -1,0 +1,199 @@
+import 'package:dualmate/canteen/model/canteen_location.dart';
+import 'package:dualmate/common/appstart/debug_startup_overrides.dart';
+import 'package:dualmate/common/data/preferences/preferences_access.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late PreferencesProvider preferencesProvider;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    preferencesProvider =
+        PreferencesProvider(PreferencesAccess(), SecureStorageAccess());
+  });
+
+  group('isActive', () {
+    test('empty overrides are inactive', () {
+      expect(const DebugStartupOverrides().isActive, isFalse);
+    });
+
+    test('skip onboarding makes overrides active', () {
+      expect(const DebugStartupOverrides(skipOnboarding: true).isActive, isTrue);
+    });
+
+    test('a rapla url makes overrides active', () {
+      expect(
+        const DebugStartupOverrides(raplaUrl: 'https://rapla.example').isActive,
+        isTrue,
+      );
+    });
+  });
+
+  group('effectiveScheduleSource', () {
+    test('explicit source wins over inferred url source', () {
+      final overrides = DebugStartupOverrides(
+        scheduleSource: ScheduleSourceType.Dualis,
+        raplaUrl: 'https://rapla.example',
+      );
+      expect(overrides.effectiveScheduleSource, ScheduleSourceType.Dualis);
+    });
+
+    test('rapla url infers rapla source', () {
+      const overrides = DebugStartupOverrides(raplaUrl: 'https://rapla.example');
+      expect(overrides.effectiveScheduleSource, ScheduleSourceType.Rapla);
+    });
+
+    test('ical url infers ical source', () {
+      const overrides = DebugStartupOverrides(icalUrl: 'https://ical.example');
+      expect(overrides.effectiveScheduleSource, ScheduleSourceType.Ical);
+    });
+
+    test('mannheim id infers mannheim source', () {
+      const overrides = DebugStartupOverrides(mannheimId: 'abc123');
+      expect(overrides.effectiveScheduleSource, ScheduleSourceType.Mannheim);
+    });
+
+    test('no source clues returns null', () {
+      const overrides = DebugStartupOverrides(skipOnboarding: true);
+      expect(overrides.effectiveScheduleSource, isNull);
+    });
+  });
+
+  group('apply', () {
+    test('marks first start as completed when skipOnboarding is set', () async {
+      const overrides = DebugStartupOverrides(skipOnboarding: true);
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.isFirstStart(), isFalse);
+    });
+
+    test('does not touch first start when skipOnboarding is false', () async {
+      const overrides = DebugStartupOverrides(raplaUrl: 'https://rapla.example');
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.isFirstStart(), isTrue);
+    });
+
+    test('persists rapla url and infers rapla source type', () async {
+      const overrides = DebugStartupOverrides(raplaUrl: 'https://rapla.example');
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.getRaplaUrl(), 'https://rapla.example');
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.Rapla.index,
+      );
+    });
+
+    test('persists ical url and infers ical source type', () async {
+      const overrides = DebugStartupOverrides(icalUrl: 'https://ical.example');
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.getIcalUrl(), 'https://ical.example');
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.Ical.index,
+      );
+    });
+
+    test('persists mannheim id and infers mannheim source type', () async {
+      const overrides = DebugStartupOverrides(mannheimId: 'course-42');
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.getMannheimScheduleId(), 'course-42');
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.Mannheim.index,
+      );
+    });
+
+    test('explicit schedule source overrides inferred url source', () async {
+      const overrides = DebugStartupOverrides(
+        raplaUrl: 'https://rapla.example',
+        scheduleSource: ScheduleSourceType.None,
+      );
+
+      await overrides.apply(preferencesProvider);
+
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.None.index,
+      );
+    });
+
+    test('persists supported canteen location id', () async {
+      const overrides = DebugStartupOverrides(
+        canteenLocationId: CanteenLocations.karlsruheId,
+      );
+
+      await overrides.apply(preferencesProvider);
+
+      expect(
+        await preferencesProvider.getSelectedCanteenLocationId(),
+        CanteenLocations.karlsruheId,
+      );
+    });
+
+    test('ignores unknown canteen location id', () async {
+      const overrides = DebugStartupOverrides(
+        canteenLocationId: 'does_not_exist',
+      );
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.getSelectedCanteenLocationId(), isNull);
+    });
+
+    test('applies a full setup combination', () async {
+      const overrides = DebugStartupOverrides(
+        skipOnboarding: true,
+        raplaUrl: 'https://rapla.example',
+        canteenLocationId: CanteenLocations.karlsruheId,
+      );
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.isFirstStart(), isFalse);
+      expect(await preferencesProvider.getRaplaUrl(), 'https://rapla.example');
+      expect(
+        await preferencesProvider.getScheduleSourceType(),
+        ScheduleSourceType.Rapla.index,
+      );
+      expect(
+        await preferencesProvider.getSelectedCanteenLocationId(),
+        CanteenLocations.karlsruheId,
+      );
+    });
+
+    test('empty overrides change nothing', () async {
+      const overrides = DebugStartupOverrides();
+
+      await overrides.apply(preferencesProvider);
+
+      expect(await preferencesProvider.isFirstStart(), isTrue);
+      expect(await preferencesProvider.getRaplaUrl(), '');
+      expect(await preferencesProvider.getSelectedCanteenLocationId(), isNull);
+    });
+  });
+
+  group('fromEnvironment', () {
+    test('returns inactive overrides when no defines are set', () {
+      final overrides = DebugStartupOverrides.fromEnvironment();
+
+      expect(overrides.isActive, isFalse);
+      expect(overrides.skipOnboarding, isFalse);
+      expect(overrides.scheduleSource, isNull);
+      expect(overrides.raplaUrl, isNull);
+      expect(overrides.canteenLocationId, isNull);
+    });
+  });
+}

--- a/test/schedule/business/schedule_source_provider_test.dart
+++ b/test/schedule/business/schedule_source_provider_test.dart
@@ -1,0 +1,58 @@
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
+import 'package:dualmate/schedule/data/schedule_query_information_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('clearScheduleCache', () {
+    test('deletes entries and query information', () async {
+      final entryRepo = _RecordingEntryRepository();
+      final queryRepo = _RecordingQueryInformationRepository();
+      final provider = ScheduleSourceProvider(
+        _FakePreferencesProvider(),
+        false,
+        entryRepo,
+        queryRepo,
+      );
+
+      await provider.clearScheduleCache();
+
+      expect(entryRepo.deleteAllCalls, 1);
+      expect(queryRepo.deleteAllCalls, 1);
+    });
+  });
+}
+
+class _FakePreferencesProvider implements PreferencesProvider {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+class _RecordingEntryRepository implements ScheduleEntryRepository {
+  int deleteAllCalls = 0;
+
+  @override
+  Future<void> deleteAllScheduleEntries() async {
+    deleteAllCalls += 1;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+class _RecordingQueryInformationRepository
+    implements ScheduleQueryInformationRepository {
+  int deleteAllCalls = 0;
+
+  @override
+  Future<void> deleteAllQueryInformation() async {
+    deleteAllCalls += 1;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}

--- a/test/ui/onboarding/dualis_login_view_model_save_test.dart
+++ b/test/ui/onboarding/dualis_login_view_model_save_test.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/dualis/model/credentials.dart';
+import 'package:dualmate/dualis/service/dualis_service.dart';
+import 'package:dualmate/ui/onboarding/viewmodels/dualis_login_view_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'save does not complete until credential persistence finishes',
+    () async {
+      final storeCompleter = Completer<void>();
+      final preferencesProvider = _DelayedCredentialsPreferencesProvider(
+        storeCompleter,
+      );
+      final viewModel = DualisLoginViewModel(
+        preferencesProvider,
+        _FakeDualisService(),
+      );
+      viewModel.username = 'testuser';
+      viewModel.password = 'testpass';
+
+      var saveCompleted = false;
+      final saveFuture = viewModel.save().then((_) {
+        saveCompleted = true;
+      });
+
+      // Let any pending microtasks drain. If save() had not awaited
+      // storeDualisCredentials, it would complete before the completer fires.
+      await Future.microtask(() {});
+      expect(saveCompleted, isFalse);
+
+      storeCompleter.complete();
+      await saveFuture;
+
+      expect(saveCompleted, isTrue);
+      expect(preferencesProvider.storeCredentialsCalls, 1);
+    },
+  );
+}
+
+class _DelayedCredentialsPreferencesProvider implements PreferencesProvider {
+  final Completer<void> _storeCompleter;
+  int storeCredentialsCalls = 0;
+
+  _DelayedCredentialsPreferencesProvider(this._storeCompleter);
+
+  @override
+  Future<void> setStoreDualisCredentials(bool value) async {}
+
+  @override
+  Future<void> storeDualisCredentials(Credentials credentials) async {
+    storeCredentialsCalls += 1;
+    await _storeCompleter.future;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+class _FakeDualisService implements DualisService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}

--- a/test/ui/onboarding/onboarding_finish_source_resync_test.dart
+++ b/test/ui/onboarding/onboarding_finish_source_resync_test.dart
@@ -1,0 +1,95 @@
+import 'package:dualmate/canteen/business/canteen_location_service.dart';
+import 'package:dualmate/common/data/preferences/preferences_access.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
+import 'package:dualmate/dualis/service/dualis_service.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/ui/onboarding/viewmodels/onboarding_view_model.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kiwi/kiwi.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    KiwiContainer().clear();
+
+    // Secure storage uses a platform channel; stub it so DualisLoginViewModel
+    // .save() does not throw during finishOnboarding().
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+      (call) async => null,
+    );
+  });
+
+  tearDown(() {
+    KiwiContainer().clear();
+  });
+
+  test('finishOnboarding re-syncs the schedule source after step saves',
+      () async {
+    final preferencesProvider =
+        PreferencesProvider(PreferencesAccess(), SecureStorageAccess());
+    final scheduleSourceProvider = _RecordingScheduleSourceProvider();
+    final container = KiwiContainer();
+    container.registerInstance<PreferencesProvider>(preferencesProvider);
+    container.registerInstance<CanteenLocationService>(
+      CanteenLocationService(preferencesProvider),
+    );
+    container.registerInstance<ScheduleSourceProvider>(
+      scheduleSourceProvider,
+    );
+    container.registerInstance<DualisService>(_FakeDualisService());
+
+    final viewModel = OnboardingViewModel(
+      preferencesProvider,
+      scheduleSourceProvider,
+      () {},
+    );
+
+    // Navigate to the last step (canteenLocation) via the default Rapla path.
+    await viewModel.nextPage(); // selectSource -> rapla
+    await viewModel.nextPage(); // rapla -> dualis
+    await viewModel.nextPage(); // dualis -> canteenLocation
+
+    expect(viewModel.currentStep, 'canteenLocation');
+
+    // Make the canteen step valid so nextPage() triggers finishOnboarding.
+    final canteenViewModel = viewModel.pages['canteenLocation']!.viewModel();
+    canteenViewModel.setIsValid(true);
+
+    await viewModel.nextPage();
+
+    expect(scheduleSourceProvider.setupScheduleSourceCalls, 1);
+  });
+}
+
+class _RecordingScheduleSourceProvider implements ScheduleSourceProvider {
+  int setupScheduleSourceCalls = 0;
+
+  @override
+  Future<bool> setupScheduleSource() async {
+    setupScheduleSourceCalls += 1;
+    return true;
+  }
+
+  @override
+  Future<void> setupForRapla(
+    String url, {
+    bool clearCachedEntries = true,
+    bool setupSource = true,
+  }) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+class _FakeDualisService implements DualisService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}

--- a/test/ui/onboarding/onboarding_required_canteen_step_test.dart
+++ b/test/ui/onboarding/onboarding_required_canteen_step_test.dart
@@ -32,6 +32,7 @@ void main() {
 
     final viewModel = OnboardingViewModel(
       preferencesProvider,
+      container.resolve<ScheduleSourceProvider>(),
       () {},
     );
 

--- a/test/ui/settings/settings_developer_replay_onboarding_test.dart
+++ b/test/ui/settings/settings_developer_replay_onboarding_test.dart
@@ -8,6 +8,7 @@ import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
 import 'package:dualmate/ui/settings/settings_page.dart';
 import 'package:flutter/material.dart';
@@ -21,12 +22,14 @@ const String _onboardingMarker = '__onboarding_marker__';
 
 void main() {
   late PreferencesProvider preferencesProvider;
+  late _RecordingScheduleSourceProvider scheduleSourceProvider;
 
   setUp(() {
     SharedPreferences.setMockInitialValues({});
     KiwiContainer().clear();
     preferencesProvider =
         PreferencesProvider(PreferencesAccess(), SecureStorageAccess());
+    scheduleSourceProvider = _RecordingScheduleSourceProvider();
     KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
     KiwiContainer().registerInstance<CanteenLocationService>(
       CanteenLocationService(preferencesProvider),
@@ -39,6 +42,9 @@ void main() {
       name: NextDayInformationNotification.name,
     );
     KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
+    KiwiContainer().registerInstance<ScheduleSourceProvider>(
+      scheduleSourceProvider,
+    );
   });
 
   tearDown(() {
@@ -58,7 +64,7 @@ void main() {
   });
 
   testWidgets(
-    'replay onboarding sets first start and navigates to onboarding',
+    'replay onboarding clears schedule cache, sets first start and navigates',
     (tester) async {
       await preferencesProvider.setIsFirstStart(false);
 
@@ -77,6 +83,7 @@ void main() {
 
       expect(find.text(_onboardingMarker), findsOneWidget);
       expect(await preferencesProvider.isFirstStart(), isTrue);
+      expect(scheduleSourceProvider.clearScheduleCacheCalls, 1);
     },
   );
 }
@@ -129,4 +136,17 @@ class _FakeTaskCallback implements TaskCallback {
 
   @override
   Future<void> schedule() async {}
+}
+
+class _RecordingScheduleSourceProvider implements ScheduleSourceProvider {
+  int clearScheduleCacheCalls = 0;
+
+  @override
+  Future<void> clearScheduleCache() async {
+    clearScheduleCacheCalls += 1;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
 }

--- a/test/ui/settings/settings_developer_replay_onboarding_test.dart
+++ b/test/ui/settings/settings_developer_replay_onboarding_test.dart
@@ -1,0 +1,132 @@
+import 'package:dualmate/canteen/business/canteen_location_service.dart';
+import 'package:dualmate/common/background/task_callback.dart';
+import 'package:dualmate/common/background/void_background_work_scheduler.dart';
+import 'package:dualmate/common/background/work_scheduler_service.dart';
+import 'package:dualmate/common/data/preferences/preferences_access.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/common/ui/notification_api.dart';
+import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
+import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
+import 'package:dualmate/ui/settings/settings_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kiwi/kiwi.dart';
+import 'package:property_change_notifier/property_change_notifier.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String _onboardingMarker = '__onboarding_marker__';
+
+void main() {
+  late PreferencesProvider preferencesProvider;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    KiwiContainer().clear();
+    preferencesProvider =
+        PreferencesProvider(PreferencesAccess(), SecureStorageAccess());
+    KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
+    KiwiContainer().registerInstance<CanteenLocationService>(
+      CanteenLocationService(preferencesProvider),
+    );
+    KiwiContainer().registerInstance<WorkSchedulerService>(
+      VoidBackgroundWorkScheduler(),
+    );
+    KiwiContainer().registerInstance<TaskCallback>(
+      _FakeTaskCallback(),
+      name: NextDayInformationNotification.name,
+    );
+    KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
+  });
+
+  tearDown(() {
+    KiwiContainer().clear();
+  });
+
+  testWidgets('replay onboarding tile is hidden until developer options unlock', (
+    tester,
+  ) async {
+    final rootViewModel = RootViewModel(KiwiContainer().resolve());
+    await rootViewModel.loadFromPreferences();
+
+    await tester.pumpWidget(_wrapWithRoutes(rootViewModel));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Replay onboarding'), findsNothing);
+  });
+
+  testWidgets(
+    'replay onboarding sets first start and navigates to onboarding',
+    (tester) async {
+      await preferencesProvider.setIsFirstStart(false);
+
+      final rootViewModel = RootViewModel(preferencesProvider);
+      await rootViewModel.loadFromPreferences();
+
+      await tester.pumpWidget(_wrapWithRoutes(rootViewModel));
+      await tester.pumpAndSettle();
+
+      await _unlockDeveloperOptions(tester);
+
+      expect(find.text('Replay onboarding'), findsOneWidget);
+
+      await tester.tap(find.text('Replay onboarding'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(_onboardingMarker), findsOneWidget);
+      expect(await preferencesProvider.isFirstStart(), isTrue);
+    },
+  );
+}
+
+Future<void> _unlockDeveloperOptions(WidgetTester tester) async {
+  final devTitle = find.text('Developer options');
+  for (var i = 0; i < 6; i++) {
+    await tester.ensureVisible(devTitle);
+    await tester.tap(devTitle);
+    await tester.pump();
+  }
+  await tester.pumpAndSettle();
+}
+
+Widget _wrapWithRoutes(RootViewModel rootViewModel) {
+  return PropertyChangeProvider<RootViewModel, String>(
+    value: rootViewModel,
+    child: MaterialApp(
+      localizationsDelegates: const [
+        LocalizationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('de')],
+      home: SettingsPage(),
+      onGenerateRoute: (settings) {
+        if (settings.name == 'onboarding') {
+          return MaterialPageRoute(
+            builder: (_) => const Scaffold(
+              body: Center(child: Text(_onboardingMarker)),
+            ),
+          );
+        }
+        return MaterialPageRoute(builder: (_) => Container());
+      },
+    ),
+  );
+}
+
+class _FakeTaskCallback implements TaskCallback {
+  @override
+  Future<void> cancel() async {}
+
+  @override
+  String getName() => 'fake-task';
+
+  @override
+  Future<void> run() async {}
+
+  @override
+  Future<void> schedule() async {}
+}

--- a/test/ui/settings/settings_developer_replay_onboarding_test.dart
+++ b/test/ui/settings/settings_developer_replay_onboarding_test.dart
@@ -8,6 +8,7 @@ import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
+import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
 import 'package:dualmate/ui/settings/settings_page.dart';
@@ -23,6 +24,7 @@ const String _onboardingMarker = '__onboarding_marker__';
 void main() {
   late PreferencesProvider preferencesProvider;
   late _RecordingScheduleSourceProvider scheduleSourceProvider;
+  late _RecordingScheduleProvider scheduleProvider;
 
   setUp(() {
     SharedPreferences.setMockInitialValues({});
@@ -30,6 +32,7 @@ void main() {
     preferencesProvider =
         PreferencesProvider(PreferencesAccess(), SecureStorageAccess());
     scheduleSourceProvider = _RecordingScheduleSourceProvider();
+    scheduleProvider = _RecordingScheduleProvider();
     KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
     KiwiContainer().registerInstance<CanteenLocationService>(
       CanteenLocationService(preferencesProvider),
@@ -45,6 +48,7 @@ void main() {
     KiwiContainer().registerInstance<ScheduleSourceProvider>(
       scheduleSourceProvider,
     );
+    KiwiContainer().registerInstance<ScheduleProvider>(scheduleProvider);
   });
 
   tearDown(() {
@@ -84,6 +88,7 @@ void main() {
       expect(find.text(_onboardingMarker), findsOneWidget);
       expect(await preferencesProvider.isFirstStart(), isTrue);
       expect(scheduleSourceProvider.clearScheduleCacheCalls, 1);
+      expect(scheduleProvider.invalidateScheduleCacheCalls, 1);
     },
   );
 }
@@ -144,6 +149,19 @@ class _RecordingScheduleSourceProvider implements ScheduleSourceProvider {
   @override
   Future<void> clearScheduleCache() async {
     clearScheduleCacheCalls += 1;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+class _RecordingScheduleProvider implements ScheduleProvider {
+  int invalidateScheduleCacheCalls = 0;
+
+  @override
+  void invalidateScheduleCache() {
+    invalidateScheduleCacheCalls += 1;
   }
 
   @override


### PR DESCRIPTION
## Summary
- Added debug-only startup overrides via `--dart-define` to skip onboarding and seed schedule/canteen preferences before the root route is chosen.
- Added a Developer options action to replay onboarding from inside the app, using the existing onboarding flow and navigation.
- Simplified Mannheim schedule setup to use the iCal-backed source path and replaced the old Mannheim course service with a new response parser/scraper flow.
- Removed now-unused diagnostics and canteen failure wrapper code, and updated localization strings to match the onboarding/settings changes.

## Testing
- `test/common/appstart/debug_startup_overrides_test.dart`
- `test/ui/settings/settings_developer_replay_onboarding_test.dart`
- `test/schedule/service/mannheim/mannheim_course_response_parser_test.dart`
- `test/ui/onboarding/onboarding_list_tile_material_test.dart`
- Not run: full `flutter test` suite
- Not run: `flutter analyze`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debug-only startup overrides to preconfigure onboarding and schedule/canteen settings, applied during app initialization.
  * Added “Replay onboarding” in Developer settings to reset first-start, clear schedule cache, and reopen onboarding.
* **Bug Fixes**
  * Onboarding now waits for Dualis credential persistence before finishing.
  * Onboarding re-syncs the schedule source after completing step saves.
* **Localization**
  * Added English and German text for “Replay onboarding”.
* **Tests**
  * Added tests for startup override parsing/apply behavior, replay onboarding UI flow, and schedule cache clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->