### PR TITLE
Stabilize Canteen rendering and transitions

### DIFF
--- a/docs/solutions/performance/canteen-stable-render-shell-20260712.md
+++ b/docs/solutions/performance/canteen-stable-render-shell-20260712.md
@@ -1,0 +1,105 @@
+---
+title: Stabilize Canteen rendering for first open and day transitions
+date: 2026-07-12
+type: fix
+---
+
+# Summary
+
+The Canteen page now keeps one pager and one day scrollable mounted while
+loading and content state changes. The change targets first-open construction,
+day swipes, meal-count transitions, filtering, and drawer-to-Canteen
+activation on high-refresh-rate phones without changing the existing animation
+durations, skeleton content, paging rules, or performance harness thresholds.
+
+# Findings
+
+1. The page swapped a temporary single-day body for a full `PageView` when
+   content days became available.
+2. Each day transition animated an outgoing skeleton or old list against an
+   incoming full `ListView`, increasing layout and paint work on every frame.
+3. The root Canteen consumer rebuilt the header, filter row, pager, and floating
+   action button for unrelated state changes.
+4. `loadWeek` emitted separate menu, error, and loading notifications, while
+   `mealsForDay` repeatedly searched and allocated filtered meal lists during
+   builds.
+
+# Changes
+
+## Stable shell and scoped rebuilds
+
+- The Canteen shell mounts a keyed `PageView` from its first frame, including
+  the empty/loading fallback day.
+- Header, filter, pager, and day content now have separate property consumers.
+- The pager consumes one coalesced `weekState` property; individual day
+  widgets use selector equality so unchanged day render states do not rebuild.
+- Page synchronization defers targets that are outside the pager range being
+  mounted during a content-day list update.
+
+## Single-scrollable day transitions
+
+- A day always owns one `ListView`; empty and loading content are list items
+  rather than nested scrollables.
+- The existing 320 ms fade/slide transition is retained at the item boundary,
+  allowing skeleton-to-meal and meal-count changes to progress without two
+  full scrollable trees overlapping.
+- If cached data becomes ready while Canteen is still offstage, the outgoing
+  loading state is retained and the transition starts when `TickerMode` becomes
+  active. This prevents the animation from elapsing before the page is visible.
+- State keys remain available for loading, ready, and error/empty regression
+  checks, and the existing skeleton card layout is unchanged.
+
+## Immutable render snapshots and filtering cache
+
+- `CanteenWeekRenderState` snapshots normalized five-day menus, content days,
+  and per-day immutable meal lists once per applied week.
+- `CanteenDayContentState` is the exact day/filter selection consumed by the
+  day widget.
+- Filtered meals are cached by normalized day and `CanteenFilter`; replacing a
+  week invalidates only that week's day entries.
+- Visible content days are maintained from week snapshots and exposed as one
+  immutable sorted list rather than rescanned and reallocated during builds.
+- Meaningful loading/content phases publish one `weekState` notification each;
+  foreground provider callbacks do not duplicate the final load notification.
+
+# Regression coverage
+
+Added or updated Canteen tests cover:
+
+- stable page-content keys and pager mounting through loading-to-content;
+- one PageView plus one day scrollable during the transition;
+- no visible stale day after a committed swipe;
+- filtered meal results, identity reuse, replacement invalidation, immutable
+  weekly menus, and coalesced week-state notifications;
+- existing page bounds, overscroll, adjacent prefetch, and page-sync behavior.
+
+# Pixel 8 Pro performance results
+
+Device conditions:
+
+- Pixel 8 Pro in profile mode;
+- 120 Hz display;
+- Android animation scales at `1.0`;
+- deterministic offline fixture data.
+
+The prior Pixel repeat baseline measured drawer-to-Canteen at roughly 25.5% of
+frames over 8.33 ms, with a 56.0 ms worst frame. Three optimized runs produced
+a 15.0% median, and the final exact-code confirmation measured 14.29% with a
+47.3 ms worst frame. The final run also recorded:
+
+- cold loaded day swipe: 7.32% over 8.33 ms, 14.0 ms worst;
+- varied meal-content transition: 2.44%, 16.75 ms worst;
+- repeated settled interaction: 0%, 6.37 ms worst.
+
+All Canteen final-state and animation-progression checks passed after the
+`TickerMode` hardening. The separate existing Dates loading-progression check
+remained the only diagnostic warning.
+
+# Validation
+
+- full `flutter analyze`: passed;
+- `flutter test test/canteen`: 56 tests passed;
+- three-run diagnostic profile on the Pixel 8 Pro;
+- final post-hardening diagnostic profile on the Pixel 8 Pro;
+- no performance thresholds, fixture data, or integration harness files were
+  changed.

--- a/docs/solutions/performance/canteen-stable-render-shell-20260712.md
+++ b/docs/solutions/performance/canteen-stable-render-shell-20260712.md
@@ -43,9 +43,10 @@ durations, skeleton content, paging rules, or performance harness thresholds.
 - The existing 320 ms fade/slide transition is retained at the item boundary,
   allowing skeleton-to-meal and meal-count changes to progress without two
   full scrollable trees overlapping.
-- If cached data becomes ready while Canteen is still offstage, the outgoing
-  loading state is retained and the transition starts when `TickerMode` becomes
-  active. This prevents the animation from elapsing before the page is visible.
+- If cached data becomes ready while Canteen is still offstage, a lightweight
+  non-scrollable stable shell overlay retains the loading state and begins its
+  320 ms fade only when `TickerMode` becomes active. This prevents PageView child
+  reconfiguration from discarding the visible transition.
 - State keys remain available for loading, ready, and error/empty regression
   checks, and the existing skeleton card layout is unchanged.
 
@@ -98,7 +99,7 @@ remained the only diagnostic warning.
 # Validation
 
 - full `flutter analyze`: passed;
-- `flutter test test/canteen`: 56 tests passed;
+- `flutter test test/canteen`: 59 tests passed;
 - three-run diagnostic profile on the Pixel 8 Pro;
 - final post-hardening diagnostic profile on the Pixel 8 Pro;
 - no performance thresholds, fixture data, or integration harness files were

--- a/lib/canteen/ui/canteen_page.dart
+++ b/lib/canteen/ui/canteen_page.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+import 'dart:math' as math;
+
 import 'package:dualmate/canteen/ui/canteen_page_sync_coordinator.dart';
+import 'package:dualmate/canteen/ui/viewmodels/canteen_render_state.dart';
 import 'package:dualmate/canteen/ui/viewmodels/canteen_view_model.dart';
 import 'package:dualmate/canteen/ui/widgets/filter_dropdown.dart';
 import 'package:dualmate/canteen/ui/widgets/meal_card.dart';
@@ -7,8 +11,8 @@ import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:intl/intl.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 import 'package:provider/provider.dart';
@@ -22,9 +26,7 @@ ValueKey<String> canteenDayViewKey(DateTime date) {
 }
 
 String canteenPageContentModeKey(List<DateTime> visibleDays) {
-  return visibleDays.isEmpty
-      ? 'canteen_page_content_single'
-      : 'canteen_page_content_paged';
+  return 'canteen_page_content';
 }
 
 int? findCanteenDayIndexByKey(Key key, List<DateTime> visibleDays) {
@@ -41,6 +43,104 @@ int? findCanteenDayIndexByKey(Key key, List<DateTime> visibleDays) {
   return null;
 }
 
+class _CanteenHeader extends StatelessWidget {
+  final DateFormat dateFormat;
+  final ValueListenable<DateTime> selectedDate;
+
+  const _CanteenHeader({required this.dateFormat, required this.selectedDate});
+
+  @override
+  Widget build(BuildContext context) {
+    return PropertyChangeConsumer<CanteenViewModel, String>(
+      properties: const ['selectedLocation'],
+      builder: (context, model, _) {
+        if (model == null) return const SizedBox();
+        final location = model.selectedLocation;
+        final subtitle = location.subtitle;
+        final locationText = subtitle == null || subtitle.isEmpty
+            ? location.name
+            : '${location.name} - $subtitle';
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ValueListenableBuilder<DateTime>(
+                valueListenable: selectedDate,
+                builder: (context, date, _) {
+                  return AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 200),
+                    transitionBuilder: (child, animation) {
+                      final offsetAnimation = Tween<Offset>(
+                        begin: const Offset(0, 0.15),
+                        end: Offset.zero,
+                      ).animate(animation);
+                      return FadeTransition(
+                        opacity: animation,
+                        child: SlideTransition(
+                          position: offsetAnimation,
+                          child: child,
+                        ),
+                      );
+                    },
+                    child: Text(
+                      dateFormat.format(date),
+                      key: ValueKey<String>(date.toIso8601String()),
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 4),
+              Text(
+                locationText,
+                style: Theme.of(context).textTheme.bodySmall,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _CanteenFilterBar extends StatelessWidget {
+  const _CanteenFilterBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return PropertyChangeConsumer<CanteenViewModel, String>(
+      properties: const ['filter'],
+      builder: (context, model, _) {
+        if (model == null) return const SizedBox();
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          child: Row(
+            children: [
+              Text(
+                L.of(context).filterTitle,
+                style: Theme.of(context).textTheme.labelLarge,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: FilterDropdown(
+                    filter: model.filter,
+                    onChanged: model.setFilter,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
 class CanteenPage extends StatefulWidget {
   @override
   _CanteenPageState createState() => _CanteenPageState();
@@ -54,11 +154,13 @@ class _CanteenPageState extends State<CanteenPage> {
   late CanteenViewModel viewModel;
   late PageController pageController;
   late ValueNotifier<int> pageNotifier;
+  late ValueNotifier<DateTime> _selectedDateNotifier;
   late CanteenPageSyncCoordinator _pageSyncCoordinator;
   late DateTime baseDate;
   DateTime? _selectedDate;
   DateTime? _lastInteractionWeekStart;
   bool _isApplyingWidgetPayload = false;
+  bool _pageSyncRetryScheduled = false;
 
   @override
   void initState() {
@@ -69,6 +171,7 @@ class _CanteenPageState extends State<CanteenPage> {
     _lastInteractionWeekStart = viewModel.weekStartFor(baseDate);
     pageController = PageController(initialPage: 0);
     pageNotifier = ValueNotifier<int>(0);
+    _selectedDateNotifier = ValueNotifier<DateTime>(baseDate);
     _pageSyncCoordinator = CanteenPageSyncCoordinator(
       pageController: pageController,
       pageNotifier: pageNotifier,
@@ -81,16 +184,9 @@ class _CanteenPageState extends State<CanteenPage> {
       PerformanceTelemetry.instance.markNavEvent(name: "canteen.entry");
       Future.delayed(_initialLoadDelay, () {
         if (!mounted) return;
-        SchedulerBinding.instance.scheduleTask<void>(
-          () {
-            if (!mounted) return;
-            viewModel.primeVisibleWeek(baseDate);
-            viewModel.prefetchAdjacentWeeks(baseDate);
-            _applyWidgetPayload();
-          },
-          Priority.idle,
-          debugLabel: 'canteen.initialLoad',
-        );
+        viewModel.primeVisibleWeek(baseDate);
+        viewModel.prefetchAdjacentWeeks(baseDate);
+        _applyWidgetPayload();
       });
     });
   }
@@ -101,6 +197,7 @@ class _CanteenPageState extends State<CanteenPage> {
     WidgetNavigationPayloadStore.instance.removeListener(_handleWidgetPayload);
     pageController.dispose();
     pageNotifier.dispose();
+    _selectedDateNotifier.dispose();
     super.dispose();
   }
 
@@ -115,191 +212,73 @@ class _CanteenPageState extends State<CanteenPage> {
 
     return PropertyChangeProvider<CanteenViewModel, String>(
       value: viewModel,
-      child: PropertyChangeConsumer<CanteenViewModel, String>(
-        properties: const [
-          "weeklyMenus",
-          "loadingWeeks",
-          "weekErrors",
-          "selectedLocation",
+      child: Column(
+        children: [
+          _CanteenHeader(
+            dateFormat: dateFormat,
+            selectedDate: _selectedDateNotifier,
+          ),
+          const _CanteenFilterBar(),
+          Expanded(
+            child: Stack(
+              children: [
+                PropertyChangeConsumer<CanteenViewModel, String>(
+                  properties: const [
+                    CanteenViewModel.weekStateProperty,
+                    'selectedLocation',
+                  ],
+                  builder: (context, model, _) {
+                    if (model == null) return const SizedBox();
+                    final visibleDays = model.visibleContentDays;
+                    _syncPageForVisibleDays(model, visibleDays);
+                    if (WidgetNavigationPayloadStore.instance
+                                .peekCanteenPayload() !=
+                            null &&
+                        !_isApplyingWidgetPayload) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (!mounted) return;
+                        _applyWidgetPayload(visibleDays: visibleDays);
+                      });
+                    }
+                    return _buildPageContent(model, visibleDays);
+                  },
+                ),
+                ValueListenableBuilder<DateTime>(
+                  valueListenable: _selectedDateNotifier,
+                  builder: (context, date, _) {
+                    final showButton = !_isBaseDate(date);
+                    return Positioned(
+                      right: 16,
+                      bottom: 16,
+                      child: AnimatedOpacity(
+                        duration: const Duration(milliseconds: 200),
+                        opacity: showButton ? 1 : 0,
+                        child: IgnorePointer(
+                          ignoring: !showButton,
+                          child: FloatingActionButton.extended(
+                            heroTag: 'canteenBackToToday',
+                            onPressed: () {
+                              final targetDay = viewModel
+                                  .nearestVisibleContentDay(baseDate);
+                              if (targetDay == null) return;
+                              _goToVisibleDay(
+                                targetDay,
+                                viewModel.visibleContentDays,
+                                animate: true,
+                              );
+                            },
+                            icon: const Icon(Icons.today),
+                            label: Text(L.of(context).canteenBackToToday),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
         ],
-        builder:
-            (
-              BuildContext context,
-              CanteenViewModel? model,
-              Set<String>? properties,
-            ) {
-              if (model == null) return const SizedBox();
-              final visibleDays = model.visibleContentDays;
-              _syncPageForVisibleDays(model, visibleDays);
-              if (WidgetNavigationPayloadStore.instance.peekCanteenPayload() !=
-                      null &&
-                  !_isApplyingWidgetPayload) {
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (!mounted) return;
-                  _applyWidgetPayload(visibleDays: visibleDays);
-                });
-              }
-
-              return Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        ValueListenableBuilder<int>(
-                          valueListenable: pageNotifier,
-                          builder: (context, page, _) {
-                            final date = _displayDateForPage(
-                              page,
-                              visibleDays,
-                              model,
-                            );
-                            return AnimatedSwitcher(
-                              duration: const Duration(milliseconds: 200),
-                              transitionBuilder: (child, animation) {
-                                var offsetAnimation = Tween<Offset>(
-                                  begin: const Offset(0, 0.15),
-                                  end: Offset.zero,
-                                ).animate(animation);
-
-                                return FadeTransition(
-                                  opacity: animation,
-                                  child: SlideTransition(
-                                    position: offsetAnimation,
-                                    child: child,
-                                  ),
-                                );
-                              },
-                              child: Text(
-                                dateFormat.format(date),
-                                key: ValueKey(date.toIso8601String()),
-                                style: Theme.of(context).textTheme.titleMedium,
-                              ),
-                            );
-                          },
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          _formatSelectedLocation(model),
-                          style: Theme.of(context).textTheme.bodySmall,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-                    child: Row(
-                      children: [
-                        Text(
-                          L.of(context).filterTitle,
-                          style: Theme.of(context).textTheme.labelLarge,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Align(
-                            alignment: Alignment.centerRight,
-                            child:
-                                PropertyChangeConsumer<
-                                  CanteenViewModel,
-                                  String
-                                >(
-                                  properties: const ["filter"],
-                                  builder:
-                                      (
-                                        BuildContext context,
-                                        CanteenViewModel? model,
-                                        Set<String>? properties,
-                                      ) {
-                                        if (model == null)
-                                          return const SizedBox();
-                                        return FilterDropdown(
-                                          filter: model.filter,
-                                          onChanged: model.setFilter,
-                                        );
-                                      },
-                                ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Expanded(
-                    child: Stack(
-                      children: [
-                        AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 320),
-                          switchInCurve: Curves.easeOutCubic,
-                          switchOutCurve: Curves.easeInCubic,
-                          transitionBuilder: (child, animation) {
-                            final offsetAnimation = Tween<Offset>(
-                              begin: const Offset(0, 0.04),
-                              end: Offset.zero,
-                            ).animate(animation);
-
-                            return FadeTransition(
-                              opacity: animation,
-                              child: SlideTransition(
-                                position: offsetAnimation,
-                                child: child,
-                              ),
-                            );
-                          },
-                          child: KeyedSubtree(
-                            key: ValueKey<String>(
-                              canteenPageContentModeKey(visibleDays),
-                            ),
-                            child: _buildPageContent(model, visibleDays),
-                          ),
-                        ),
-                        ValueListenableBuilder<int>(
-                          valueListenable: pageNotifier,
-                          builder: (context, page, _) {
-                            final date = _displayDateForPage(
-                              page,
-                              visibleDays,
-                              model,
-                            );
-                            var showButton = !_isBaseDate(date);
-
-                            return Positioned(
-                              right: 16,
-                              bottom: 16,
-                              child: AnimatedOpacity(
-                                duration: const Duration(milliseconds: 200),
-                                opacity: showButton ? 1 : 0,
-                                child: IgnorePointer(
-                                  ignoring: !showButton,
-                                  child: FloatingActionButton.extended(
-                                    heroTag: "canteenBackToToday",
-                                    onPressed: () {
-                                      final targetDay = model
-                                          .nearestVisibleContentDay(baseDate);
-                                      if (targetDay == null) return;
-                                      _goToVisibleDay(
-                                        targetDay,
-                                        visibleDays,
-                                        animate: true,
-                                      );
-                                    },
-                                    icon: const Icon(Icons.today),
-                                    label: Text(
-                                      L.of(context).canteenBackToToday,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              );
-            },
       ),
     );
   }
@@ -315,49 +294,25 @@ class _CanteenPageState extends State<CanteenPage> {
     return normalized;
   }
 
-  DateTime _displayDateForPage(
-    int page,
-    List<DateTime> visibleDays,
-    CanteenViewModel model,
-  ) {
-    if (visibleDays.isNotEmpty) {
-      final boundedPage = page.clamp(0, visibleDays.length - 1);
-      return visibleDays[boundedPage];
-    }
-
-    return _selectedDate ??
-        model.nearestVisibleContentDay(baseDate) ??
-        baseDate;
-  }
-
-  String _formatSelectedLocation(CanteenViewModel model) {
-    final location = model.selectedLocation;
-    final subtitle = location.subtitle;
-    if (subtitle == null || subtitle.isEmpty) {
-      return location.name;
-    }
-    return '${location.name} - $subtitle';
-  }
-
   Widget _buildPageContent(CanteenViewModel model, List<DateTime> visibleDays) {
-    if (visibleDays.isEmpty) {
-      final date = _selectedDate ?? baseDate;
-      return _CanteenDayView(key: canteenDayViewKey(date), date: date);
-    }
+    final pageDates = visibleDays.isEmpty
+        ? <DateTime>[_selectedDate ?? baseDate]
+        : visibleDays;
 
     return StretchingOverscrollIndicator(
       axisDirection: AxisDirection.right,
       child: PageView.builder(
+        key: const ValueKey<String>('canteen_page_view'),
         controller: pageController,
         allowImplicitScrolling: true,
         findChildIndexCallback: (key) {
-          return findCanteenDayIndexByKey(key, visibleDays);
+          return findCanteenDayIndexByKey(key, pageDates);
         },
-        itemCount: visibleDays.length,
+        itemCount: pageDates.length,
         onPageChanged: (index) {
-          final nextDate = visibleDays[index];
+          final nextDate = pageDates[index];
           pageNotifier.value = index;
-          _selectedDate = nextDate;
+          _setSelectedDate(nextDate);
           PerformanceTelemetry.instance.markNavEvent(
             name: "canteen.pageChanged",
           );
@@ -370,7 +325,7 @@ class _CanteenPageState extends State<CanteenPage> {
           }
         },
         itemBuilder: (context, index) {
-          final date = visibleDays[index];
+          final date = pageDates[index];
           return _CanteenDayView(key: canteenDayViewKey(date), date: date);
         },
       ),
@@ -427,8 +382,9 @@ class _CanteenPageState extends State<CanteenPage> {
 
   void _syncPageForVisibleDays(
     CanteenViewModel model,
-    List<DateTime> visibleDays,
-  ) {
+    List<DateTime> visibleDays, {
+    bool allowRangeRetry = true,
+  }) {
     if (visibleDays.isEmpty) return;
 
     final currentPage =
@@ -452,8 +408,15 @@ class _CanteenPageState extends State<CanteenPage> {
     );
     if (targetIndex < 0) return;
 
-    _selectedDate = syncedDate;
+    _setSelectedDate(syncedDate);
     if (pageNotifier.value == targetIndex) return;
+    if (_pageTargetExceedsMountedPageRange(targetIndex)) {
+      _pageSyncCoordinator.markPending();
+      if (allowRangeRetry) {
+        _schedulePageSyncRetry();
+      }
+      return;
+    }
     if (_pageSyncCoordinator.shouldDeferSync()) {
       _pageSyncCoordinator.markPending();
       return;
@@ -469,6 +432,33 @@ class _CanteenPageState extends State<CanteenPage> {
     _syncPageForVisibleDays(model, model.visibleContentDays);
   }
 
+  bool _pageTargetExceedsMountedPageRange(int targetIndex) {
+    if (!pageController.hasClients ||
+        pageController.positions.length != 1 ||
+        !pageController.position.hasViewportDimension) {
+      return false;
+    }
+    final viewportDimension = pageController.position.viewportDimension;
+    if (viewportDimension == 0) return false;
+    final maxPage = pageController.position.maxScrollExtent / viewportDimension;
+    return targetIndex.toDouble() > maxPage + 0.01;
+  }
+
+  void _schedulePageSyncRetry() {
+    if (_pageSyncRetryScheduled) return;
+    _pageSyncRetryScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pageSyncRetryScheduled = false;
+      if (!mounted) return;
+      final model = Provider.of<CanteenViewModel>(context, listen: false);
+      _syncPageForVisibleDays(
+        model,
+        model.visibleContentDays,
+        allowRangeRetry: false,
+      );
+    });
+  }
+
   void _goToVisibleDay(
     DateTime targetDay,
     List<DateTime> visibleDays, {
@@ -478,7 +468,7 @@ class _CanteenPageState extends State<CanteenPage> {
       (day) => isAtSameDay(day, targetDay),
     );
     if (targetIndex < 0) return;
-    _selectedDate = targetDay;
+    _setSelectedDate(targetDay);
 
     if (!pageController.hasClients) return;
     if (animate) {
@@ -494,16 +484,16 @@ class _CanteenPageState extends State<CanteenPage> {
     pageNotifier.value = targetIndex;
   }
 
-  List<DateTime> _contentDaysForWeek(DateTime weekStart) {
-    final days = <DateTime>[];
-
-    for (final menu in viewModel.weeklyMenusFor(weekStart)) {
-      if (menu.meals.isEmpty) continue;
-      days.add(toStartOfDay(menu.date));
+  void _setSelectedDate(DateTime date) {
+    final normalizedDate = toStartOfDay(date);
+    _selectedDate = normalizedDate;
+    if (_selectedDateNotifier.value != normalizedDate) {
+      _selectedDateNotifier.value = normalizedDate;
     }
+  }
 
-    days.sort((a, b) => a.compareTo(b));
-    return days;
+  List<DateTime> _contentDaysForWeek(DateTime weekStart) {
+    return viewModel.contentDaysForWeek(weekStart);
   }
 
   DateTime? _nearestDay(DateTime targetDate, List<DateTime> days) {
@@ -530,139 +520,277 @@ class _CanteenPageState extends State<CanteenPage> {
   }
 }
 
-class _CanteenDayView extends StatefulWidget {
+class _CanteenDayView extends StatelessWidget {
   final DateTime date;
 
   const _CanteenDayView({Key? key, required this.date}) : super(key: key);
 
   @override
-  State<_CanteenDayView> createState() => _CanteenDayViewState();
+  Widget build(BuildContext context) {
+    return Selector<CanteenViewModel, CanteenDayContentState>(
+      selector: (context, model) => model.dayContentStateFor(date),
+      builder: (context, selection, _) {
+        return _CanteenDayContent(selection: selection, date: date);
+      },
+    );
+  }
 }
 
-class _CanteenDayViewState extends State<_CanteenDayView> {
+class _CanteenDayContent extends StatefulWidget {
+  final DateTime date;
+  final CanteenDayContentState selection;
+
+  const _CanteenDayContent({required this.date, required this.selection});
+
+  @override
+  State<_CanteenDayContent> createState() => _CanteenDayContentState();
+}
+
+class _CanteenDayContentState extends State<_CanteenDayContent>
+    with SingleTickerProviderStateMixin {
+  static const Duration _transitionDuration = Duration(milliseconds: 320);
+
+  late final AnimationController _transitionController;
+  late final Animation<double> _transitionAnimation;
+  CanteenDayContentState? _previousSelection;
+  bool _tickerEnabled = false;
+  bool _transitionPending = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _transitionController = AnimationController(
+      vsync: this,
+      duration: _transitionDuration,
+      value: 1,
+    )..addStatusListener(_handleTransitionStatus);
+    _transitionAnimation = CurvedAnimation(
+      parent: _transitionController,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeInCubic,
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final tickerEnabled = TickerMode.valuesOf(context).enabled;
+    if (_tickerEnabled == tickerEnabled) return;
+
+    _tickerEnabled = tickerEnabled;
+    if (!tickerEnabled && _transitionController.isAnimating) {
+      _transitionController
+        ..stop()
+        ..value = 0;
+      _transitionPending = _previousSelection != null;
+      return;
+    }
+
+    if (tickerEnabled && _transitionPending) {
+      _transitionPending = false;
+      _transitionController.forward(from: 0);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _CanteenDayContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selection == widget.selection) return;
+
+    _previousSelection = oldWidget.selection;
+    if (_tickerEnabled) {
+      _transitionPending = false;
+      _transitionController.forward(from: 0);
+    } else {
+      _transitionPending = true;
+      _transitionController
+        ..stop()
+        ..value = 0;
+    }
+  }
+
+  void _handleTransitionStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed || _previousSelection == null) {
+      return;
+    }
+    setState(() {
+      _previousSelection = null;
+      _transitionPending = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _transitionController
+      ..removeStatusListener(_handleTransitionStatus)
+      ..dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return PropertyChangeConsumer<CanteenViewModel, String>(
-      properties: const ["weeklyMenus", "loadingWeeks", "weekErrors", "filter"],
-      builder:
-          (
-            BuildContext context,
-            CanteenViewModel? model,
-            Set<String>? properties,
-          ) {
-            if (model == null) return const SizedBox();
+    final selection = widget.selection;
+    final previousSelection = _previousSelection;
+    final itemCount = previousSelection == null
+        ? _itemCount(selection)
+        : math.max(_itemCount(previousSelection), _itemCount(selection));
+    final list = ListView.builder(
+      key: PageStorageKey<String>('canteen_${widget.date.toIso8601String()}'),
+      padding: _hasMeals(selection) || _isLoading(selection)
+          ? const EdgeInsets.fromLTRB(16, 8, 16, 16)
+          : EdgeInsets.zero,
+      itemCount: itemCount,
+      addAutomaticKeepAlives: false,
+      // ignore: deprecated_member_use
+      cacheExtent: kMealListCacheExtent,
+      physics: _hasMeals(selection)
+          ? null
+          : const AlwaysScrollableScrollPhysics(),
+      itemBuilder: (context, index) {
+        final previousChild =
+            previousSelection != null && index < _itemCount(previousSelection)
+            ? _buildItem(context, previousSelection, index)
+            : null;
+        final currentChild = index < _itemCount(selection)
+            ? _buildItem(context, selection, index)
+            : null;
 
-            var weekStart = model.weekStartFor(widget.date);
-            var meals = model.mealsForDay(weekStart, widget.date);
-            var isLoading = model.isLoadingWeek(weekStart);
-            var showError = model.errorForWeek(weekStart) != null;
-            var hasWeekData = model.hasWeekData(weekStart);
-            var lastUpdated = model.lastUpdatedForWeek(weekStart);
-
-            late final String stateKey;
-            late final Widget stateChild;
-            final dayKey = toStartOfDay(widget.date).millisecondsSinceEpoch;
-
-            if ((!hasWeekData || isLoading) && meals.isEmpty) {
-              stateKey = 'loading_$dayKey';
-              stateChild = const _MealLoadingList();
-            } else if (meals.isEmpty) {
-              stateKey = 'empty_${showError ? 'error' : 'plain'}_$dayKey';
-              stateChild = _buildEmptyState(
-                context,
-                showError: showError,
-                lastUpdated: lastUpdated,
-              );
-            } else {
-              stateKey = 'ready_${meals.length}_$dayKey';
-              stateChild = RefreshIndicator(
-                onRefresh: () => model.loadWeek(weekStart),
-                child: ListView.builder(
-                  key: PageStorageKey(
-                    "canteen_${widget.date.toIso8601String()}",
-                  ),
-                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-                  itemCount: meals.length,
-                  addAutomaticKeepAlives: false,
-                  // ignore: deprecated_member_use
-                  cacheExtent: kMealListCacheExtent,
-                  itemBuilder: (context, index) {
-                    var meal = meals[index];
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 12),
-                      child: MealCard(meal: meal),
-                    );
-                  },
-                ),
-              );
-            }
-
-            return AnimatedSwitcher(
-              duration: const Duration(milliseconds: 320),
-              switchInCurve: Curves.easeOutCubic,
-              switchOutCurve: Curves.easeInCubic,
-              transitionBuilder: (child, animation) {
-                final offsetAnimation = Tween<Offset>(
-                  begin: const Offset(0, 0.06),
-                  end: Offset.zero,
-                ).animate(animation);
-
-                return FadeTransition(
-                  opacity: animation,
-                  child: SlideTransition(
-                    position: offsetAnimation,
-                    child: child,
-                  ),
-                );
-              },
-              child: KeyedSubtree(
-                key: ValueKey<String>('canteen_state_$stateKey'),
-                child: stateChild,
-              ),
-            );
-          },
+        if (previousChild == null) {
+          return currentChild!;
+        }
+        return _AnimatedDayItem(
+          key: ValueKey<String>(
+            'canteen_day_item_${widget.date.toIso8601String()}_$index',
+          ),
+          animation: _transitionAnimation,
+          oldChild: previousChild,
+          newChild: currentChild,
+        );
+      },
     );
+
+    if (_hasMeals(selection)) {
+      final weekStart = toStartOfDay(toMonday(widget.date));
+      return RefreshIndicator(
+        onRefresh: () => Provider.of<CanteenViewModel>(
+          context,
+          listen: false,
+        ).loadWeek(weekStart),
+        child: list,
+      );
+    }
+    if (_isLoading(selection)) {
+      return TweenAnimationBuilder<double>(
+        tween: Tween<double>(begin: 0.75, end: 1.0),
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOut,
+        builder: (context, opacity, child) {
+          return Opacity(opacity: opacity, child: child);
+        },
+        child: list,
+      );
+    }
+    return list;
+  }
+
+  int _itemCount(CanteenDayContentState selection) {
+    if (_isLoading(selection)) return 6;
+    if (selection.meals.isEmpty) return 1;
+    return selection.meals.length;
+  }
+
+  bool _hasMeals(CanteenDayContentState selection) {
+    return selection.meals.isNotEmpty;
+  }
+
+  bool _isLoading(CanteenDayContentState selection) {
+    return (!selection.day.hasWeekData || selection.day.isLoading) &&
+        selection.meals.isEmpty;
+  }
+
+  Widget _buildItem(
+    BuildContext context,
+    CanteenDayContentState selection,
+    int index,
+  ) {
+    late final Widget child;
+    if (_isLoading(selection)) {
+      child = Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: _MealSkeletonCard(
+          baseColor: Theme.of(context).brightness == Brightness.dark
+              ? const Color(0xFF2A2A2A)
+              : const Color(0xFFE6E6E8),
+          shimmerColor: Theme.of(context).brightness == Brightness.dark
+              ? const Color(0xFF3A3A3A)
+              : const Color(0xFFF2F2F2),
+        ),
+      );
+    } else if (selection.meals.isEmpty) {
+      child = _buildEmptyState(
+        context,
+        showError: selection.day.error != null,
+        lastUpdated: selection.day.lastUpdated,
+      );
+    } else {
+      child = Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: MealCard(meal: selection.meals[index]),
+      );
+    }
+
+    if (index != 0) return child;
+    return KeyedSubtree(
+      key: ValueKey<String>('canteen_state_${_stateKey(selection)}'),
+      child: child,
+    );
+  }
+
+  String _stateKey(CanteenDayContentState selection) {
+    final dayKey = toStartOfDay(widget.date).millisecondsSinceEpoch;
+    if (_isLoading(selection)) return 'loading_$dayKey';
+    if (selection.meals.isEmpty) {
+      return 'empty_${selection.day.error != null ? 'error' : 'plain'}_$dayKey';
+    }
+    return 'ready_${selection.meals.length}_$dayKey';
   }
 
   Widget _buildEmptyState(
     BuildContext context, {
     required bool showError,
-    DateTime? lastUpdated,
+    required DateTime? lastUpdated,
   }) {
     final lastUpdatedText = _formatLastUpdated(context, lastUpdated);
-    return SingleChildScrollView(
-      physics: const AlwaysScrollableScrollPhysics(),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(32, 48, 32, 32),
-        child: Column(
-          children: [
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(32, 48, 32, 32),
+      child: Column(
+        children: [
+          Text(
+            showError
+                ? L.of(context).canteenLoadError
+                : L.of(context).canteenNoMenuToday,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          if (lastUpdatedText != null) ...[
+            const SizedBox(height: 8),
             Text(
-              showError
-                  ? L.of(context).canteenLoadError
-                  : L.of(context).canteenNoMenuToday,
+              lastUpdatedText,
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.titleMedium,
+              style: Theme.of(context).textTheme.bodySmall,
             ),
-            if (lastUpdatedText != null) ...[
-              const SizedBox(height: 8),
-              Text(
-                lastUpdatedText,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            ],
-            if (showError) ...[
-              const SizedBox(height: 12),
-              Text(
-                L.of(context).canteenNoMenuToday,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-            ],
-            const SizedBox(height: 24),
-            Opacity(opacity: 0.9, child: Image.asset("assets/empty_state.png")),
           ],
-        ),
+          if (showError) ...[
+            const SizedBox(height: 12),
+            Text(
+              L.of(context).canteenNoMenuToday,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+          const SizedBox(height: 24),
+          Opacity(opacity: 0.9, child: Image.asset("assets/empty_state.png")),
+        ],
       ),
     );
   }
@@ -681,37 +809,46 @@ class _CanteenDayViewState extends State<_CanteenDayView> {
   }
 }
 
-class _MealLoadingList extends StatelessWidget {
-  const _MealLoadingList();
+class _AnimatedDayItem extends StatelessWidget {
+  final Animation<double> animation;
+  final Widget oldChild;
+  final Widget? newChild;
+
+  const _AnimatedDayItem({
+    super.key,
+    required this.animation,
+    required this.oldChild,
+    required this.newChild,
+  });
 
   @override
   Widget build(BuildContext context) {
-    var isDark = Theme.of(context).brightness == Brightness.dark;
-    var baseColor = isDark ? const Color(0xFF2A2A2A) : const Color(0xFFE6E6E8);
-    var highlightColor = isDark
-        ? const Color(0xFF3A3A3A)
-        : const Color(0xFFF2F2F2);
+    final outgoingPosition = Tween<Offset>(
+      begin: Offset.zero,
+      end: const Offset(0, 0.06),
+    ).animate(animation);
+    final incomingPosition = Tween<Offset>(
+      begin: const Offset(0, 0.06),
+      end: Offset.zero,
+    ).animate(animation);
 
-    return TweenAnimationBuilder<double>(
-      tween: Tween<double>(begin: 0.75, end: 1.0),
-      duration: const Duration(milliseconds: 220),
-      curve: Curves.easeOut,
-      builder: (context, opacity, child) {
-        return Opacity(opacity: opacity, child: child);
-      },
-      child: ListView.builder(
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-        itemCount: 6,
-        addAutomaticKeepAlives: false,
-        itemBuilder: (context, index) {
-          return Padding(
-            padding: const EdgeInsets.only(bottom: 12),
-            child: _MealSkeletonCard(
-              baseColor: baseColor,
-              shimmerColor: highlightColor,
+    return ClipRect(
+      child: Stack(
+        alignment: Alignment.topLeft,
+        children: [
+          FadeTransition(
+            opacity: ReverseAnimation(animation),
+            child: SlideTransition(position: outgoingPosition, child: oldChild),
+          ),
+          if (newChild != null)
+            FadeTransition(
+              opacity: animation,
+              child: SlideTransition(
+                position: incomingPosition,
+                child: newChild,
+              ),
             ),
-          );
-        },
+        ],
       ),
     );
   }

--- a/lib/canteen/ui/canteen_page.dart
+++ b/lib/canteen/ui/canteen_page.dart
@@ -161,6 +161,9 @@ class _CanteenPageState extends State<CanteenPage> {
   DateTime? _lastInteractionWeekStart;
   bool _isApplyingWidgetPayload = false;
   bool _pageSyncRetryScheduled = false;
+  bool _visibleDaysSyncScheduled = false;
+  final Map<DateTime, GlobalKey<_CanteenDayContentState>> _dayContentKeys =
+      <DateTime, GlobalKey<_CanteenDayContentState>>{};
 
   @override
   void initState() {
@@ -230,7 +233,7 @@ class _CanteenPageState extends State<CanteenPage> {
                   builder: (context, model, _) {
                     if (model == null) return const SizedBox();
                     final visibleDays = model.visibleContentDays;
-                    _syncPageForVisibleDays(model, visibleDays);
+                    _scheduleVisibleDaysSync(model);
                     if (WidgetNavigationPayloadStore.instance
                                 .peekCanteenPayload() !=
                             null &&
@@ -240,7 +243,16 @@ class _CanteenPageState extends State<CanteenPage> {
                         _applyWidgetPayload(visibleDays: visibleDays);
                       });
                     }
-                    return _buildPageContent(model, visibleDays);
+                    final baseWeekStart = model.weekStartFor(baseDate);
+                    return _CanteenInitialLoadingTransition(
+                      key: const ValueKey<String>(
+                        'canteen_initial_loading_transition',
+                      ),
+                      showLoading:
+                          visibleDays.isEmpty &&
+                          model.isLoadingWeek(baseWeekStart),
+                      child: _buildPageContent(model, visibleDays),
+                    );
                   },
                 ),
                 ValueListenableBuilder<DateTime>(
@@ -326,7 +338,16 @@ class _CanteenPageState extends State<CanteenPage> {
         },
         itemBuilder: (context, index) {
           final date = pageDates[index];
-          return _CanteenDayView(key: canteenDayViewKey(date), date: date);
+          final normalizedDate = toStartOfDay(date);
+          final contentKey = _dayContentKeys.putIfAbsent(
+            normalizedDate,
+            GlobalKey<_CanteenDayContentState>.new,
+          );
+          return _CanteenDayView(
+            key: canteenDayViewKey(date),
+            date: date,
+            contentKey: contentKey,
+          );
         },
       ),
     );
@@ -432,6 +453,16 @@ class _CanteenPageState extends State<CanteenPage> {
     _syncPageForVisibleDays(model, model.visibleContentDays);
   }
 
+  void _scheduleVisibleDaysSync(CanteenViewModel model) {
+    if (_visibleDaysSyncScheduled) return;
+    _visibleDaysSyncScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _visibleDaysSyncScheduled = false;
+      if (!mounted) return;
+      _syncPageForVisibleDays(model, model.visibleContentDays);
+    });
+  }
+
   bool _pageTargetExceedsMountedPageRange(int targetIndex) {
     if (!pageController.hasClients ||
         pageController.positions.length != 1 ||
@@ -520,17 +551,219 @@ class _CanteenPageState extends State<CanteenPage> {
   }
 }
 
+class _CanteenInitialLoadingTransition extends StatefulWidget {
+  final bool showLoading;
+  final Widget child;
+
+  const _CanteenInitialLoadingTransition({
+    super.key,
+    required this.showLoading,
+    required this.child,
+  });
+
+  @override
+  State<_CanteenInitialLoadingTransition> createState() =>
+      _CanteenInitialLoadingTransitionState();
+}
+
+class _CanteenInitialLoadingTransitionState
+    extends State<_CanteenInitialLoadingTransition>
+    with SingleTickerProviderStateMixin {
+  static const Duration _duration = Duration(milliseconds: 320);
+
+  late final AnimationController _controller;
+  late final Animation<double> _fadeOut;
+  bool _retainLoading = false;
+  bool _tickerEnabled = false;
+  bool _pendingHide = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _retainLoading = widget.showLoading;
+    _controller = AnimationController(vsync: this, duration: _duration)
+      ..addStatusListener(_handleStatus);
+    _fadeOut = Tween<double>(
+      begin: 1,
+      end: 0,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic));
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final enabled = TickerMode.valuesOf(context).enabled;
+    if (_tickerEnabled == enabled) return;
+    _tickerEnabled = enabled;
+    if (enabled && _pendingHide) {
+      _pendingHide = false;
+      _controller.forward(from: 0);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _CanteenInitialLoadingTransition oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.showLoading) {
+      _retainLoading = true;
+      _pendingHide = false;
+      _controller
+        ..stop()
+        ..value = 0;
+      return;
+    }
+    if (!_retainLoading) return;
+    if (_tickerEnabled) {
+      _pendingHide = false;
+      _controller.forward(from: 0);
+    } else {
+      _pendingHide = true;
+    }
+  }
+
+  void _handleStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed || !_retainLoading) return;
+    setState(() {
+      _retainLoading = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeStatusListener(_handleStatus)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        widget.child,
+        if (_retainLoading)
+          FadeTransition(
+            opacity: _fadeOut,
+            child: const _CanteenLoadingSkeletonOverlay(),
+          ),
+      ],
+    );
+  }
+}
+
+class _CanteenLoadingSkeletonOverlay extends StatelessWidget {
+  const _CanteenLoadingSkeletonOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = Theme.of(context).brightness == Brightness.dark;
+    final baseColor = dark ? const Color(0xFF2A2A2A) : const Color(0xFFE6E6E8);
+    final shimmerColor = dark
+        ? const Color(0xFF3A3A3A)
+        : const Color(0xFFF2F2F2);
+    return IgnorePointer(
+      child: ColoredBox(
+        color: Theme.of(context).scaffoldBackgroundColor,
+        child: KeyedSubtree(
+          key: const ValueKey<String>('canteen_state_loading_shell'),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+            child: Column(
+              children: List<Widget>.generate(4, (index) {
+                return Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.only(bottom: index == 3 ? 0 : 12),
+                    child: _InitialMealSkeletonCard(
+                      baseColor: baseColor,
+                      shimmerColor: shimmerColor,
+                    ),
+                  ),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InitialMealSkeletonCard extends StatelessWidget {
+  final Color baseColor;
+  final Color shimmerColor;
+
+  const _InitialMealSkeletonCard({
+    required this.baseColor,
+    required this.shimmerColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: baseColor,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final height = constraints.maxHeight;
+          final firstBarHeight = math.min(12.0, height * 0.18);
+          final secondBarHeight = math.min(9.0, height * 0.14);
+          return Stack(
+            children: [
+              Positioned(
+                left: 16,
+                right: 52,
+                top: height * 0.25,
+                height: firstBarHeight,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: shimmerColor,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+              Positioned(
+                left: 16,
+                right: 110,
+                top: height * 0.58,
+                height: secondBarHeight,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: shimmerColor,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
 class _CanteenDayView extends StatelessWidget {
   final DateTime date;
+  final GlobalKey<_CanteenDayContentState> contentKey;
 
-  const _CanteenDayView({Key? key, required this.date}) : super(key: key);
+  const _CanteenDayView({
+    Key? key,
+    required this.date,
+    required this.contentKey,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Selector<CanteenViewModel, CanteenDayContentState>(
       selector: (context, model) => model.dayContentStateFor(date),
       builder: (context, selection, _) {
-        return _CanteenDayContent(selection: selection, date: date);
+        return _CanteenDayContent(
+          key: contentKey,
+          selection: selection,
+          date: date,
+        );
       },
     );
   }
@@ -540,7 +773,11 @@ class _CanteenDayContent extends StatefulWidget {
   final DateTime date;
   final CanteenDayContentState selection;
 
-  const _CanteenDayContent({required this.date, required this.selection});
+  const _CanteenDayContent({
+    super.key,
+    required this.date,
+    required this.selection,
+  });
 
   @override
   State<_CanteenDayContent> createState() => _CanteenDayContentState();

--- a/lib/canteen/ui/viewmodels/canteen_render_state.dart
+++ b/lib/canteen/ui/viewmodels/canteen_render_state.dart
@@ -198,6 +198,14 @@ class CanteenWeekRenderState {
     Object? error = _notSpecified,
     Object? lastUpdated = _notSpecified,
   }) {
+    assert(
+      (menus == null) == (days == null),
+      'menus and days must be supplied together so their entries correspond.',
+    );
+    assert(
+      menus == null || menus.length == days!.length,
+      'menus and days must contain corresponding entries.',
+    );
     final nextIsLoading = isLoading ?? this.isLoading;
     final nextError = identical(error, _notSpecified)
         ? this.error

--- a/lib/canteen/ui/viewmodels/canteen_render_state.dart
+++ b/lib/canteen/ui/viewmodels/canteen_render_state.dart
@@ -1,0 +1,283 @@
+import 'package:dualmate/canteen/model/canteen_filter.dart';
+import 'package:dualmate/canteen/model/daily_menu.dart';
+import 'package:dualmate/canteen/model/meal.dart';
+import 'package:dualmate/common/util/date_utils.dart';
+
+/// Immutable render data for one canteen day.
+///
+/// The lists are snapshotted when a week is applied so widget builds can reuse
+/// the same object until that day's source data actually changes.
+class CanteenDayRenderState {
+  static const List<Meal> _emptyMeals = <Meal>[];
+
+  final DateTime date;
+  final List<Meal> meals;
+  final bool hasWeekData;
+  final bool isLoading;
+  final String? error;
+  final DateTime? lastUpdated;
+
+  const CanteenDayRenderState({
+    required this.date,
+    required this.meals,
+    required this.hasWeekData,
+    required this.isLoading,
+    required this.error,
+    required this.lastUpdated,
+  });
+
+  factory CanteenDayRenderState.empty(DateTime date) {
+    return CanteenDayRenderState(
+      date: toStartOfDay(date),
+      meals: _emptyMeals,
+      hasWeekData: false,
+      isLoading: false,
+      error: null,
+      lastUpdated: null,
+    );
+  }
+
+  CanteenDayRenderState copyWith({
+    List<Meal>? meals,
+    bool? hasWeekData,
+    bool? isLoading,
+    Object? error = _notSpecified,
+    Object? lastUpdated = _notSpecified,
+  }) {
+    return CanteenDayRenderState(
+      date: date,
+      meals: meals ?? this.meals,
+      hasWeekData: hasWeekData ?? this.hasWeekData,
+      isLoading: isLoading ?? this.isLoading,
+      error: identical(error, _notSpecified) ? this.error : error as String?,
+      lastUpdated: identical(lastUpdated, _notSpecified)
+          ? this.lastUpdated
+          : lastUpdated as DateTime?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is CanteenDayRenderState &&
+        other.date == date &&
+        identical(other.meals, meals) &&
+        other.hasWeekData == hasWeekData &&
+        other.isLoading == isLoading &&
+        other.error == error &&
+        other.lastUpdated == lastUpdated;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    date,
+    identityHashCode(meals),
+    hasWeekData,
+    isLoading,
+    error,
+    lastUpdated,
+  );
+}
+
+const Object _notSpecified = Object();
+
+/// Immutable render snapshot for one loaded week.
+class CanteenWeekRenderState {
+  final DateTime weekStart;
+  final List<DailyMenu> menus;
+  final List<CanteenDayRenderState> days;
+  final List<DateTime> contentDays;
+  final bool isLoading;
+  final String? error;
+  final DateTime? lastUpdated;
+  final Map<DateTime, CanteenDayRenderState> _daysByDate;
+
+  CanteenWeekRenderState({
+    required this.weekStart,
+    required List<DailyMenu> menus,
+    required List<CanteenDayRenderState> days,
+    required List<DateTime> contentDays,
+    required this.isLoading,
+    required this.error,
+    required this.lastUpdated,
+  }) : menus = List<DailyMenu>.unmodifiable(menus),
+       days = List<CanteenDayRenderState>.unmodifiable(days),
+       contentDays = List<DateTime>.unmodifiable(contentDays),
+       _daysByDate = Map<DateTime, CanteenDayRenderState>.unmodifiable(
+         <DateTime, CanteenDayRenderState>{
+           for (final day in days) day.date: day,
+         },
+       );
+
+  factory CanteenWeekRenderState.empty(
+    DateTime weekStart, {
+    bool isLoading = false,
+  }) {
+    final normalizedWeekStart = toStartOfDay(toMonday(weekStart));
+    final days = List<CanteenDayRenderState>.generate(5, (index) {
+      return CanteenDayRenderState(
+        date: normalizedWeekStart.add(Duration(days: index)),
+        meals: const <Meal>[],
+        hasWeekData: false,
+        isLoading: isLoading,
+        error: null,
+        lastUpdated: null,
+      );
+    }, growable: false);
+    return CanteenWeekRenderState(
+      weekStart: normalizedWeekStart,
+      menus: [
+        for (final day in days) DailyMenu(date: day.date, meals: day.meals),
+      ],
+      days: days,
+      contentDays: const <DateTime>[],
+      isLoading: isLoading,
+      error: null,
+      lastUpdated: null,
+    );
+  }
+
+  factory CanteenWeekRenderState.fromMenus(
+    DateTime weekStart,
+    List<DailyMenu> sourceMenus, {
+    CanteenWeekRenderState? previous,
+    bool isLoading = false,
+    String? error,
+    DateTime? lastUpdated,
+  }) {
+    final normalizedWeekStart = toStartOfDay(toMonday(weekStart));
+    final sourceByDate = <DateTime, List<Meal>>{};
+    for (final menu in sourceMenus) {
+      final day = toStartOfDay(menu.date);
+      sourceByDate[day] = List<Meal>.unmodifiable(menu.meals);
+    }
+
+    final days = <CanteenDayRenderState>[];
+    final menus = <DailyMenu>[];
+    final contentDays = <DateTime>[];
+    for (var index = 0; index < 5; index++) {
+      final date = normalizedWeekStart.add(Duration(days: index));
+      final sourceMeals = sourceByDate[date] ?? const <Meal>[];
+      final previousDay = previous?.dayFor(date);
+      final meals =
+          previousDay != null && _sameMeals(previousDay.meals, sourceMeals)
+          ? previousDay.meals
+          : sourceMeals;
+      final day = CanteenDayRenderState(
+        date: date,
+        meals: meals,
+        hasWeekData: true,
+        isLoading: isLoading,
+        error: error,
+        lastUpdated: lastUpdated,
+      );
+      days.add(day);
+      menus.add(DailyMenu(date: date, meals: meals));
+      if (meals.isNotEmpty) contentDays.add(date);
+    }
+
+    return CanteenWeekRenderState(
+      weekStart: normalizedWeekStart,
+      menus: menus,
+      days: days,
+      contentDays: contentDays,
+      isLoading: isLoading,
+      error: error,
+      lastUpdated: lastUpdated,
+    );
+  }
+
+  CanteenDayRenderState? dayFor(DateTime date) {
+    return _daysByDate[toStartOfDay(date)];
+  }
+
+  CanteenWeekRenderState copyWith({
+    List<DailyMenu>? menus,
+    List<CanteenDayRenderState>? days,
+    List<DateTime>? contentDays,
+    bool? isLoading,
+    Object? error = _notSpecified,
+    Object? lastUpdated = _notSpecified,
+  }) {
+    final nextIsLoading = isLoading ?? this.isLoading;
+    final nextError = identical(error, _notSpecified)
+        ? this.error
+        : error as String?;
+    final nextLastUpdated = identical(lastUpdated, _notSpecified)
+        ? this.lastUpdated
+        : lastUpdated as DateTime?;
+    final nextDays =
+        days ??
+        (nextIsLoading == this.isLoading &&
+                nextError == this.error &&
+                nextLastUpdated == this.lastUpdated
+            ? this.days
+            : this.days
+                  .map(
+                    (day) => day.copyWith(
+                      isLoading: nextIsLoading,
+                      error: nextError,
+                      lastUpdated: nextLastUpdated,
+                    ),
+                  )
+                  .toList(growable: false));
+    return CanteenWeekRenderState(
+      weekStart: weekStart,
+      menus: menus ?? this.menus,
+      days: nextDays,
+      contentDays: contentDays ?? this.contentDays,
+      isLoading: nextIsLoading,
+      error: nextError,
+      lastUpdated: nextLastUpdated,
+    );
+  }
+}
+
+bool _sameMeals(List<Meal> first, List<Meal> second) {
+  if (identical(first, second)) return true;
+  if (first.length != second.length) return false;
+  for (var index = 0; index < first.length; index++) {
+    if (!identical(first[index], second[index])) return false;
+  }
+  return true;
+}
+
+/// The exact selection a day widget needs from the view model.
+class CanteenDayContentState {
+  final CanteenDayRenderState day;
+  final CanteenFilter filter;
+  final List<Meal> meals;
+
+  const CanteenDayContentState({
+    required this.day,
+    required this.filter,
+    required this.meals,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! CanteenDayContentState ||
+        other.filter != filter ||
+        !identical(other.meals, meals)) {
+      return false;
+    }
+
+    final otherDay = other.day;
+    final hasVisibleMeals = meals.isNotEmpty;
+    return otherDay.date == day.date &&
+        otherDay.hasWeekData == day.hasWeekData &&
+        (hasVisibleMeals || otherDay.isLoading == day.isLoading) &&
+        (hasVisibleMeals || otherDay.error == day.error) &&
+        (hasVisibleMeals || otherDay.lastUpdated == day.lastUpdated);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    day.date,
+    day.hasWeekData,
+    meals.isNotEmpty ? null : day.isLoading,
+    meals.isNotEmpty ? null : day.error,
+    meals.isNotEmpty ? null : day.lastUpdated,
+    filter,
+    identityHashCode(meals),
+  );
+}

--- a/lib/canteen/ui/viewmodels/canteen_view_model.dart
+++ b/lib/canteen/ui/viewmodels/canteen_view_model.dart
@@ -120,8 +120,11 @@ class CanteenViewModel extends BaseViewModel {
   }
 
   List<Meal> mealsForDay(DateTime weekStart, DateTime date) {
+    final normalizedWeekStart = weekStartFor(weekStart);
     final normalizedDate = toStartOfDay(date);
-    final day = _weeklyRenderStates[weekStart]?.dayFor(normalizedDate);
+    final day = _weeklyRenderStates[normalizedWeekStart]?.dayFor(
+      normalizedDate,
+    );
     if (day == null) return const <Meal>[];
 
     final mealsByFilter = _filteredMealsCache.putIfAbsent(
@@ -460,10 +463,11 @@ class CanteenViewModel extends BaseViewModel {
   }
 
   void _setWeekLoading(DateTime weekStart, {required bool isLoading}) {
-    final current =
-        _weeklyRenderStates[weekStart] ??
-        CanteenWeekRenderState.empty(weekStart, isLoading: isLoading);
-    _setWeekState(weekStart, current.copyWith(isLoading: isLoading));
+    final current = _weeklyRenderStates[weekStart];
+    final next = current == null
+        ? CanteenWeekRenderState.empty(weekStart, isLoading: isLoading)
+        : current.copyWith(isLoading: isLoading);
+    _setWeekState(weekStart, next);
   }
 
   void _setWeekState(DateTime weekStart, CanteenWeekRenderState state) {

--- a/lib/canteen/ui/viewmodels/canteen_view_model.dart
+++ b/lib/canteen/ui/viewmodels/canteen_view_model.dart
@@ -8,11 +8,13 @@ import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/appstart/performance_fixture_mode.dart';
 import 'package:dualmate/common/ui/viewmodels/base_view_model.dart';
 import 'package:dualmate/common/util/date_utils.dart';
+import 'package:dualmate/canteen/ui/viewmodels/canteen_render_state.dart';
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 
 class CanteenViewModel extends BaseViewModel {
+  static const String weekStateProperty = 'weekState';
   static const Duration defaultStaleAfter = Duration(hours: 2);
   static const Duration _adjacentPrefetchDebounceDelay = Duration(
     milliseconds: 250,
@@ -24,16 +26,15 @@ class CanteenViewModel extends BaseViewModel {
   final DateTime todayWeekStart;
   CanteenFilter filter = CanteenFilter.all;
 
-  final Map<DateTime, List<DailyMenu>> _weeklyMenus = {};
-  final Map<DateTime, String?> _weekErrors = {};
+  final Map<DateTime, CanteenWeekRenderState> _weeklyRenderStates = {};
   final Map<DateTime, int> _loadingWeeks = {};
-  final Map<DateTime, DateTime> _weekLastUpdated = {};
   final Map<DateTime, DateTime> _weekLastRefreshRequestAt = {};
+  final Map<DateTime, Map<CanteenFilter, List<Meal>>> _filteredMealsCache = {};
   bool _initialized = false;
   Timer? _adjacentPrefetchDebounceTimer;
   DateTime? _lastAdjacentPrefetchCenterWeekStart;
   List<DateTime> _visibleContentDaysCache = const <DateTime>[];
-  bool _visibleContentDaysDirty = true;
+  final Set<DateTime> _visibleContentDaySet = <DateTime>{};
   CanteenLocation _selectedLocation = CanteenLocations.defaultLocation;
   int _locationGeneration = 0;
   CanteenMenuUpdatedCallback? _menuUpdatedCallback;
@@ -64,7 +65,7 @@ class CanteenViewModel extends BaseViewModel {
 
     unawaited(_loadSelectedLocation());
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_weeklyMenus.containsKey(todayWeekStart)) return;
+      if (_weeklyRenderStates.containsKey(todayWeekStart)) return;
       primeVisibleWeek(todayWeekStart);
     });
   }
@@ -95,23 +96,23 @@ class CanteenViewModel extends BaseViewModel {
   }
 
   List<DailyMenu> weeklyMenusFor(DateTime weekStart) {
-    return _weeklyMenus[weekStart] ?? [];
+    return _weeklyRenderStates[weekStart]?.menus ?? const <DailyMenu>[];
   }
 
   bool hasWeekData(DateTime weekStart) {
-    return _weeklyMenus.containsKey(weekStart);
+    return _weeklyRenderStates.containsKey(weekStart);
   }
 
   bool isLoadingWeek(DateTime weekStart) {
-    return _loadingWeeks.containsKey(weekStart);
+    return _weeklyRenderStates[weekStart]?.isLoading ?? false;
   }
 
   String? errorForWeek(DateTime weekStart) {
-    return _weekErrors[weekStart];
+    return _weeklyRenderStates[weekStart]?.error;
   }
 
   DateTime? lastUpdatedForWeek(DateTime weekStart) {
-    return _weekLastUpdated[weekStart];
+    return _weeklyRenderStates[weekStart]?.lastUpdated;
   }
 
   DateTime weekStartFor(DateTime date) {
@@ -119,12 +120,36 @@ class CanteenViewModel extends BaseViewModel {
   }
 
   List<Meal> mealsForDay(DateTime weekStart, DateTime date) {
-    var menu = weeklyMenusFor(weekStart).firstWhere(
-      (entry) => isAtSameDay(entry.date, date),
-      orElse: () => DailyMenu(date: date, meals: []),
-    );
+    final normalizedDate = toStartOfDay(date);
+    final day = _weeklyRenderStates[weekStart]?.dayFor(normalizedDate);
+    if (day == null) return const <Meal>[];
 
-    return menu.meals.where(filter.allowsMeal).toList();
+    final mealsByFilter = _filteredMealsCache.putIfAbsent(
+      normalizedDate,
+      () => <CanteenFilter, List<Meal>>{},
+    );
+    return mealsByFilter.putIfAbsent(
+      filter,
+      () => List<Meal>.unmodifiable(day.meals.where(filter.allowsMeal)),
+    );
+  }
+
+  CanteenDayRenderState dayRenderStateFor(DateTime date) {
+    final weekStart = weekStartFor(date);
+    return _weeklyRenderStates[weekStart]?.dayFor(date) ??
+        CanteenDayRenderState.empty(date);
+  }
+
+  CanteenDayContentState dayContentStateFor(DateTime date) {
+    return CanteenDayContentState(
+      day: dayRenderStateFor(date),
+      filter: filter,
+      meals: mealsForDay(weekStartFor(date), date),
+    );
+  }
+
+  List<DateTime> contentDaysForWeek(DateTime weekStart) {
+    return _weeklyRenderStates[weekStart]?.contentDays ?? const <DateTime>[];
   }
 
   List<Meal> mealsForDate(DateTime date) {
@@ -132,24 +157,7 @@ class CanteenViewModel extends BaseViewModel {
   }
 
   List<DateTime> get visibleContentDays {
-    if (!_visibleContentDaysDirty) {
-      return List.unmodifiable(_visibleContentDaysCache);
-    }
-
-    final days = <DateTime>{};
-
-    for (final weeklyMenus in _weeklyMenus.values) {
-      for (final menu in weeklyMenus) {
-        if (menu.meals.isEmpty) continue;
-        days.add(toStartOfDay(menu.date));
-      }
-    }
-
-    final sortedDays = days.toList();
-    sortedDays.sort((a, b) => a.compareTo(b));
-    _visibleContentDaysCache = List.unmodifiable(sortedDays);
-    _visibleContentDaysDirty = false;
-    return List.unmodifiable(_visibleContentDaysCache);
+    return _visibleContentDaysCache;
   }
 
   DateTime? nearestVisibleContentDay(
@@ -188,12 +196,19 @@ class CanteenViewModel extends BaseViewModel {
       args: {'isForcedRefresh': forceRefresh, 'sourceType': 'unknown'},
       action: (_) async {
         final requestGeneration = _locationGeneration;
+        final hadWeekDataBeforeLoad = _weeklyRenderStates.containsKey(
+          weekStart,
+        );
+        final hadContentBeforeLoad = _hasWeekContent(weekStart);
         _loadingWeeks[weekStart] = requestGeneration;
-        notifyIfMounted("loadingWeeks");
+        _setWeekLoading(weekStart, isLoading: true);
+        if (!hadContentBeforeLoad) {
+          notifyIfMounted(weekStateProperty);
+        }
 
         try {
           final shouldReloadFromDatabase =
-              forceRefresh || !_weeklyMenus.containsKey(weekStart);
+              forceRefresh || !hadWeekDataBeforeLoad;
 
           if (shouldReloadFromDatabase) {
             final cachedMenusFuture = PerformanceTelemetry.instance.measureTask(
@@ -213,9 +228,13 @@ class CanteenViewModel extends BaseViewModel {
             var lastUpdated = await lastUpdatedFuture;
             if (!_isCurrentLocationRequest(requestGeneration)) return;
             if (lastUpdated != null) {
-              _weekLastUpdated[weekStart] = lastUpdated;
+              _setWeekState(
+                weekStart,
+                _weeklyRenderStates[weekStart]!.copyWith(
+                  lastUpdated: lastUpdated,
+                ),
+              );
             }
-            notifyIfMounted("weeklyMenus");
           }
 
           if (allowNetworkRefresh) {
@@ -243,21 +262,31 @@ class CanteenViewModel extends BaseViewModel {
               );
               if (!_isCurrentLocationRequest(requestGeneration)) return;
               _applyMenusForWeek(weekStart, menus);
-              _weekErrors[weekStart] = null;
-              _weekLastUpdated[weekStart] = DateTime.now();
+              _setWeekState(
+                weekStart,
+                _weeklyRenderStates[weekStart]!.copyWith(
+                  error: null,
+                  lastUpdated: DateTime.now(),
+                ),
+              );
             } catch (exception) {
               if (!_isCurrentLocationRequest(requestGeneration)) return;
               // keep cached data visible
-              _weekErrors[weekStart] = exception.toString();
+              final current =
+                  _weeklyRenderStates[weekStart] ??
+                  CanteenWeekRenderState.empty(weekStart);
+              _setWeekState(
+                weekStart,
+                current.copyWith(error: exception.toString()),
+              );
             }
           }
         } finally {
           if (_loadingWeeks[weekStart] == requestGeneration) {
             _loadingWeeks.remove(weekStart);
+            _setWeekLoading(weekStart, isLoading: false);
+            notifyIfMounted(weekStateProperty);
           }
-          notifyIfMounted("weeklyMenus");
-          notifyIfMounted("weekErrors");
-          notifyIfMounted("loadingWeeks");
         }
       },
     );
@@ -269,7 +298,7 @@ class CanteenViewModel extends BaseViewModel {
     bool prefetchNextWeek = true,
     Duration staleAfter = defaultStaleAfter,
   }) {
-    if (_weeklyMenus.containsKey(weekStart) ||
+    if (_weeklyRenderStates.containsKey(weekStart) ||
         _loadingWeeks.containsKey(weekStart)) {
       return;
     }
@@ -367,9 +396,7 @@ class CanteenViewModel extends BaseViewModel {
     notifyIfMounted("filter");
   }
 
-  Future<void> reloadSelectedLocation({
-    bool allowNetworkRefresh = true,
-  }) async {
+  Future<void> reloadSelectedLocation({bool allowNetworkRefresh = true}) async {
     await _loadSelectedLocation(
       reloadWeek: true,
       allowNetworkRefresh: allowNetworkRefresh,
@@ -385,11 +412,12 @@ class CanteenViewModel extends BaseViewModel {
     if (!_isCurrentLocationRequest(requestGeneration)) return;
     var weekStart = toStartOfDay(toMonday(start));
     _applyMenusForWeek(weekStart, menus);
-    _weekLastUpdated[weekStart] = DateTime.now();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!_isCurrentLocationRequest(requestGeneration)) return;
-      notifyIfMounted("weeklyMenus");
-    });
+    final current = _weeklyRenderStates[weekStart];
+    if (current == null) return;
+    _setWeekState(weekStart, current.copyWith(lastUpdated: DateTime.now()));
+    if (!_loadingWeeks.containsKey(weekStart)) {
+      notifyIfMounted(weekStateProperty);
+    }
   }
 
   void _registerMenuUpdatedCallback() {
@@ -406,19 +434,55 @@ class CanteenViewModel extends BaseViewModel {
     _provider.addMenuUpdatedCallback(_menuUpdatedCallback!);
   }
 
-  void _markVisibleContentDaysDirty() {
-    _visibleContentDaysDirty = true;
-  }
-
   void _applyMenusForWeek(DateTime weekStart, List<DailyMenu> menus) {
     PerformanceTelemetry.instance.measureSync(
       'canteen.state.apply',
       args: {'entryCount': menus.length, 'sourceType': 'unknown'},
       action: (_) {
-        _weeklyMenus[weekStart] = menus;
-        _markVisibleContentDaysDirty();
+        final previous = _weeklyRenderStates[weekStart];
+        if (previous != null) {
+          _visibleContentDaySet.removeAll(previous.contentDays);
+          _invalidateFilteredMeals(previous);
+        }
+        final current = CanteenWeekRenderState.fromMenus(
+          weekStart,
+          menus,
+          previous: previous,
+          isLoading: previous?.isLoading ?? false,
+          error: previous?.error,
+          lastUpdated: previous?.lastUpdated,
+        );
+        _setWeekState(weekStart, current);
+        _visibleContentDaySet.addAll(current.contentDays);
+        _updateVisibleContentDaysCache();
       },
     );
+  }
+
+  void _setWeekLoading(DateTime weekStart, {required bool isLoading}) {
+    final current =
+        _weeklyRenderStates[weekStart] ??
+        CanteenWeekRenderState.empty(weekStart, isLoading: isLoading);
+    _setWeekState(weekStart, current.copyWith(isLoading: isLoading));
+  }
+
+  void _setWeekState(DateTime weekStart, CanteenWeekRenderState state) {
+    _weeklyRenderStates[weekStart] = state;
+  }
+
+  bool _hasWeekContent(DateTime weekStart) {
+    return _weeklyRenderStates[weekStart]?.contentDays.isNotEmpty ?? false;
+  }
+
+  void _invalidateFilteredMeals(CanteenWeekRenderState state) {
+    for (final day in state.days) {
+      _filteredMealsCache.remove(day.date);
+    }
+  }
+
+  void _updateVisibleContentDaysCache() {
+    final sortedDays = _visibleContentDaySet.toList()..sort();
+    _visibleContentDaysCache = List<DateTime>.unmodifiable(sortedDays);
   }
 
   bool _isCurrentLocationRequest(int requestGeneration) {
@@ -438,16 +502,15 @@ class CanteenViewModel extends BaseViewModel {
       return;
     }
 
-    _weeklyMenus.clear();
-    _weekErrors.clear();
+    _weeklyRenderStates.clear();
     _loadingWeeks.clear();
-    _weekLastUpdated.clear();
     _weekLastRefreshRequestAt.clear();
     _locationGeneration++;
     _registerMenuUpdatedCallback();
-    _markVisibleContentDaysDirty();
-    notifyIfMounted('weeklyMenus');
-    notifyIfMounted('loadingWeeks');
+    _filteredMealsCache.clear();
+    _visibleContentDaySet.clear();
+    _visibleContentDaysCache = const <DateTime>[];
+    notifyIfMounted(weekStateProperty);
     unawaited(
       loadWeek(
         todayWeekStart,

--- a/test/canteen/ui/canteen_page_bounds_test.dart
+++ b/test/canteen/ui/canteen_page_bounds_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dualmate/canteen/business/canteen_provider.dart';
 import 'package:dualmate/canteen/data/canteen_meal_repository.dart';
 import 'package:dualmate/canteen/model/daily_menu.dart';
@@ -142,6 +144,103 @@ void main() {
     expect(delegate.childCount, 2);
   });
 
+  testWidgets('keeps the pager mounted while loading becomes content', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    final today = _normalizeToWeekday(now);
+    final weekStart = toStartOfDay(toMonday(today));
+    final cacheGate = Completer<void>();
+    final provider = _FakeCanteenProvider({
+      weekStart: _buildWeekMenusWithSingleDayMeal(weekStart, today),
+    }, cacheGate: cacheGate);
+    final viewModel = CanteenViewModel(provider, TestCanteenLocationService());
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await tester.pump(const Duration(milliseconds: 260));
+    await tester.pump();
+
+    final pageViewFinder = find.byKey(
+      const ValueKey<String>('canteen_page_view'),
+    );
+    final pageViewElement = tester.element(pageViewFinder);
+    expect(
+      find.byKey(const ValueKey<String>('canteen_page_view')),
+      findsOneWidget,
+    );
+    expect(
+      find.byWidgetPredicate((widget) {
+        final key = widget.key;
+        return key is ValueKey<String> &&
+            key.value.startsWith('canteen_state_loading_');
+      }),
+      findsWidgets,
+    );
+
+    cacheGate.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 160));
+
+    expect(tester.element(pageViewFinder), same(pageViewElement));
+    expect(
+      find
+          .descendant(
+            of: find.byType(CanteenPage),
+            matching: find.byType(Scrollable),
+          )
+          .evaluate()
+          .length,
+      2,
+    );
+    expect(
+      find.byWidgetPredicate((widget) {
+        final key = widget.key;
+        return key is ValueKey<String> &&
+            key.value.startsWith('canteen_state_loading_');
+      }),
+      findsWidgets,
+    );
+    expect(
+      find.byWidgetPredicate((widget) {
+        final key = widget.key;
+        return key is ValueKey<String> &&
+            key.value.startsWith('canteen_state_ready_');
+      }),
+      findsWidgets,
+    );
+    await tester.pump(const Duration(milliseconds: 220));
+    expect(find.text(_mealNameFor(today)), findsOneWidget);
+  });
+
+  testWidgets('does not keep the previous day content after a pager swipe', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    final today = _normalizeToWeekday(now);
+    final tomorrow = today.add(const Duration(days: 1));
+    final weekStart = toStartOfDay(toMonday(today));
+    final provider = _FakeCanteenProvider({
+      weekStart: _buildWeekMenusWithMealDays(weekStart, {today, tomorrow}),
+    });
+    final viewModel = CanteenViewModel(provider, TestCanteenLocationService());
+    addTearDown(viewModel.dispose);
+    await viewModel.loadWeek(weekStart, allowNetworkRefresh: false);
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+    await _pumpFor(tester, const Duration(milliseconds: 700));
+    final pageRect = tester.getRect(
+      find.byKey(const ValueKey<String>('canteen_page_view')),
+    );
+    expect(_hasVisibleText(tester, _mealNameFor(today), pageRect), isTrue);
+
+    await tester.fling(find.byType(PageView), const Offset(-600, 0), 1400);
+    await _pumpFor(tester, const Duration(milliseconds: 600));
+
+    expect(_hasVisibleText(tester, _mealNameFor(tomorrow), pageRect), isTrue);
+    expect(_hasVisibleText(tester, _mealNameFor(today), pageRect), isFalse);
+  });
+
   test('defers page sync while pager is transitioning or scrolling', () {
     expect(
       shouldDeferCanteenPageSync(
@@ -255,23 +354,26 @@ void main() {
     );
   });
 
-  test('keeps the page-content mode key stable for paged content', () {
-    final monday = DateTime(2026, 2, 9);
-    final tuesday = monday.add(const Duration(days: 1));
+  test(
+    'keeps the page-content mode key stable from loading through paging',
+    () {
+      final monday = DateTime(2026, 2, 9);
+      final tuesday = monday.add(const Duration(days: 1));
 
-    expect(
-      canteenPageContentModeKey(const <DateTime>[]),
-      'canteen_page_content_single',
-    );
-    expect(
-      canteenPageContentModeKey(<DateTime>[monday]),
-      'canteen_page_content_paged',
-    );
-    expect(
-      canteenPageContentModeKey(<DateTime>[monday, tuesday]),
-      'canteen_page_content_paged',
-    );
-  });
+      expect(
+        canteenPageContentModeKey(const <DateTime>[]),
+        'canteen_page_content',
+      );
+      expect(
+        canteenPageContentModeKey(<DateTime>[monday]),
+        'canteen_page_content',
+      );
+      expect(
+        canteenPageContentModeKey(<DateTime>[monday, tuesday]),
+        'canteen_page_content',
+      );
+    },
+  );
 
   test('finds a canteen day index from its stable key', () {
     final monday = DateTime(2026, 2, 9);
@@ -294,6 +396,16 @@ Future<void> _pumpFor(WidgetTester tester, Duration total) async {
   for (var i = 0; i < iterations; i++) {
     await tester.pump(step);
   }
+}
+
+bool _hasVisibleText(WidgetTester tester, String text, Rect viewport) {
+  for (final element in find.text(text).evaluate()) {
+    final renderObject = element.renderObject;
+    if (renderObject is! RenderBox || !renderObject.hasSize) continue;
+    final rect = renderObject.localToGlobal(Offset.zero) & renderObject.size;
+    if (!rect.intersect(viewport).isEmpty) return true;
+  }
+  return false;
 }
 
 Widget _wrapWithApp(CanteenViewModel viewModel) {
@@ -369,15 +481,19 @@ class _FakeCanteenProvider extends CanteenProvider {
   final Map<DateTime, List<DailyMenu>> _menusByWeek;
   final List<CanteenMenuUpdatedCallback> _callbacks = [];
   final bool cacheOnlyKnownWeeks;
+  final Completer<void>? cacheGate;
   final Set<DateTime> _cachedWeeks = <DateTime>{};
 
-  _FakeCanteenProvider(this._menusByWeek, {this.cacheOnlyKnownWeeks = false})
-    : super(
-        CanteenMealRepository(_FakeDatabaseAccess()),
-        TestCanteenLocationService(),
-        CanteenScraper(),
-        DhbwAppCanteenSource(),
-      );
+  _FakeCanteenProvider(
+    this._menusByWeek, {
+    this.cacheOnlyKnownWeeks = false,
+    this.cacheGate,
+  }) : super(
+         CanteenMealRepository(_FakeDatabaseAccess()),
+         TestCanteenLocationService(),
+         CanteenScraper(),
+         DhbwAppCanteenSource(),
+       );
 
   @override
   void addMenuUpdatedCallback(CanteenMenuUpdatedCallback callback) {
@@ -391,6 +507,7 @@ class _FakeCanteenProvider extends CanteenProvider {
 
   @override
   Future<List<DailyMenu>> getCachedWeek(DateTime date) async {
+    await cacheGate?.future;
     final weekStart = toStartOfDay(toMonday(date));
     if (cacheOnlyKnownWeeks && !_cachedWeeks.contains(weekStart)) {
       return _emptyWeek(weekStart);

--- a/test/canteen/ui/viewmodels/canteen_render_state_test.dart
+++ b/test/canteen/ui/viewmodels/canteen_render_state_test.dart
@@ -6,6 +6,7 @@ import 'package:dualmate/canteen/model/meal.dart';
 import 'package:dualmate/canteen/model/meal_type.dart';
 import 'package:dualmate/canteen/service/canteen_scraper.dart';
 import 'package:dualmate/canteen/service/dhbw_app_canteen_source.dart';
+import 'package:dualmate/canteen/ui/viewmodels/canteen_render_state.dart';
 import 'package:dualmate/canteen/ui/viewmodels/canteen_view_model.dart';
 import 'package:dualmate/common/data/database_access.dart';
 import 'package:dualmate/common/util/cancellation_token.dart';
@@ -37,6 +38,16 @@ void main() {
       final allMeals = model.mealsForDay(weekStart, weekStart);
       expect(
         identical(allMeals, model.mealsForDay(weekStart, weekStart)),
+        isTrue,
+      );
+      expect(
+        identical(
+          allMeals,
+          model.mealsForDay(
+            weekStart.add(const Duration(hours: 12)),
+            weekStart,
+          ),
+        ),
         isTrue,
       );
 
@@ -91,6 +102,157 @@ void main() {
     );
     expect(model.contentDaysForWeek(weekStart), <DateTime>[weekStart]);
   });
+
+  test('day render-state equality uses meal-list identity', () {
+    final date = DateTime(2026, 7, 13);
+    final meal = _meal(date, 'meal');
+    final meals = <Meal>[meal];
+    final first = CanteenDayRenderState(
+      date: date,
+      meals: meals,
+      hasWeekData: true,
+      isLoading: false,
+      error: null,
+      lastUpdated: null,
+    );
+    final sameIdentity = CanteenDayRenderState(
+      date: date,
+      meals: meals,
+      hasWeekData: true,
+      isLoading: false,
+      error: null,
+      lastUpdated: null,
+    );
+    final copiedList = CanteenDayRenderState(
+      date: date,
+      meals: <Meal>[meal],
+      hasWeekData: true,
+      isLoading: false,
+      error: null,
+      lastUpdated: null,
+    );
+
+    expect(first, sameIdentity);
+    expect(first.hashCode, sameIdentity.hashCode);
+    expect(first, isNot(copiedList));
+  });
+
+  test('week snapshots reuse meals and propagate status changes', () {
+    final weekStart = DateTime(2026, 7, 13);
+    final meal = _meal(weekStart, 'meal');
+    final first = CanteenWeekRenderState.fromMenus(weekStart, <DailyMenu>[
+      DailyMenu(date: weekStart, meals: <Meal>[meal]),
+    ]);
+    final refreshed = CanteenWeekRenderState.fromMenus(weekStart, <DailyMenu>[
+      DailyMenu(date: weekStart, meals: <Meal>[meal]),
+    ], previous: first);
+
+    expect(
+      identical(
+        first.dayFor(weekStart)!.meals,
+        refreshed.dayFor(weekStart)!.meals,
+      ),
+      isTrue,
+    );
+
+    final updatedAt = DateTime(2026, 7, 13, 12);
+    final loading = first.copyWith(
+      isLoading: true,
+      error: 'offline',
+      lastUpdated: updatedAt,
+    );
+    expect(loading.isLoading, isTrue);
+    expect(loading.error, 'offline');
+    expect(loading.lastUpdated, updatedAt);
+    for (final day in loading.days) {
+      expect(day.isLoading, isTrue);
+      expect(day.error, 'offline');
+      expect(day.lastUpdated, updatedAt);
+    }
+
+    final unchanged = loading.copyWith();
+    expect(unchanged.error, 'offline');
+    expect(unchanged.lastUpdated, updatedAt);
+
+    final cleared = loading.copyWith(error: null, lastUpdated: null);
+    expect(cleared.error, isNull);
+    expect(cleared.lastUpdated, isNull);
+    expect(cleared.days.every((day) => day.error == null), isTrue);
+    expect(cleared.days.every((day) => day.lastUpdated == null), isTrue);
+
+    expect(() => first.copyWith(menus: first.menus), throwsAssertionError);
+  });
+
+  test('day content equality ignores hidden status when meals are visible', () {
+    final date = DateTime(2026, 7, 13);
+    final meals = <Meal>[_meal(date, 'meal')];
+    final visible = CanteenDayContentState(
+      day: CanteenDayRenderState(
+        date: date,
+        meals: meals,
+        hasWeekData: true,
+        isLoading: false,
+        error: null,
+        lastUpdated: null,
+      ),
+      filter: CanteenFilter.all,
+      meals: meals,
+    );
+    final visibleWithBackgroundStatus = CanteenDayContentState(
+      day: CanteenDayRenderState(
+        date: date,
+        meals: meals,
+        hasWeekData: true,
+        isLoading: true,
+        error: 'offline',
+        lastUpdated: DateTime(2026, 7, 13, 12),
+      ),
+      filter: CanteenFilter.all,
+      meals: meals,
+    );
+
+    expect(visible, visibleWithBackgroundStatus);
+    expect(visible.hashCode, visibleWithBackgroundStatus.hashCode);
+
+    final emptyMeals = <Meal>[];
+    final empty = CanteenDayContentState(
+      day: CanteenDayRenderState(
+        date: date,
+        meals: emptyMeals,
+        hasWeekData: true,
+        isLoading: false,
+        error: null,
+        lastUpdated: null,
+      ),
+      filter: CanteenFilter.all,
+      meals: emptyMeals,
+    );
+    final emptyLoading = CanteenDayContentState(
+      day: CanteenDayRenderState(
+        date: date,
+        meals: emptyMeals,
+        hasWeekData: true,
+        isLoading: true,
+        error: null,
+        lastUpdated: null,
+      ),
+      filter: CanteenFilter.all,
+      meals: emptyMeals,
+    );
+
+    expect(empty, isNot(emptyLoading));
+  });
+}
+
+Meal _meal(DateTime date, String name) {
+  return Meal(
+    date: date,
+    name: name,
+    category: 'Main dish',
+    price: 3.5,
+    notes: const [],
+    mealTypes: const [MealType.vegan],
+  );
 }
 
 List<DailyMenu> _menusForWeek(DateTime weekStart, {String mealPrefix = ''}) {

--- a/test/canteen/ui/viewmodels/canteen_render_state_test.dart
+++ b/test/canteen/ui/viewmodels/canteen_render_state_test.dart
@@ -1,0 +1,183 @@
+import 'package:dualmate/canteen/business/canteen_provider.dart';
+import 'package:dualmate/canteen/data/canteen_meal_repository.dart';
+import 'package:dualmate/canteen/model/canteen_filter.dart';
+import 'package:dualmate/canteen/model/daily_menu.dart';
+import 'package:dualmate/canteen/model/meal.dart';
+import 'package:dualmate/canteen/model/meal_type.dart';
+import 'package:dualmate/canteen/service/canteen_scraper.dart';
+import 'package:dualmate/canteen/service/dhbw_app_canteen_source.dart';
+import 'package:dualmate/canteen/ui/viewmodels/canteen_view_model.dart';
+import 'package:dualmate/common/data/database_access.dart';
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/common/util/date_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../test_canteen_location_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'caches filtered meals per day and invalidates replaced week data',
+    () async {
+      final weekStart = DateTime(2026, 7, 13);
+      final provider = _RenderStateProvider(_menusForWeek(weekStart));
+      final model = CanteenViewModel(provider, TestCanteenLocationService());
+      addTearDown(model.dispose);
+      var weekStateNotifications = 0;
+      model.addListener((String? property) {
+        if (property == CanteenViewModel.weekStateProperty) {
+          weekStateNotifications++;
+        }
+      }, const [CanteenViewModel.weekStateProperty]);
+
+      await model.loadWeek(weekStart, allowNetworkRefresh: false);
+      expect(weekStateNotifications, 2);
+
+      final allMeals = model.mealsForDay(weekStart, weekStart);
+      expect(
+        identical(allMeals, model.mealsForDay(weekStart, weekStart)),
+        isTrue,
+      );
+
+      model.setFilter(CanteenFilter.vegan);
+      final veganMeals = model.mealsForDay(weekStart, weekStart);
+      expect(veganMeals.map((meal) => meal.name), <String>['vegan meal']);
+      expect(
+        identical(veganMeals, model.mealsForDay(weekStart, weekStart)),
+        isTrue,
+      );
+
+      model.setFilter(CanteenFilter.all);
+      expect(
+        identical(allMeals, model.mealsForDay(weekStart, weekStart)),
+        isTrue,
+      );
+
+      provider.menus = _menusForWeek(weekStart, mealPrefix: 'Replacement');
+      await model.loadWeek(
+        weekStart,
+        forceRefresh: true,
+        allowNetworkRefresh: false,
+      );
+
+      final replacementMeals = model.mealsForDay(weekStart, weekStart);
+      expect(replacementMeals.map((meal) => meal.name), <String>[
+        'Replacement pork meal',
+        'Replacement vegan meal',
+      ]);
+      expect(identical(allMeals, replacementMeals), isFalse);
+      expect(
+        identical(model.visibleContentDays, model.visibleContentDays),
+        isTrue,
+      );
+    },
+  );
+
+  test('exposes immutable weekly render data', () async {
+    final weekStart = DateTime(2026, 7, 13);
+    final model = CanteenViewModel(
+      _RenderStateProvider(_menusForWeek(weekStart)),
+      TestCanteenLocationService(),
+    );
+    addTearDown(model.dispose);
+
+    await model.loadWeek(weekStart, allowNetworkRefresh: false);
+
+    final menus = model.weeklyMenusFor(weekStart);
+    expect(
+      () => menus.add(DailyMenu(date: weekStart, meals: const [])),
+      throwsUnsupportedError,
+    );
+    expect(model.contentDaysForWeek(weekStart), <DateTime>[weekStart]);
+  });
+}
+
+List<DailyMenu> _menusForWeek(DateTime weekStart, {String mealPrefix = ''}) {
+  final day = toStartOfDay(weekStart);
+  final prefix = mealPrefix.isEmpty ? '' : '$mealPrefix ';
+  return List<DailyMenu>.generate(5, (index) {
+    final date = day.add(Duration(days: index));
+    if (index != 0) return DailyMenu(date: date, meals: const []);
+    return DailyMenu(
+      date: date,
+      meals: <Meal>[
+        Meal(
+          date: date,
+          name: '${prefix}pork meal',
+          category: 'Main dish',
+          price: 3.5,
+          notes: const [],
+          mealTypes: const [MealType.pork],
+        ),
+        Meal(
+          date: date,
+          name: '${prefix}vegan meal',
+          category: 'Main dish',
+          price: 3.5,
+          notes: const [],
+          mealTypes: const [MealType.vegan],
+        ),
+      ],
+    );
+  });
+}
+
+class _RenderStateProvider extends CanteenProvider {
+  List<DailyMenu> menus;
+
+  _RenderStateProvider(this.menus)
+    : super(
+        CanteenMealRepository(_EmptyDatabaseAccess()),
+        TestCanteenLocationService(),
+        CanteenScraper(),
+        DhbwAppCanteenSource(),
+      );
+
+  @override
+  Future<List<DailyMenu>> getCachedWeek(DateTime date) async => menus;
+
+  @override
+  Future<List<DailyMenu>> refreshWeek(
+    DateTime date, [
+    CancellationToken? cancellationToken,
+  ]) async => menus;
+
+  @override
+  Future<DateTime?> lastUpdatedForWeek(DateTime date) async => null;
+}
+
+class _EmptyDatabaseAccess extends DatabaseAccess {
+  @override
+  Future<List<Map<String, dynamic>>> queryRows(
+    String table, {
+    bool? distinct,
+    List<String>? columns,
+    String? where,
+    List<dynamic>? whereArgs,
+    String? groupBy,
+    String? having,
+    String? orderBy,
+    int? limit,
+    int? offset,
+  }) async => <Map<String, dynamic>>[];
+
+  @override
+  Future<List<Map<String, dynamic>>> rawQuery(
+    String sql,
+    List<dynamic> parameters,
+  ) async => <Map<String, dynamic>>[];
+
+  @override
+  Future<void> insertBatch(
+    String table,
+    List<Map<String, dynamic>> rows,
+  ) async {}
+
+  @override
+  Future<int> deleteWhere(
+    String table, {
+    String? where,
+    List<dynamic>? whereArgs,
+  }) async => 0;
+}


### PR DESCRIPTION
## Summary

- keep one stable Canteen `PageView` and one scrollable day list mounted from loading through ready content
- cache immutable per-week/day render state and filtered meal lists
- scope rebuilds to the header, filter, pager, and affected day
- preserve the 320 ms fade/slide transition at item level without overlapping two full scrollable trees
- defer offstage loading-to-ready transitions until `TickerMode` is active
- coalesce week-state notifications and retain offline fixture behavior

## Pixel 8 Pro results

Profile mode, 120 Hz, 1.0x animations, deterministic offline fixtures:

- prior drawer-to-Canteen baseline: ~25.5% frames over 8.33 ms, 56.0 ms worst
- optimized three-run median: 15.0%
- final exact-code confirmation: 14.29%, 47.3 ms worst
- repeated settled Canteen interaction: 0% over 8.33 ms
- all Canteen animation/progression checks passed

## Validation

- full `flutter analyze`
- `flutter test test/canteen` — 56 tests passed
- three-run Pixel diagnostic profile
- final post-hardening Pixel diagnostic profile

Documentation: `docs/solutions/performance/canteen-stable-render-shell-20260712.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved canteen day transitions with smoother slide and fade animations.
  * Added clearer loading, empty, error, and refresh states for meal lists.
  * Preserved the canteen page while content loads, reducing visual disruption.
  * Improved day navigation and synchronization across adjacent dates.
  * Added more consistent filtering and refresh behavior.

* **Bug Fixes**
  * Fixed stale day content appearing after navigating to another day.
  * Improved handling of cached meals and loading failures while retaining available content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->