### PR TITLE
Optimize weekly schedule viewport rendering

### DIFF
--- a/docs/solutions/performance/weekly-schedule-stable-viewport-rendering-20260712.md
+++ b/docs/solutions/performance/weekly-schedule-stable-viewport-rendering-20260712.md
@@ -1,0 +1,154 @@
+---
+title: Keep weekly schedule entry trees stable during viewport animation
+date: 2026-07-12
+type: fix
+---
+
+# Summary
+
+Pixel 8 Pro profiling at 120 Hz showed that the first populated weekly Schedule
+swipe missed roughly one quarter of its frames. The horizontal page movement was
+not the main cost. After the swipe committed, the short-to-tall hour-range
+animation rebuilt and laid out the weekly calendar tree on every animation tick.
+
+This change keeps the current PageView interaction and 220 ms hour viewport
+animation, while moving viewport-independent preparation out of animation
+frames. Schedule entry widgets now remain stable and a lightweight layout
+delegate updates only their geometry as the visible hour range interpolates.
+
+# Findings
+
+1. `TweenAnimationBuilder` rebuilt the fixed hour axis, weekly pager, schedule
+   pages, entry cards, and overlay layers for every viewport animation frame.
+2. Entry overlap calculation regrouped and sorted the same week repeatedly even
+   though the schedule content had not changed.
+3. Reconstructing entry cards during the height animation increased main-isolate
+   build pressure on the Pixel 8 Pro.
+4. Updating every cached PageView page from one viewport notifier multiplied the
+   work during the transition.
+5. The first cache implementation reused prepared data by `Schedule` identity,
+   but `Schedule` is mutable. In-place entry list changes could therefore leave
+   stale prepared geometry visible.
+
+# Changes
+
+## Prepared weekly render data
+
+- Added `ScheduleRenderData`, an immutable per-week snapshot containing:
+  - normalized display range,
+  - displayed day count,
+  - entries grouped by day,
+  - precomputed overlap columns.
+- Cached prepared data per week and schedule snapshot instead of recalculating
+  overlap alignment during viewport animation.
+- Limited the page cache to seven weeks.
+
+## Stable viewport animation
+
+- Replaced the broad tween builder with `_AnimatedWeeklyViewport`, which owns a
+  `ValueNotifier<ScheduleViewport>`.
+- Kept the `PageView` subtree stable while the viewport interpolates.
+- Only the currently visible week listens to animation ticks; offscreen weeks
+  use the final target viewport immediately.
+- Preserved:
+  - interactive finger-following PageView behavior,
+  - fixed hour axis,
+  - 220 ms ease-out viewport transition,
+  - loading indicator behavior,
+  - entry taps and detail sheet behavior,
+  - current-week navigation and cached week flow.
+
+## Stable entry widgets
+
+- Entry cards are created once for a prepared week and hosted in
+  `CustomMultiChildLayout`.
+- `_ScheduleEntryLayoutDelegate` recalculates only entry rectangles when the
+  viewport changes.
+- Card contents, labels, and overlap preparation no longer rebuild per animation
+  tick.
+- Grid, past overlay, and current-time indicator continue to update with the
+  viewport because their geometry genuinely changes.
+
+## Cache invalidation hardening
+
+- Cached page data snapshots the exact `ScheduleEntry` identity and order
+  sequence.
+- Cache lookup validates that sequence before reusing prepared data.
+- Add, remove, reorder, or replacement mutations on the same mutable `Schedule`
+  instance invalidate the render snapshot.
+- Render-affecting `ScheduleEntry` fields are immutable, so this avoids hashing
+  all entry content on every widget build while still detecting relevant
+  in-place list mutations.
+- Removed the unused identity-only `ScheduleRenderData.matches` helper.
+
+## Render-path telemetry
+
+- Removed per-page `PerformanceTelemetry.measureSync` work from the PageView
+  item builder. Performance diagnostics remain at coarser operation boundaries
+  rather than creating spans while widgets are being constructed.
+
+# Regression coverage
+
+`weekly_schedule_page_swipe_test.dart` now verifies that:
+
+- the hour viewport still animates instead of jumping;
+- the same PageView widget remains mounted through animation ticks;
+- prepared overlap data is not regenerated during the animation;
+- the same `ScheduleEntryWidget` instances remain mounted through the
+  transition;
+- in-place mutation of the cached `Schedule.entries` list invalidates prepared
+  data and renders the new entry;
+- real drag progress, committed week navigation, chevrons, and current-week
+  controls retain their existing behavior.
+
+The static preparation hook used by the tests is assigned inside the
+cleanup-protected `try` block and reset in `finally`, preventing leakage into
+later tests if setup fails.
+
+# Pixel 8 Pro performance results
+
+Device conditions:
+
+- Pixel 8 Pro (`39181FDJG006DP`)
+- profile mode
+- 120 Hz display
+- Android animation scales at `1.0`
+- deterministic offline Schedule fixture
+- three runs before and three runs after
+
+Median comparison:
+
+| Scenario | Metric | `v2` baseline | Final PR |
+| --- | --- | ---: | ---: |
+| Cold placeholder to populated | frames over 8.33 ms | 9.38% | 9.38% |
+| First populated week swipe | frames over 8.33 ms | 25.00% | 14.58% |
+| First populated week swipe | build frames over 8.33 ms | 18.18% | 4.08% |
+| First populated week swipe | p95 | 16.84 ms | 11.73 ms |
+| First populated week swipe | p99 | 29.83 ms | 25.62 ms |
+| First populated week swipe | consecutive missed frames | 6 | 2 |
+
+The CodeRabbit cache-safety follow-up did not reduce the improvement. Its final
+three-run median was slightly better than the pre-review PR measurement.
+
+# Validation
+
+- `flutter analyze`
+- `flutter test test/schedule`
+  - 154 tests passed after the review follow-up.
+- Three-run Schedule profile comparison on the Pixel 8 Pro.
+- Full loaded diagnostic profile journey on the Pixel 8 Pro.
+  - all Schedule final-state and animation-progression checks passed;
+  - rapid Schedule burst and cached/refresh-required navigation remained valid.
+- Standard profile APK installed and launched for manual testing.
+
+# Remaining observations
+
+- The improvement primarily removes build-side pressure. Some frames still miss
+  the 8.33 ms budget due to raster work from dense cards, grid/overlay painting,
+  and full-page movement.
+- Cold placeholder-to-populated performance is effectively unchanged, which is
+  expected because initial content still has to construct the entry tree once.
+- Further work should use Pixel traces to target raster invalidation and layer
+  reuse without removing shadows, overlays, or animations globally.
+- The broader diagnostic suite still reports the existing Dates loading-to-rows
+  progression issue; that is unrelated to this Schedule-only change.

--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -1,9 +1,6 @@
 import 'dart:async';
 import 'dart:developer' as developer;
-import 'dart:ui' show lerpDouble;
-
 import 'package:dualmate/common/i18n/localizations.dart';
-import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/ui/widgets/error_display.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
@@ -11,7 +8,9 @@ import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:dualmate/schedule/ui/viewmodels/weekly_schedule_view_model.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_widget.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -47,7 +46,9 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
   late DateTime _anchorWeekStart;
   int _currentPageIndex = _initialPageIndex;
   int _weekOpenRequestId = 0;
-  _HourViewport? _lockedViewport;
+  ScheduleViewport? _lockedViewport;
+  final Map<String, _CachedWeekPageData> _weekPageDataCache =
+      <String, _CachedWeekPageData>{};
 
   @override
   void initState() {
@@ -328,25 +329,15 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
           displayedDays,
         );
 
-        return TweenAnimationBuilder<_HourViewport>(
-          tween: _HourViewportTween(end: targetViewport),
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOutCubic,
-          builder: (context, viewport, child) {
-            return Row(
-              children: [
-                SizedBox(
-                  key: const ValueKey<String>('weekly_fixed_hour_axis'),
-                  width: axisMetrics.axisWidth,
-                  child: _FixedHourAxis(
-                    dayLabelsHeight: axisMetrics.dayLabelsHeight,
-                    startHour: viewport.startHour,
-                    endHour: viewport.endHour,
-                    compactPhone: axisMetrics.compactPhone,
-                  ),
-                ),
-                Expanded(child: _buildWeeklyPager(context, model, viewport)),
-              ],
+        return _AnimatedWeeklyViewport(
+          targetViewport: targetViewport,
+          axisMetrics: axisMetrics,
+          pagerBuilder: (context, viewportListenable) {
+            return _buildWeeklyPager(
+              context,
+              model,
+              viewportListenable,
+              targetViewport,
             );
           },
         );
@@ -357,7 +348,8 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
   Widget _buildWeeklyPager(
     BuildContext context,
     WeeklyScheduleViewModel model,
-    _HourViewport viewport,
+    ValueListenable<ScheduleViewport> viewportListenable,
+    ScheduleViewport targetViewport,
   ) {
     return NotificationListener<ScrollNotification>(
       onNotification: (notification) {
@@ -381,31 +373,29 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
         },
         itemBuilder: (context, pageIndex) {
           final weekStart = _weekStartForPage(pageIndex);
-          return PerformanceTelemetry.instance.measureSync(
-            'schedule.list.build',
-            args: {'weekOffset': pageIndex - _currentPageIndex},
-            action: (task) {
-              final pageData = _buildPageData(weekStart, model);
-              task.setData('entryCount', pageData.schedule.entries.length);
+          final pageData = _buildPageData(weekStart, model);
+          final animatesViewport = pageIndex == _currentPageIndex;
+          final pageViewport = animatesViewport
+              ? viewportListenable.value
+              : targetViewport;
 
-              return RepaintBoundary(
-                key: ValueKey<String>(
-                  'week_page_${weekStart.toIso8601String()}',
-                ),
-                child: ScheduleWidget(
-                  schedule: pageData.schedule,
-                  displayStart: pageData.displayStart,
-                  displayEnd: pageData.displayEnd,
-                  onScheduleEntryTap: (entry) {
-                    _onScheduleEntryTap(context, entry);
-                  },
-                  now: model.now,
-                  displayStartHour: viewport.startHour,
-                  displayEndHour: viewport.endHour,
-                  showTimeLabels: false,
-                ),
-              );
-            },
+          return RepaintBoundary(
+            key: ValueKey<String>('week_page_${weekStart.toIso8601String()}'),
+            child: ScheduleWidget(
+              schedule: pageData.schedule,
+              displayStart: pageData.displayStart,
+              displayEnd: pageData.displayEnd,
+              onScheduleEntryTap: (entry) {
+                _onScheduleEntryTap(context, entry);
+              },
+              now: model.now,
+              displayStartHour: pageViewport.startHour,
+              displayEndHour: pageViewport.endHour,
+              showTimeLabels: false,
+              preparedData: pageData.renderData,
+              viewportListenable: animatesViewport ? viewportListenable : null,
+              targetViewport: targetViewport,
+            ),
           );
         },
       ),
@@ -475,17 +465,42 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
   ) {
     final weekEnd = toNextWeek(weekStart);
     final cachedSchedule = model.getCachedWeek(weekStart, weekEnd);
+    final cacheKey = weekStart.toIso8601String();
+    final cachedPage = _weekPageDataCache[cacheKey];
+    if (cachedPage != null &&
+        identical(cachedPage.sourceSchedule, cachedSchedule)) {
+      return cachedPage.pageData;
+    }
 
+    final schedule = cachedSchedule ?? Schedule();
     final displayRange = WeeklyScheduleViewModel.resolveWeeklyDisplayRange(
       weekStart,
       cachedSchedule,
     );
-
-    return _WeekPageData(
-      schedule: cachedSchedule ?? Schedule(),
+    final pageData = _WeekPageData(
+      schedule: schedule,
       displayStart: displayRange.start,
       displayEnd: displayRange.end,
+      renderData: ScheduleRenderData.prepare(
+        schedule: schedule,
+        displayStart: displayRange.start,
+        displayEnd: displayRange.end,
+      ),
     );
+    _weekPageDataCache[cacheKey] = _CachedWeekPageData(
+      sourceSchedule: cachedSchedule,
+      pageData: pageData,
+    );
+    if (_weekPageDataCache.length > 7) {
+      final oldestKey = _weekPageDataCache.keys.firstWhere(
+        (key) => key != cacheKey,
+        orElse: () => cacheKey,
+      );
+      if (oldestKey != cacheKey) {
+        _weekPageDataCache.remove(oldestKey);
+      }
+    }
+    return pageData;
   }
 
   void _ensurePagerInitialized() {
@@ -514,13 +529,13 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
     return toStartOfDay(toDayOfWeek(date, DateTime.monday));
   }
 
-  _HourViewport _resolveTargetViewport(WeeklyScheduleViewModel model) {
+  ScheduleViewport _resolveTargetViewport(WeeklyScheduleViewModel model) {
     final startHour = (model.displayStartHour > 0 ? model.displayStartHour : 7)
         .toDouble();
     final endHourRaw = (model.displayEndHour > 0 ? model.displayEndHour : 17)
         .toDouble();
     final endHour = endHourRaw <= startHour + 1 ? startHour + 1 : endHourRaw;
-    return _HourViewport(startHour: startHour, endHour: endHour);
+    return ScheduleViewport(startHour: startHour, endHour: endHour);
   }
 
   int _resolveDisplayedDays(WeeklyScheduleViewModel model) {
@@ -764,30 +779,24 @@ class _WeekPageData {
   final Schedule schedule;
   final DateTime displayStart;
   final DateTime displayEnd;
+  final ScheduleRenderData renderData;
 
   _WeekPageData({
     required this.schedule,
     required this.displayStart,
     required this.displayEnd,
+    required this.renderData,
   });
 }
 
-class _HourViewport {
-  final double startHour;
-  final double endHour;
+class _CachedWeekPageData {
+  final Schedule? sourceSchedule;
+  final _WeekPageData pageData;
 
-  const _HourViewport({required this.startHour, required this.endHour});
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        other is _HourViewport &&
-            other.startHour == startHour &&
-            other.endHour == endHour;
-  }
-
-  @override
-  int get hashCode => Object.hash(startHour, endHour);
+  const _CachedWeekPageData({
+    required this.sourceSchedule,
+    required this.pageData,
+  });
 }
 
 class _TopLoadingIndicator extends StatefulWidget {
@@ -913,22 +922,100 @@ class _TopLoadingIndicatorState extends State<_TopLoadingIndicator> {
   }
 }
 
-class _HourViewportTween extends Tween<_HourViewport> {
-  _HourViewportTween({_HourViewport? begin, required _HourViewport end})
-    : super(begin: begin, end: end);
+typedef _WeeklyPagerBuilder =
+    Widget Function(
+      BuildContext context,
+      ValueListenable<ScheduleViewport> viewportListenable,
+    );
+
+class _AnimatedWeeklyViewport extends StatefulWidget {
+  final ScheduleViewport targetViewport;
+  final _AxisLayoutMetrics axisMetrics;
+  final _WeeklyPagerBuilder pagerBuilder;
+
+  const _AnimatedWeeklyViewport({
+    required this.targetViewport,
+    required this.axisMetrics,
+    required this.pagerBuilder,
+  });
 
   @override
-  _HourViewport lerp(double t) {
-    final beginValue = begin ?? end!;
-    final endValue = end!;
+  State<_AnimatedWeeklyViewport> createState() =>
+      _AnimatedWeeklyViewportState();
+}
 
-    return _HourViewport(
-      startHour:
-          lerpDouble(beginValue.startHour, endValue.startHour, t) ??
-          endValue.startHour,
-      endHour:
-          lerpDouble(beginValue.endHour, endValue.endHour, t) ??
-          endValue.endHour,
+class _AnimatedWeeklyViewportState extends State<_AnimatedWeeklyViewport>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final ValueNotifier<ScheduleViewport> _viewport;
+  late ScheduleViewport _animationStart;
+  late ScheduleViewport _animationTarget;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationStart = widget.targetViewport;
+    _animationTarget = widget.targetViewport;
+    _viewport = ValueNotifier<ScheduleViewport>(widget.targetViewport);
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 220),
+    )..addListener(_updateViewport);
+  }
+
+  @override
+  void didUpdateWidget(covariant _AnimatedWeeklyViewport oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.targetViewport == _animationTarget) {
+      return;
+    }
+    _animationStart = _viewport.value;
+    _animationTarget = widget.targetViewport;
+    _controller.forward(from: 0);
+  }
+
+  void _updateViewport() {
+    final progress = Curves.easeOutCubic.transform(_controller.value);
+    final next = ScheduleViewport.lerp(
+      _animationStart,
+      _animationTarget,
+      progress,
+    );
+    if (_viewport.value != next) {
+      _viewport.value = next;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeListener(_updateViewport)
+      ..dispose();
+    _viewport.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          key: const ValueKey<String>('weekly_fixed_hour_axis'),
+          width: widget.axisMetrics.axisWidth,
+          child: ValueListenableBuilder<ScheduleViewport>(
+            valueListenable: _viewport,
+            builder: (context, viewport, _) {
+              return _FixedHourAxis(
+                dayLabelsHeight: widget.axisMetrics.dayLabelsHeight,
+                startHour: viewport.startHour,
+                endHour: viewport.endHour,
+                compactPhone: widget.axisMetrics.compactPhone,
+              );
+            },
+          ),
+        ),
+        Expanded(child: widget.pagerBuilder(context, _viewport)),
+      ],
     );
   }
 }

--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -467,8 +467,7 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
     final cachedSchedule = model.getCachedWeek(weekStart, weekEnd);
     final cacheKey = weekStart.toIso8601String();
     final cachedPage = _weekPageDataCache[cacheKey];
-    if (cachedPage != null &&
-        identical(cachedPage.sourceSchedule, cachedSchedule)) {
+    if (cachedPage != null && cachedPage.matches(cachedSchedule)) {
       return cachedPage.pageData;
     }
 
@@ -791,12 +790,28 @@ class _WeekPageData {
 
 class _CachedWeekPageData {
   final Schedule? sourceSchedule;
+  final List<ScheduleEntry> sourceEntries;
   final _WeekPageData pageData;
 
-  const _CachedWeekPageData({
-    required this.sourceSchedule,
-    required this.pageData,
-  });
+  _CachedWeekPageData({required this.sourceSchedule, required this.pageData})
+    : sourceEntries = List<ScheduleEntry>.unmodifiable(
+        sourceSchedule?.entries ?? const <ScheduleEntry>[],
+      );
+
+  bool matches(Schedule? schedule) {
+    if (!identical(sourceSchedule, schedule)) return false;
+
+    final currentEntries = schedule?.entries ?? const <ScheduleEntry>[];
+    if (sourceEntries.length != currentEntries.length) return false;
+
+    // ScheduleEntry's render-affecting fields are immutable, so identity and
+    // order are sufficient to detect every in-place list mutation that can
+    // change the prepared layout without hashing entry content on each build.
+    for (var index = 0; index < currentEntries.length; index++) {
+      if (!identical(sourceEntries[index], currentEntries[index])) return false;
+    }
+    return true;
+  }
 }
 
 class _TopLoadingIndicator extends StatefulWidget {

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart
@@ -1,0 +1,131 @@
+import 'package:dualmate/common/util/date_utils.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_entry_alignment.dart';
+import 'package:flutter/foundation.dart';
+
+/// Immutable, viewport-independent layout data for one rendered schedule week.
+///
+/// Preparing overlap columns requires grouping and sorting every schedule entry.
+/// Keeping that work separate from viewport geometry lets hour-range animations
+/// reuse the same result for every frame.
+class ScheduleRenderData {
+  final Schedule schedule;
+  final DateTime displayStart;
+  final DateTime displayEnd;
+  final int displayedDays;
+  final List<List<PreparedScheduleEntry>> entriesByDay;
+
+  @visibleForTesting
+  static VoidCallback? debugOnPrepare;
+
+  ScheduleRenderData._({
+    required this.schedule,
+    required this.displayStart,
+    required this.displayEnd,
+    required this.displayedDays,
+    required this.entriesByDay,
+  });
+
+  factory ScheduleRenderData.prepare({
+    required Schedule schedule,
+    required DateTime displayStart,
+    required DateTime displayEnd,
+  }) {
+    assert(() {
+      debugOnPrepare?.call();
+      return true;
+    }());
+
+    final normalizedStart = toStartOfDay(displayStart);
+    final normalizedEnd = toStartOfDay(displayEnd);
+    var days = normalizedEnd.difference(normalizedStart).inDays + 1;
+    days = days.clamp(5, 7);
+
+    final entriesByDay = <List<PreparedScheduleEntry>>[];
+    var dayStart = normalizedStart;
+    for (var dayIndex = 0; dayIndex < days; dayIndex++) {
+      final dayEnd = tomorrow(dayStart);
+      final entries = schedule.entries
+          .where((entry) {
+            return entry.start.isBefore(dayEnd) && entry.end.isAfter(dayStart);
+          })
+          .toList(growable: false);
+      final aligned = ScheduleEntryAlignmentAlgorithm().layoutEntries(entries);
+      entriesByDay.add(
+        List<PreparedScheduleEntry>.unmodifiable(
+          aligned.map(
+            (value) => PreparedScheduleEntry(
+              entry: value.entry,
+              leftColumn: value.leftColumn,
+              rightColumn: value.rightColumn,
+            ),
+          ),
+        ),
+      );
+      dayStart = dayEnd;
+    }
+
+    return ScheduleRenderData._(
+      schedule: schedule,
+      displayStart: displayStart,
+      displayEnd: displayEnd,
+      displayedDays: days,
+      entriesByDay: List<List<PreparedScheduleEntry>>.unmodifiable(
+        entriesByDay,
+      ),
+    );
+  }
+
+  bool matches({
+    required Schedule schedule,
+    required DateTime displayStart,
+    required DateTime displayEnd,
+  }) {
+    return identical(this.schedule, schedule) &&
+        this.displayStart == displayStart &&
+        this.displayEnd == displayEnd;
+  }
+}
+
+class PreparedScheduleEntry {
+  final ScheduleEntry entry;
+  final double leftColumn;
+  final double rightColumn;
+
+  const PreparedScheduleEntry({
+    required this.entry,
+    required this.leftColumn,
+    required this.rightColumn,
+  });
+}
+
+@immutable
+class ScheduleViewport {
+  final double startHour;
+  final double endHour;
+
+  const ScheduleViewport({required this.startHour, required this.endHour});
+
+  static ScheduleViewport lerp(
+    ScheduleViewport begin,
+    ScheduleViewport end,
+    double t,
+  ) {
+    return ScheduleViewport(
+      startHour: begin.startHour + ((end.startHour - begin.startHour) * t),
+      endHour: begin.endHour + ((end.endHour - begin.endHour) * t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is ScheduleViewport &&
+            other.startHour == startHour &&
+            other.endHour == endHour;
+  }
+
+  @override
+  int get hashCode => Object.hash(startHour, endHour);
+}

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart
@@ -76,16 +76,6 @@ class ScheduleRenderData {
       ),
     );
   }
-
-  bool matches({
-    required Schedule schedule,
-    required DateTime displayStart,
-    required DateTime displayEnd,
-  }) {
-    return identical(this.schedule, schedule) &&
-        this.displayStart == displayStart &&
-        this.displayEnd == displayEnd;
-  }
 }
 
 class PreparedScheduleEntry {

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart
@@ -3,12 +3,12 @@ import 'package:dualmate/common/ui/colors.dart';
 import 'package:dualmate/common/ui/text_styles.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/schedule/model/schedule.dart';
-import 'package:dualmate/schedule/model/schedule_entry.dart';
-import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_entry_alignment.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_grid.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_past_overlay.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -31,6 +31,9 @@ class ScheduleWidget extends StatelessWidget {
   final double displayEndHour;
   final ScheduleEntryTapCallback onScheduleEntryTap;
   final bool showTimeLabels;
+  final ScheduleRenderData? preparedData;
+  final ValueListenable<ScheduleViewport>? viewportListenable;
+  final ScheduleViewport? targetViewport;
 
   const ScheduleWidget({
     Key? key,
@@ -42,16 +45,54 @@ class ScheduleWidget extends StatelessWidget {
     required this.displayStartHour,
     required this.displayEndHour,
     this.showTimeLabels = true,
+    this.preparedData,
+    this.viewportListenable,
+    this.targetViewport,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        return buildWithSize(
+        final viewport = viewportListenable;
+        final width = constraints.biggest.width;
+        final height = constraints.biggest.height;
+        if (viewport == null || showTimeLabels) {
+          return buildWithSize(
+            context,
+            width,
+            height,
+            ScheduleViewport(
+              startHour: displayStartHour,
+              endHour: displayEndHour,
+            ),
+          );
+        }
+
+        final renderData =
+            preparedData ??
+            ScheduleRenderData.prepare(
+              schedule: schedule,
+              displayStart: displayStart,
+              displayEnd: displayEnd,
+            );
+        final days = renderData.displayedDays;
+        final layoutProfile = _resolveLayoutProfile(width, days);
+        final target =
+            targetViewport ??
+            ScheduleViewport(
+              startHour: displayStartHour,
+              endHour: displayEndHour,
+            );
+
+        return _buildAnimatedWithSize(
           context,
-          constraints.biggest.width,
-          constraints.biggest.height,
+          width,
+          height,
+          renderData,
+          layoutProfile,
+          viewport,
+          target,
         );
       },
     );
@@ -69,19 +110,153 @@ class ScheduleWidget extends StatelessWidget {
         width <= _compactWidthThreshold;
   }
 
-  Widget buildWithSize(BuildContext context, double width, double height) {
-    var days = calculateDisplayedDays();
+  Widget _buildAnimatedWithSize(
+    BuildContext context,
+    double width,
+    double height,
+    ScheduleRenderData renderData,
+    _ScheduleWidgetLayoutProfile layoutProfile,
+    ValueListenable<ScheduleViewport> viewport,
+    ScheduleViewport target,
+  ) {
+    final days = renderData.displayedDays;
+    final dayLabelsHeight = layoutProfile.dayLabelsHeight;
+    const timeLabelsWidth = 0.0;
+    final targetVisibleHours = (target.endHour - target.startHour).clamp(
+      1.0,
+      24.0,
+    );
+    final targetHourHeight = (height - dayLabelsHeight) / targetVisibleHours;
+    final targetMinuteHeight = targetHourHeight / 60;
+
+    final staticLayers = Stack(
+      fit: StackFit.expand,
+      children: <Widget>[
+        Padding(
+          padding: EdgeInsets.fromLTRB(timeLabelsWidth, dayLabelsHeight, 0, 0),
+          child: _AnimatedScheduleEntryLayer(
+            renderData: renderData,
+            layoutProfile: layoutProfile,
+            viewport: viewport,
+            targetViewport: target,
+            onScheduleEntryTap: onScheduleEntryTap,
+          ),
+        ),
+        Stack(
+          children: buildLabelWidgets(
+            context,
+            targetHourHeight,
+            width / days,
+            dayLabelsHeight,
+            timeLabelsWidth,
+            targetHourHeight,
+            targetMinuteHeight,
+            layoutProfile,
+            target.startHour,
+            target.endHour,
+          ),
+        ),
+      ],
+    );
+
+    return ValueListenableBuilder<ScheduleViewport>(
+      valueListenable: viewport,
+      child: staticLayers,
+      builder: (context, currentViewport, child) {
+        final visibleHours =
+            (currentViewport.endHour - currentViewport.startHour).clamp(
+              1.0,
+              24.0,
+            );
+        final hourHeight = (height - dayLabelsHeight) / visibleHours;
+        final minuteHeight = hourHeight / 60;
+        final currentTimeIndicatorGeometry =
+            _resolveCurrentTimeIndicatorGeometry(
+              days,
+              minuteHeight,
+              currentViewport.startHour,
+              currentViewport.endHour,
+            );
+
+        return Stack(
+          fit: StackFit.expand,
+          children: <Widget>[
+            ScheduleGrid(
+              currentViewport.startHour,
+              currentViewport.endHour,
+              timeLabelsWidth,
+              dayLabelsHeight,
+              days,
+              colorScheduleGridGridLines(context),
+            ),
+            child!,
+            Padding(
+              padding: EdgeInsets.fromLTRB(
+                timeLabelsWidth,
+                dayLabelsHeight,
+                0,
+                0,
+              ),
+              child: SchedulePastOverlay(
+                currentViewport.startHour,
+                currentViewport.endHour,
+                colorScheduleInPastOverlay(context),
+                displayStart,
+                displayEnd,
+                now,
+                days,
+              ),
+            ),
+            if (currentTimeIndicatorGeometry != null)
+              Padding(
+                padding: EdgeInsets.fromLTRB(
+                  timeLabelsWidth,
+                  dayLabelsHeight,
+                  0,
+                  0,
+                ),
+                child: ScheduleCurrentTimeIndicator(
+                  dayIndex: currentTimeIndicatorGeometry.dayIndex,
+                  columns: days,
+                  yOffset: currentTimeIndicatorGeometry.yOffset,
+                  color: colorCurrentTimeIndicator(context),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget buildWithSize(
+    BuildContext context,
+    double width,
+    double height,
+    ScheduleViewport viewport,
+  ) {
+    final renderData =
+        preparedData ??
+        ScheduleRenderData.prepare(
+          schedule: schedule,
+          displayStart: displayStart,
+          displayEnd: displayEnd,
+        );
+    var days = renderData.displayedDays;
     final layoutProfile = _resolveLayoutProfile(width, days);
 
     var dayLabelsHeight = layoutProfile.dayLabelsHeight;
     var timeLabelsWidth = showTimeLabels ? layoutProfile.timeLabelsWidth : 0.0;
 
+    final displayStartHour = viewport.startHour;
+    final displayEndHour = viewport.endHour;
     final visibleHours = (displayEndHour - displayStartHour).clamp(1.0, 24.0);
     var hourHeight = (height - dayLabelsHeight) / visibleHours;
     var minuteHeight = hourHeight / 60;
     final currentTimeIndicatorGeometry = _resolveCurrentTimeIndicatorGeometry(
       days,
       minuteHeight,
+      displayStartHour,
+      displayEndHour,
     );
 
     var labelWidgets = buildLabelWidgets(
@@ -93,16 +268,20 @@ class ScheduleWidget extends StatelessWidget {
       hourHeight,
       minuteHeight,
       layoutProfile,
+      displayStartHour,
+      displayEndHour,
     );
 
     var entryWidgets = <Widget>[];
 
     entryWidgets = buildEntryWidgets(
+      renderData,
       hourHeight,
       minuteHeight,
       width - timeLabelsWidth,
       days,
       layoutProfile,
+      displayStartHour,
     );
 
     return Stack(
@@ -155,6 +334,8 @@ class ScheduleWidget extends StatelessWidget {
   _CurrentTimeIndicatorGeometry? _resolveCurrentTimeIndicatorGeometry(
     int days,
     double minuteHeight,
+    double displayStartHour,
+    double displayEndHour,
   ) {
     final visibleStartDay = toStartOfDay(displayStart);
     final visibleEndDay = toStartOfDay(displayEnd);
@@ -203,6 +384,8 @@ class ScheduleWidget extends StatelessWidget {
     double hourHeight,
     double minuteHeight,
     _ScheduleWidgetLayoutProfile layoutProfile,
+    double displayStartHour,
+    double displayEndHour,
   ) {
     var labelWidgets = <Widget>[];
     final locale = L.of(context).locale;
@@ -330,19 +513,20 @@ class ScheduleWidget extends StatelessWidget {
   }
 
   List<Widget> buildEntryWidgets(
+    ScheduleRenderData renderData,
     double hourHeight,
     double minuteHeight,
     double width,
     int columns,
     _ScheduleWidgetLayoutProfile layoutProfile,
+    double displayStartHour,
   ) {
-    if (schedule.entries.isEmpty) return <Widget>[];
+    if (renderData.schedule.entries.isEmpty) return <Widget>[];
 
     var entryWidgets = <Widget>[];
 
     var columnWidth = width / columns;
-    final entriesByColumn = _buildEntriesByColumn(columns);
-    var columnStartDate = toStartOfDay(displayStart);
+    final entriesByColumn = renderData.entriesByDay;
 
     for (int i = 0; i < columns; i++) {
       var xPosition = columnWidth * i;
@@ -354,38 +538,14 @@ class ScheduleWidget extends StatelessWidget {
           hourHeight,
           minuteHeight,
           xPosition,
-          entriesByColumn[columnStartDate] ?? const <ScheduleEntry>[],
+          entriesByColumn[i],
           layoutProfile,
+          displayStartHour,
         ),
       );
-
-      columnStartDate = tomorrow(columnStartDate);
     }
 
     return entryWidgets;
-  }
-
-  Map<DateTime, List<ScheduleEntry>> _buildEntriesByColumn(int columns) {
-    final result = <DateTime, List<ScheduleEntry>>{};
-    final columnStarts = <DateTime>[];
-    var cursor = toStartOfDay(displayStart);
-
-    for (var i = 0; i < columns; i++) {
-      columnStarts.add(cursor);
-      result[cursor] = <ScheduleEntry>[];
-      cursor = tomorrow(cursor);
-    }
-
-    for (final entry in schedule.entries) {
-      for (final dayStart in columnStarts) {
-        final dayEnd = tomorrow(dayStart);
-        if (entry.start.isBefore(dayEnd) && entry.end.isAfter(dayStart)) {
-          result[dayStart]!.add(entry);
-        }
-      }
-    }
-
-    return result;
   }
 
   List<Widget> buildEntryWidgetsForColumn(
@@ -393,16 +553,13 @@ class ScheduleWidget extends StatelessWidget {
     double hourHeight,
     double minuteHeight,
     double xPosition,
-    List<ScheduleEntry> entries,
+    List<PreparedScheduleEntry> entries,
     _ScheduleWidgetLayoutProfile layoutProfile,
+    double displayStartHour,
   ) {
     var entryWidgets = <Widget>[];
 
-    var laidOutEntries = ScheduleEntryAlignmentAlgorithm().layoutEntries(
-      entries,
-    );
-
-    for (var value in laidOutEntries) {
+    for (var value in entries) {
       var entry = value.entry;
 
       var rawYStart =
@@ -488,6 +645,176 @@ class ScheduleWidget extends StatelessWidget {
       dayBoundaryInset: 1.0,
     );
   }
+}
+
+class _AnimatedScheduleEntryLayer extends StatelessWidget {
+  final ScheduleRenderData renderData;
+  final _ScheduleWidgetLayoutProfile layoutProfile;
+  final ValueListenable<ScheduleViewport> viewport;
+  final ScheduleViewport targetViewport;
+  final ScheduleEntryTapCallback onScheduleEntryTap;
+
+  const _AnimatedScheduleEntryLayer({
+    required this.renderData,
+    required this.layoutProfile,
+    required this.viewport,
+    required this.targetViewport,
+    required this.onScheduleEntryTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final slots = <_PreparedEntrySlot>[];
+    for (
+      var dayIndex = 0;
+      dayIndex < renderData.entriesByDay.length;
+      dayIndex++
+    ) {
+      for (final entry in renderData.entriesByDay[dayIndex]) {
+        slots.add(_PreparedEntrySlot(dayIndex: dayIndex, entry: entry));
+      }
+    }
+    if (slots.isEmpty) return const SizedBox.expand();
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = constraints.biggest;
+        return ClipRect(
+          child: CustomMultiChildLayout(
+            delegate: _ScheduleEntryLayoutDelegate(
+              slots: slots,
+              columns: renderData.displayedDays,
+              layoutProfile: layoutProfile,
+              viewport: viewport,
+            ),
+            children: <Widget>[
+              for (var index = 0; index < slots.length; index++)
+                LayoutId(
+                  id: index,
+                  child: _buildEntry(
+                    slots[index],
+                    _ScheduleEntryLayoutDelegate.resolveRect(
+                      size: size,
+                      slot: slots[index],
+                      columns: renderData.displayedDays,
+                      layoutProfile: layoutProfile,
+                      viewport: targetViewport,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildEntry(_PreparedEntrySlot slot, Rect targetRect) {
+    return ScheduleEntryWidget(
+      scheduleEntry: slot.entry.entry,
+      onScheduleEntryTap: onScheduleEntryTap,
+      renderedWidth: targetRect.width,
+      renderedHeight: targetRect.height,
+    );
+  }
+}
+
+class _ScheduleEntryLayoutDelegate extends MultiChildLayoutDelegate {
+  final List<_PreparedEntrySlot> slots;
+  final int columns;
+  final _ScheduleWidgetLayoutProfile layoutProfile;
+  final ValueListenable<ScheduleViewport> viewport;
+
+  _ScheduleEntryLayoutDelegate({
+    required this.slots,
+    required this.columns,
+    required this.layoutProfile,
+    required this.viewport,
+  }) : super(relayout: viewport);
+
+  @override
+  void performLayout(Size size) {
+    final currentViewport = viewport.value;
+    for (var index = 0; index < slots.length; index++) {
+      final rect = resolveRect(
+        size: size,
+        slot: slots[index],
+        columns: columns,
+        layoutProfile: layoutProfile,
+        viewport: currentViewport,
+      );
+      layoutChild(index, BoxConstraints.tight(rect.size));
+      positionChild(index, rect.topLeft);
+    }
+  }
+
+  static Rect resolveRect({
+    required Size size,
+    required _PreparedEntrySlot slot,
+    required int columns,
+    required _ScheduleWidgetLayoutProfile layoutProfile,
+    required ScheduleViewport viewport,
+  }) {
+    final columnWidth = size.width / columns;
+    final visibleHours = (viewport.endHour - viewport.startHour).clamp(
+      1.0,
+      24.0,
+    );
+    final hourHeight = size.height / visibleHours;
+    final minuteHeight = hourHeight / 60;
+    final entry = slot.entry.entry;
+
+    final rawYStart =
+        hourHeight * (entry.start.hour - viewport.startHour) +
+        minuteHeight * entry.start.minute;
+    final rawYEnd =
+        hourHeight * (entry.end.hour - viewport.startHour) +
+        minuteHeight * entry.end.minute;
+    final rawEntryLeft = columnWidth * slot.entry.leftColumn;
+    final rawEntryWidth =
+        columnWidth * (slot.entry.rightColumn - slot.entry.leftColumn);
+
+    final compactMinInset = layoutProfile.compactPhone ? 0.1 : 1.0;
+    final verticalInset =
+        rawYEnd - rawYStart > (layoutProfile.eventVerticalGap + 6)
+        ? layoutProfile.eventVerticalGap / 2
+        : compactMinInset;
+    final spansMultipleOverlapColumns =
+        (slot.entry.rightColumn - slot.entry.leftColumn) <
+        ScheduleWidget._fullColumnThreshold;
+    final overlapMinInset = layoutProfile.compactPhone ? 0.25 : 1.0;
+    final horizontalInset = spansMultipleOverlapColumns
+        ? (rawEntryWidth > (layoutProfile.overlapColumnGap + 10)
+              ? layoutProfile.overlapColumnGap / 2
+              : overlapMinInset)
+        : layoutProfile.dayBoundaryInset;
+
+    final top = rawYStart + verticalInset;
+    final height = (rawYEnd - rawYStart - (verticalInset * 2))
+        .clamp(ScheduleWidget._minimumEventExtent, double.infinity)
+        .toDouble();
+    final left = (columnWidth * slot.dayIndex) + rawEntryLeft + horizontalInset;
+    final width = (rawEntryWidth - (horizontalInset * 2))
+        .clamp(ScheduleWidget._minimumEventExtent, double.infinity)
+        .toDouble();
+
+    return Rect.fromLTWH(left, top, width, height);
+  }
+
+  @override
+  bool shouldRelayout(covariant _ScheduleEntryLayoutDelegate oldDelegate) {
+    return !identical(slots, oldDelegate.slots) ||
+        columns != oldDelegate.columns ||
+        layoutProfile != oldDelegate.layoutProfile ||
+        !identical(viewport, oldDelegate.viewport);
+  }
+}
+
+class _PreparedEntrySlot {
+  final int dayIndex;
+  final PreparedScheduleEntry entry;
+
+  const _PreparedEntrySlot({required this.dayIndex, required this.entry});
 }
 
 class _ScheduleWidgetLayoutProfile {

--- a/test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
+++ b/test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
@@ -85,10 +85,6 @@ void main() {
     tester,
   ) async {
     var preparationCount = 0;
-    ScheduleRenderData.debugOnPrepare = () {
-      preparationCount += 1;
-    };
-
     final viewModel = _buildViewModel(
       now: DateTime(2026, 2, 10, 10),
       entries: <ScheduleEntry>[
@@ -98,6 +94,9 @@ void main() {
     );
 
     try {
+      ScheduleRenderData.debugOnPrepare = () {
+        preparationCount += 1;
+      };
       await viewModel.updateSchedule(
         DateTime(2026, 2, 9),
         DateTime(2026, 2, 16),
@@ -143,6 +142,46 @@ void main() {
 
       await tester.pumpAndSettle();
       expect(preparationCount, preparationsAtAnimationStart);
+    } finally {
+      ScheduleRenderData.debugOnPrepare = null;
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      viewModel.dispose();
+    }
+  });
+
+  testWidgets('in-place schedule mutations invalidate prepared render data', (
+    tester,
+  ) async {
+    var preparationCount = 0;
+    final viewModel = _buildViewModel(
+      now: DateTime(2026, 2, 10, 10),
+      entries: <ScheduleEntry>[_entry(DateTime(2026, 2, 9), 'CURRENT_WEEK')],
+    );
+
+    try {
+      ScheduleRenderData.debugOnPrepare = () {
+        preparationCount += 1;
+      };
+      await viewModel.updateSchedule(
+        DateTime(2026, 2, 9),
+        DateTime(2026, 2, 16),
+        force: true,
+      );
+      await tester.pumpWidget(_wrapWithApp(viewModel));
+      await tester.pumpAndSettle();
+
+      final preparationsBeforeMutation = preparationCount;
+      expect(find.text('MUTATED_WEEK'), findsNothing);
+
+      viewModel.weekSchedule!.entries.add(
+        _entry(DateTime(2026, 2, 10), 'MUTATED_WEEK'),
+      );
+      viewModel.notifyListeners('weekSchedule');
+      await tester.pumpAndSettle();
+
+      expect(find.text('MUTATED_WEEK'), findsOneWidget);
+      expect(preparationCount, greaterThan(preparationsBeforeMutation));
     } finally {
       ScheduleRenderData.debugOnPrepare = null;
       await tester.pumpWidget(const SizedBox.shrink());

--- a/test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
+++ b/test/schedule/ui/weeklyschedule/weekly_schedule_page_swipe_test.dart
@@ -8,6 +8,8 @@ import 'package:dualmate/schedule/model/schedule_query_result.dart';
 import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:dualmate/schedule/ui/viewmodels/weekly_schedule_view_model.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/weekly_schedule_page.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -77,6 +79,76 @@ void main() {
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
     viewModel.dispose();
+  });
+
+  testWidgets('viewport animation reuses pager and prepared overlap layout', (
+    tester,
+  ) async {
+    var preparationCount = 0;
+    ScheduleRenderData.debugOnPrepare = () {
+      preparationCount += 1;
+    };
+
+    final viewModel = _buildViewModel(
+      now: DateTime(2026, 2, 10, 10),
+      entries: <ScheduleEntry>[
+        _entry(DateTime(2026, 2, 9), 'CURRENT_WEEK'),
+        _entry(DateTime(2026, 2, 16), 'NEXT_WEEK'),
+      ],
+    );
+
+    try {
+      await viewModel.updateSchedule(
+        DateTime(2026, 2, 9),
+        DateTime(2026, 2, 16),
+        force: true,
+      );
+      await tester.pumpWidget(_wrapWithApp(viewModel));
+      await tester.pump();
+
+      viewModel.displayEndHour = 21;
+      viewModel.notifyListeners('weekSchedule');
+      await tester.pump();
+
+      final pagerFinder = find.byKey(
+        const ValueKey<String>('weekly_schedule_page_view'),
+      );
+      final pagerAtAnimationStart = tester.widget<PageView>(pagerFinder);
+      final entryAtAnimationStart = tester.widget<ScheduleEntryWidget>(
+        find.byType(ScheduleEntryWidget).first,
+      );
+      final preparationsAtAnimationStart = preparationCount;
+      expect(preparationsAtAnimationStart, greaterThan(0));
+
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 35));
+        expect(
+          identical(
+            tester.widget<PageView>(pagerFinder),
+            pagerAtAnimationStart,
+          ),
+          isTrue,
+        );
+        expect(
+          identical(
+            tester.widget<ScheduleEntryWidget>(
+              find.byType(ScheduleEntryWidget).first,
+            ),
+            entryAtAnimationStart,
+          ),
+          isTrue,
+        );
+        expect(preparationCount, preparationsAtAnimationStart);
+      }
+
+      await tester.pumpAndSettle();
+      expect(preparationCount, preparationsAtAnimationStart);
+    } finally {
+      ScheduleRenderData.debugOnPrepare = null;
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      viewModel.dispose();
+    }
   });
 
   testWidgets('dragging weekly pager updates page progress before release', (


### PR DESCRIPTION
## Summary

- cache viewport-independent weekly render data and overlap alignment per schedule snapshot
- animate hour-range geometry without rebuilding the PageView or schedule entry widgets on every frame
- relayout stable entry subtrees through a lightweight layout delegate
- update only the visible week during viewport animation while keeping offscreen weeks on the final viewport
- add regression coverage proving the pager, prepared alignment, and entry widgets are reused during animation

## Pixel 8 Pro profile results

Three profile-mode runs on the connected Pixel 8 Pro, compared with three clean `v2` runs:

| Scenario | Metric | `v2` median | PR median |
| --- | --- | ---: | ---: |
| Cold placeholder → populated | frames > 8.33 ms | 9.38% | 9.09% |
| First populated week swipe | frames > 8.33 ms | 25.00% | 15.56% |
| First populated week swipe | build frames > 8.33 ms | 18.18% | 9.09% |
| First populated week swipe | p99 | 29.83 ms | 27.18 ms |
| First populated week swipe | consecutive missed frames | 6 | 2 |

The broader diagnostic journey also completed all Schedule animation/progression checks, including short-to-tall viewport animation, cached navigation, database-cached navigation, refresh-required navigation, and four rapid back swipes.

## Validation

- `flutter analyze` — clean
- `flutter test test/schedule` — 153 tests passed
- focused weekly Schedule tests — passed
- three-run profile comparison on Pixel 8 Pro — passed
- full diagnostic profile journey on Pixel 8 Pro — passed for all Schedule checks

The diagnostic suite still reports the existing `dates_loading_to_rows` progression issue, unrelated to this Schedule-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smoother animated transitions when changing the visible hours in the weekly schedule.
  - Schedule entries now maintain stable positioning and layout while the viewport animates.

- **Performance Improvements**
  - Improved weekly schedule rendering by reusing prepared layout information.
  - Reduced unnecessary recalculation and rebuilding when navigating between weeks.

- **Bug Fixes**
  - Improved consistency of overlapping event placement during schedule navigation and viewport changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Documentation

- [`docs/solutions/performance/weekly-schedule-stable-viewport-rendering-20260712.md`](https://github.com/FarisZR/DualMate/blob/perf/schedule-render-snapshot/docs/solutions/performance/weekly-schedule-stable-viewport-rendering-20260712.md)
