### PR TITLE
Add adaptive orientation locking for phone-sized displays

### DIFF
--- a/docs/solutions/android/2026-07-04-adaptive-orientation-lock.md
+++ b/docs/solutions/android/2026-07-04-adaptive-orientation-lock.md
@@ -1,0 +1,36 @@
+---
+title: Adaptive orientation lock for phone-sized displays
+type: fix
+date: 2026-07-04
+---
+
+# Summary
+
+DualMate now locks orientation to portrait only when the real display is
+phone-sized. Tablets, foldables, and large-screen/windowed devices leave
+orientation unrestricted so Android can use normal portrait and landscape
+behavior.
+
+# Implementation
+
+- `PlatformUtil.initializePortraitLandscapeMode()` attaches an
+  `AdaptiveOrientationLock` after `runApp`, preserving non-blocking startup.
+- The lock reads `FlutterView.display.size / display.devicePixelRatio` and uses
+  shortest side `< 600dp` as the phone breakpoint.
+- Phone-sized displays call `SystemChrome.setPreferredOrientations()` with
+  `portraitUp` and `portraitDown`.
+- Tablet and large-screen displays call `SystemChrome.setPreferredOrientations`
+  with an empty orientation list, leaving orientation unrestricted.
+- The lock observes display metric changes and re-applies the policy when the
+  display crosses the breakpoint.
+
+# Validation
+
+- `flutter test test/common/util/adaptive_orientation_lock_test.dart`
+
+Covered cases:
+
+- phone portrait stays portrait-only
+- phone landscape is forced back to portrait
+- tablet landscape remains unrestricted
+- metric changes from phone to large screen remove the portrait restriction

--- a/docs/support/launch-and-orientation.md
+++ b/docs/support/launch-and-orientation.md
@@ -1,7 +1,7 @@
 # Launch and orientation behavior
 
 ## Summary
-The app no longer uses a custom splash screen. Orientation is allowed in all directions on phones and tablets. A lightweight loading shell appears while initialization completes.
+The app no longer uses a custom splash screen. Orientation is adaptive: phones are locked to portrait, while tablets and large-screen devices keep normal system portrait/landscape behavior. A lightweight loading shell appears while initialization completes.
 
 ## What to expect on launch
 - Android shows the system splash (app icon) on Android 12+.
@@ -9,7 +9,9 @@ The app no longer uses a custom splash screen. Orientation is allowed in all dir
 - A loading spinner is shown until the app finishes initialization.
 
 ## Orientation support
-- Portrait and landscape are supported on phones and tablets.
+- Phone-sized displays are portrait-only because landscape leaves too little usable app space.
+- Tablet and large-screen displays support normal portrait and landscape behavior.
+- The app bases the orientation policy on the real Flutter display size, not the possibly letterboxed `MediaQuery` size.
 - Tablet layout uses the navigation drawer alongside content.
 - Phone layout uses the standard app bar and drawer.
 
@@ -19,8 +21,9 @@ The app no longer uses a custom splash screen. Orientation is allowed in all dir
 
 ## Notes for QA
 - Test cold start in portrait and landscape.
-- Rotate during launch and confirm the first visible screen matches the device orientation.
-- Verify the main screens are usable in landscape (schedule, dualis, date management, settings, onboarding).
+- On phones, rotate to landscape and confirm the app returns to portrait.
+- On tablets or large-screen/windowed devices, confirm landscape remains available.
+- Resize foldable/tablet windows across the 600dp shortest-side breakpoint and confirm the policy updates without restarting the app.
 
 ## Performance profiling quickstart
 - Run profile on a device: `flutter run --profile -d <DEVICE_ID>`

--- a/lib/common/util/platform_util.dart
+++ b/lib/common/util/platform_util.dart
@@ -1,10 +1,18 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+typedef FlutterViewProvider = FlutterView Function();
+typedef PreferredOrientationsSetter =
+    Future<void> Function(List<DeviceOrientation> orientations);
+
 class PlatformUtil {
+  static final AdaptiveOrientationLock _orientationLock =
+      AdaptiveOrientationLock();
+
   static FlutterView _implicitView() =>
       WidgetsBinding.instance.platformDispatcher.implicitView!;
 
@@ -27,15 +35,94 @@ class PlatformUtil {
   }
 
   static Future<void> initializePortraitLandscapeMode() async {
-    await SystemChrome.setPreferredOrientations([
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-    ]);
+    await _orientationLock.attach();
   }
 
   static bool isAndroid() {
     return Platform.isAndroid;
+  }
+}
+
+class AdaptiveOrientationLock with WidgetsBindingObserver {
+  AdaptiveOrientationLock({
+    FlutterViewProvider? viewProvider,
+    PreferredOrientationsSetter? setPreferredOrientations,
+  }) : _viewProvider =
+           viewProvider ??
+           (() => WidgetsBinding.instance.platformDispatcher.implicitView!),
+       _setPreferredOrientations =
+           setPreferredOrientations ?? SystemChrome.setPreferredOrientations;
+
+  static const double phoneShortestSideBreakpointDp = 600;
+
+  final FlutterViewProvider _viewProvider;
+  final PreferredOrientationsSetter _setPreferredOrientations;
+
+  bool _isAttached = false;
+  List<DeviceOrientation>? _lastAppliedOrientations;
+
+  Future<void> attach() async {
+    if (!_isAttached) {
+      WidgetsBinding.instance.addObserver(this);
+      _isAttached = true;
+    }
+    await update();
+  }
+
+  void detach() {
+    if (!_isAttached) {
+      return;
+    }
+    WidgetsBinding.instance.removeObserver(this);
+    _isAttached = false;
+    _lastAppliedOrientations = null;
+  }
+
+  @override
+  void didChangeMetrics() {
+    unawaited(update());
+  }
+
+  Future<void> update() async {
+    final orientations = preferredOrientationsForDisplay(
+      _viewProvider().display,
+    );
+    if (_sameOrientations(_lastAppliedOrientations, orientations)) {
+      return;
+    }
+    _lastAppliedOrientations = List.unmodifiable(orientations);
+    await _setPreferredOrientations(orientations);
+  }
+
+  static bool isPhoneSizedDisplay(Display display) {
+    final logicalDisplaySize = display.size / display.devicePixelRatio;
+    return logicalDisplaySize.shortestSide < phoneShortestSideBreakpointDp;
+  }
+
+  static List<DeviceOrientation> preferredOrientationsForDisplay(
+    Display display,
+  ) {
+    if (isPhoneSizedDisplay(display)) {
+      return const [
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+      ];
+    }
+    return const [];
+  }
+
+  static bool _sameOrientations(
+    List<DeviceOrientation>? previous,
+    List<DeviceOrientation> next,
+  ) {
+    if (previous == null || previous.length != next.length) {
+      return false;
+    }
+    for (var index = 0; index < previous.length; index++) {
+      if (previous[index] != next[index]) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/test/common/util/adaptive_orientation_lock_test.dart
+++ b/test/common/util/adaptive_orientation_lock_test.dart
@@ -1,0 +1,103 @@
+import 'package:dualmate/common/util/platform_util.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('phone portrait display applies portrait-only orientations', (
+    tester,
+  ) async {
+    _setDisplay(tester, physicalSize: const Size(1080, 2400), dpr: 3);
+    final calls = <List<DeviceOrientation>>[];
+    final lock = _buildLock(tester, calls);
+    addTearDown(() => _resetDisplay(tester, lock));
+
+    await lock.attach();
+
+    expect(calls, [
+      [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown],
+    ]);
+  });
+
+  testWidgets('phone landscape display is still forced to portrait', (
+    tester,
+  ) async {
+    _setDisplay(tester, physicalSize: const Size(2400, 1080), dpr: 3);
+    final calls = <List<DeviceOrientation>>[];
+    final lock = _buildLock(tester, calls);
+    addTearDown(() => _resetDisplay(tester, lock));
+
+    await lock.attach();
+
+    expect(calls, [
+      [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown],
+    ]);
+  });
+
+  testWidgets(
+    'tablet landscape display leaves system orientation unrestricted',
+    (tester) async {
+      _setDisplay(tester, physicalSize: const Size(2560, 1600), dpr: 2);
+      final calls = <List<DeviceOrientation>>[];
+      final lock = _buildLock(tester, calls);
+      addTearDown(() => _resetDisplay(tester, lock));
+
+      await lock.attach();
+
+      expect(calls, [<DeviceOrientation>[]]);
+    },
+  );
+
+  testWidgets(
+    'display metric changes re-evaluate without restricting large screens',
+    (tester) async {
+      _setDisplay(tester, physicalSize: const Size(1080, 2400), dpr: 3);
+      final calls = <List<DeviceOrientation>>[];
+      final lock = _buildLock(tester, calls);
+      addTearDown(() => _resetDisplay(tester, lock));
+
+      await lock.attach();
+      expect(calls.last, [
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+      ]);
+
+      calls.clear();
+      _setDisplay(tester, physicalSize: const Size(2560, 1600), dpr: 2);
+      await tester.pump();
+
+      expect(calls, [<DeviceOrientation>[]]);
+
+      calls.clear();
+      _setDisplay(tester, physicalSize: const Size(2800, 1800), dpr: 2);
+      await tester.pump();
+
+      expect(calls, isEmpty);
+    },
+  );
+}
+
+AdaptiveOrientationLock _buildLock(
+  WidgetTester tester,
+  List<List<DeviceOrientation>> calls,
+) {
+  return AdaptiveOrientationLock(
+    viewProvider: () => tester.view,
+    setPreferredOrientations: (orientations) async {
+      calls.add(List<DeviceOrientation>.of(orientations));
+    },
+  );
+}
+
+void _setDisplay(
+  WidgetTester tester, {
+  required Size physicalSize,
+  required double dpr,
+}) {
+  tester.view.display.devicePixelRatio = dpr;
+  tester.view.display.size = physicalSize;
+}
+
+void _resetDisplay(WidgetTester tester, AdaptiveOrientationLock lock) {
+  lock.detach();
+  tester.view.display.reset();
+}


### PR DESCRIPTION
## Summary
- Lock Android orientation to portrait only on phone-sized displays using the real Flutter display size.
- Leave tablets, foldables, and large-screen or windowed devices unrestricted so Android can use normal portrait and landscape behavior.
- Re-evaluate orientation policy when display metrics change, including crossing the 600dp shortest-side breakpoint.
- Update launch/orientation docs and add solution notes for the new behavior.

## Testing
- `flutter test test/common/util/adaptive_orientation_lock_test.dart`
- Verified phone-sized portrait display applies portrait-only orientations.
- Verified phone-sized landscape display is forced back to portrait.
- Verified tablet landscape display remains unrestricted.
- Verified display metric changes re-apply the policy without re-restricting large screens.