### PR TITLE
Render Dualis tables lazily

### DIFF
--- a/docs/solutions/performance/dualis-lazy-table-rendering-20260712.md
+++ b/docs/solutions/performance/dualis-lazy-table-rendering-20260712.md
@@ -70,6 +70,8 @@ Tests cover:
 - deferred persistence after a frame;
 - persistence when the pager is disposed;
 - rapid-selection coalescing to the latest page;
+- generic pager persistence coverage in the mirrored `test/ui` tree;
+- content-key-only sliver fade restarts and a hittable overview tooltip target;
 - absence of eager `DataTable` trees.
 
 # Pixel 8 Pro results
@@ -108,7 +110,7 @@ meaningful than that percentage.
 # Validation
 
 - full `flutter analyze`;
-- `flutter test test/dualis` — 36 tests passed after final review;
+- `flutter test test/dualis test/ui/pager_widget_test.dart` — 37 tests passed after final review;
 - three-run current-`v2` Pixel control;
 - three-run final-branch Pixel diagnostic;
 - all Dualis final-state, session-restore, and scroll-progression checks passed;

--- a/docs/solutions/performance/dualis-lazy-table-rendering-20260712.md
+++ b/docs/solutions/performance/dualis-lazy-table-rendering-20260712.md
@@ -1,0 +1,115 @@
+---
+title: Keep Dualis tables lazy through first-open and tab transitions
+date: 2026-07-12
+type: fix
+---
+
+# Summary
+
+Dualis overview and exam results rendered every module and exam row inside
+intrinsic `DataTable` trees. On the Pixel 8 Pro at 120 Hz, first-open and tab
+switching therefore combined destination construction, intrinsic measurement,
+and complete table layout in one interaction window.
+
+This change replaces the eager tables with fixed-width lazy slivers while
+preserving the existing page structure, loading placeholders, row grouping,
+text wrapping, refresh behavior, and tab selection semantics.
+
+# Changes
+
+## Lazy overview modules
+
+- Replaced the overview `SingleChildScrollView` and eager `DataTable` with a
+  `CustomScrollView` and lazy `SliverList`.
+- Module rows are built only near the viewport.
+- Column widths are resolved once from the available page width rather than by
+  intrinsic table measurement across every row.
+- Module names retain bounded two-line wrapping and the original 48–72 px row
+  height behavior.
+- The stable `dualis_modules_ready_<count>` key remains available to the
+  performance harness independent of the row implementation.
+
+## Lazy exam results
+
+- Replaced one eager `DataTable` per module with a lazy sequence of module
+  headers and exam rows.
+- Precomputed module start offsets allow direct item-to-module lookup without
+  flattening all row widgets.
+- Preserved module grouping, credits and grade alignment, 45–72 px exam row
+  height, two-line exam names, semester labels, and grade-state text.
+- Localized grade strings are prepared during build from the current
+  localization context, so locale changes cannot leave stale labels.
+
+## Lightweight sliver transitions
+
+- Replaced `AnimatedSwitcher` layouts that retained two complete table trees
+  with a single current sliver tree and a 200/220 ms fade.
+- Sliver content is constructed in `build`, not `initState`, so inherited theme
+  and localization dependencies are valid.
+- Loading placeholders and populated content keep their existing public keys
+  and duration behavior.
+
+## Deferred tab persistence
+
+- Bottom-navigation selection updates immediately.
+- Preference persistence starts after the current frame and coalesces rapid
+  selections to the latest page.
+- A pending write still completes if the pager is disposed before the callback
+  runs.
+
+# Regression coverage
+
+Tests cover:
+
+- lazy construction of distant overview module rows;
+- lazy construction of distant exam rows;
+- long module and exam labels without overflow;
+- loading placeholder to populated content transitions;
+- stable populated-content readiness markers;
+- immediate tab switching;
+- deferred persistence after a frame;
+- persistence when the pager is disposed;
+- rapid-selection coalescing to the latest page;
+- absence of eager `DataTable` trees.
+
+# Pixel 8 Pro results
+
+Device conditions:
+
+- Pixel 8 Pro in profile mode;
+- 120 Hz display;
+- Android animation scales at `1.0`;
+- deterministic offline fixtures;
+- three current-`v2` control runs and three final branch runs.
+
+Median comparison:
+
+| Scenario | Metric | Current `v2` | Final branch |
+| --- | --- | ---: | ---: |
+| Drawer → populated Dualis | frames > 8.33 ms | 23.53% | 22.86% |
+| Drawer → populated Dualis | p95 | 18.79 ms | 16.54 ms |
+| Drawer → populated Dualis | p99 / worst | 36.82 ms | 25.73 ms |
+| Drawer → populated Dualis | frames > 16.67 ms | 3 | 2 |
+| Drawer → populated Dualis | frames > 33 ms | 1 | 0 |
+| Loaded result scroll | p95 | 6.71 ms | 6.84 ms |
+| Loaded result scroll | worst | 8.52 ms | 9.76 ms |
+| Loaded tab switch | median worst | 40.67 ms | 31.22 ms |
+| Loaded tab switch | frames > 33 ms | 1 | 0 |
+
+The result-scroll path remains effectively neutral because the current fixture
+contains a modest number of visible rows. The structural benefit grows with
+larger module and exam datasets because distant rows are no longer constructed
+or intrinsically measured.
+
+The tab-switch scenario contains only five measured frames, so its percentage
+is highly sensitive to one frame. Tail latency and the >33 ms result are more
+meaningful than that percentage.
+
+# Validation
+
+- full `flutter analyze`;
+- `flutter test test/dualis` — 36 tests passed after final review;
+- three-run current-`v2` Pixel control;
+- three-run final-branch Pixel diagnostic;
+- all Dualis final-state, session-restore, and scroll-progression checks passed;
+- no performance thresholds, fixture data, or animation durations were reduced.

--- a/lib/dualis/ui/exam_results_page/exam_results_page.dart
+++ b/lib/dualis/ui/exam_results_page/exam_results_page.dart
@@ -1,7 +1,12 @@
+import 'dart:math' as math;
+
 import 'package:dualmate/common/i18n/localizations.dart';
-import 'package:dualmate/common/util/platform_util.dart';
+import 'package:dualmate/dualis/model/exam.dart';
 import 'package:dualmate/dualis/model/exam_grade.dart';
+import 'package:dualmate/dualis/model/module.dart';
+import 'package:dualmate/dualis/model/semester.dart';
 import 'package:dualmate/dualis/ui/viewmodels/study_grades_view_model.dart';
+import 'package:dualmate/dualis/ui/widgets/dualis_sliver_content_transition.dart';
 import 'package:flutter/material.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 import 'package:provider/provider.dart';
@@ -13,252 +18,428 @@ class ExamResultsPage extends StatelessWidget {
 
     return RefreshIndicator(
       onRefresh: () => viewModel.refreshData(force: true),
-      child: Container(
-        height: double.infinity,
-        child: SingleChildScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          scrollDirection: Axis.vertical,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
-                child: Text(
-                  L.of(context).dualisExamResultsTitle,
-                  style: Theme.of(context).textTheme.titleLarge,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final tableLayout = _ExamTableLayout.fromWidth(constraints.maxWidth);
+
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: <Widget>[
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+                  child: Text(
+                    L.of(context).dualisExamResultsTitle,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: <Widget>[
-                    Text(L.of(context).dualisExamResultsSemesterSelect),
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(24, 0, 0, 0),
-                      child: PropertyChangeConsumer<StudyGradesViewModel, String>(
-                        properties: const [
-                          "currentSemesterName",
-                          "allSemesterNames",
-                        ],
-                        builder: (
-                          BuildContext context,
-                          StudyGradesViewModel? model,
-                          Set<String>? properties,
-                        ) {
-                          if (model == null) return Container();
-                          return DropdownButton<String>(
-                            onChanged: (value) {
-                              if (value != null) {
-                                model.loadSemester(value);
-                              }
-                            },
-                            value: model.currentSemesterName.isEmpty
-                                ? null
-                                : model.currentSemesterName,
-                            items: model.allSemesterNames
-                                .map(
-                                  (n) => DropdownMenuItem<String>(
-                                    child: Text(n),
-                                    value: n,
-                                  ),
-                                )
-                                .toList(),
-                          );
-                        },
-                      ),
-                    )
-                  ],
-                ),
-              ),
+              SliverToBoxAdapter(child: _SemesterSelector()),
               PropertyChangeConsumer<StudyGradesViewModel, String>(
                 properties: const [
-                  "currentSemester",
-                  "isLoadingCurrentSemester",
+                  'currentSemester',
+                  'isLoadingCurrentSemester',
                 ],
-                builder: (
-                  BuildContext context,
-                  StudyGradesViewModel? model,
-                  Set<String>? properties,
-                ) =>
-                    model == null
-                        ? Container()
-                        : buildModulesColumn(context, model),
+                builder:
+                    (
+                      BuildContext context,
+                      StudyGradesViewModel? model,
+                      Set<String>? properties,
+                    ) {
+                      if (model == null) {
+                        return const SliverToBoxAdapter(
+                          child: SizedBox.shrink(),
+                        );
+                      }
+
+                      final showLoading =
+                          model.isLoadingCurrentSemester &&
+                          model.currentSemester.modules.isEmpty;
+                      return DualisSliverContentTransition(
+                        showLoading: showLoading,
+                        contentKey: model.currentSemester,
+                        duration: const Duration(milliseconds: 200),
+                        loadingBuilder: (_) => const SliverToBoxAdapter(
+                          child: _SemesterLoadingPlaceholder(
+                            key: ValueKey<String>('dualis_semester_loading'),
+                          ),
+                        ),
+                        contentBuilder: (context) => _ExamResultsSliver(
+                          data: _ExamResultsRenderData.from(
+                            model.currentSemester,
+                            L.of(context),
+                          ),
+                          tableLayout: tableLayout,
+                        ),
+                      );
+                    },
               ),
             ],
-          ),
-        ),
+          );
+        },
       ),
     );
   }
+}
 
-  Widget buildModulesColumn(
-      BuildContext context, StudyGradesViewModel viewModel) {
-    final showLoading = viewModel.isLoadingCurrentSemester &&
-        viewModel.currentSemester.modules.isEmpty;
-
-    return AnimatedSwitcher(
-      layoutBuilder: (Widget? currentChild, List<Widget> previousChildren) {
-        List<Widget> children = previousChildren;
-        if (currentChild != null) {
-          children = children.toList()..add(currentChild);
-        }
-        return Stack(
-          children: children,
-          alignment: Alignment.topCenter,
-        );
-      },
-      child: showLoading
-          ? const _SemesterLoadingPlaceholder(
-              key: ValueKey<String>('dualis_semester_loading'),
-            )
-          : Column(
-              key: ValueKey("semester_${viewModel.currentSemester.name}"),
-              children: buildModulesDataTables(context, viewModel),
+class _SemesterSelector extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: <Widget>[
+          Text(L.of(context).dualisExamResultsSemesterSelect),
+          Padding(
+            padding: const EdgeInsets.only(left: 24),
+            child: PropertyChangeConsumer<StudyGradesViewModel, String>(
+              properties: const ['currentSemesterName', 'allSemesterNames'],
+              builder:
+                  (
+                    BuildContext context,
+                    StudyGradesViewModel? model,
+                    Set<String>? properties,
+                  ) {
+                    if (model == null) return const SizedBox.shrink();
+                    return DropdownButton<String>(
+                      onChanged: (value) {
+                        if (value != null) {
+                          model.loadSemester(value);
+                        }
+                      },
+                      value: model.currentSemesterName.isEmpty
+                          ? null
+                          : model.currentSemesterName,
+                      items: model.allSemesterNames
+                          .map(
+                            (name) => DropdownMenuItem<String>(
+                              value: name,
+                              child: Text(name),
+                            ),
+                          )
+                          .toList(growable: false),
+                    );
+                  },
             ),
-      duration: const Duration(milliseconds: 200),
+          ),
+        ],
+      ),
     );
   }
+}
 
-  List<Widget> buildModulesDataTables(
-      BuildContext context, StudyGradesViewModel viewModel) {
-    var dataTables = <Widget>[];
+class _ExamTableLayout {
+  final double examWidth;
+  final double creditsWidth;
+  final double gradeWidth;
+  final double tableWidth;
 
-    var isFirstModule = true;
-    for (var module in viewModel.currentSemester.modules) {
-      dataTables.add(DataTable(
-        horizontalMargin: 24,
-        columnSpacing: 0,
-        dataRowMinHeight: 45,
-        dataRowMaxHeight: 72,
-        headingRowHeight: 65,
-        rows: buildModuleDataRows(context, module),
-        columns: buildModuleColumns(context, module,
-            displayGradeHeader: isFirstModule),
-      ));
-      isFirstModule = false;
-    }
-    return dataTables;
+  const _ExamTableLayout({
+    required this.examWidth,
+    required this.creditsWidth,
+    required this.gradeWidth,
+    required this.tableWidth,
+  });
+
+  factory _ExamTableLayout.fromWidth(double width) {
+    final contentWidth = math.max(0.0, width - 48).toDouble();
+    return _ExamTableLayout(
+      examWidth: contentWidth * 0.5,
+      creditsWidth: contentWidth * 0.25,
+      gradeWidth: contentWidth * 0.25,
+      tableWidth: width,
+    );
   }
+}
 
-  List<DataRow> buildModuleDataRows(BuildContext context, var module) {
-    var dataRows = <DataRow>[];
+class _ExamResultsRenderData {
+  final List<_ExamModuleRenderData> modules;
+  final List<int> moduleStarts;
+  final int childCount;
 
-    for (var exam in module.exams) {
-      dataRows.add(
-        DataRow(
-          cells: <DataCell>[
-            DataCell(Column(
-              mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  exam.name ?? "",
-                  style: Theme.of(context).textTheme.bodySmall,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if ((exam.semester ?? '').isNotEmpty)
-                  Text(
-                    exam.semester ?? "",
-                    style: Theme.of(context).textTheme.bodySmall,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-              ],
-            )),
-            DataCell.empty,
-            DataCell(Padding(
-              padding: const EdgeInsets.fromLTRB(0, 0, 16, 0),
-              child: _examGradeToWidget(context, exam.grade),
-            )),
-          ],
+  const _ExamResultsRenderData({
+    required this.modules,
+    required this.moduleStarts,
+    required this.childCount,
+  });
+
+  factory _ExamResultsRenderData.from(Semester semester, L localizations) {
+    final modules = <_ExamModuleRenderData>[];
+    final moduleStarts = <int>[];
+    var childCount = 0;
+
+    for (
+      var moduleIndex = 0;
+      moduleIndex < semester.modules.length;
+      moduleIndex += 1
+    ) {
+      final module = semester.modules[moduleIndex];
+      moduleStarts.add(childCount);
+      modules.add(
+        _ExamModuleRenderData.from(
+          module,
+          localizations,
+          displayGradeHeader: moduleIndex == 0,
         ),
       );
+      childCount += module.exams.length + 1;
     }
-    return dataRows;
+
+    return _ExamResultsRenderData(
+      modules: modules,
+      moduleStarts: moduleStarts,
+      childCount: childCount,
+    );
   }
 
-  Widget _examGradeToWidget(BuildContext context, ExamGrade grade) {
-    switch (grade.state) {
-      case ExamGradeState.NotGraded:
-        return Text("");
-      case ExamGradeState.Graded:
-        return Text(grade.gradeValue);
-      case ExamGradeState.Passed:
-        return Text(L.of(context).examPassed);
-      case ExamGradeState.Failed:
-        return Text(L.of(context).examNotPassed);
+  int moduleIndexFor(int itemIndex) {
+    var low = 0;
+    var high = moduleStarts.length - 1;
+    while (low <= high) {
+      final middle = (low + high) ~/ 2;
+      if (moduleStarts[middle] <= itemIndex) {
+        if (middle == moduleStarts.length - 1 ||
+            moduleStarts[middle + 1] > itemIndex) {
+          return middle;
+        }
+        low = middle + 1;
+      } else {
+        high = middle - 1;
+      }
     }
+    return 0;
   }
+}
 
-  List<DataColumn> buildModuleColumns(BuildContext context, var module,
-      {var displayGradeHeader = false}) {
-    var displayWidth = MediaQuery.of(context).size.width;
+class _ExamModuleRenderData {
+  final String name;
+  final String creditsHeader;
+  final List<_ExamRowRenderData> rows;
+  final bool displayGradeHeader;
 
-    if (PlatformUtil.isTablet()) {
-      displayWidth -= 250;
-    }
+  const _ExamModuleRenderData({
+    required this.name,
+    required this.creditsHeader,
+    required this.rows,
+    required this.displayGradeHeader,
+  });
 
-    return <DataColumn>[
-      DataColumn(
-        label: ConstrainedBox(
-          constraints: BoxConstraints.expand(
-            width: displayWidth * 0.5 -
-                24, // Subtract the horizontal padding of the DataTable
+  factory _ExamModuleRenderData.from(
+    Module module,
+    L localizations, {
+    required bool displayGradeHeader,
+  }) {
+    return _ExamModuleRenderData(
+      name: module.name,
+      creditsHeader:
+          '${localizations.dualisExamResultsCreditsColumnHeader}:  ${module.credits}',
+      rows: module.exams
+          .map((exam) => _ExamRowRenderData.from(exam, localizations))
+          .toList(growable: false),
+      displayGradeHeader: displayGradeHeader,
+    );
+  }
+}
+
+class _ExamRowRenderData {
+  final String name;
+  final String semester;
+  final String grade;
+
+  const _ExamRowRenderData({
+    required this.name,
+    required this.semester,
+    required this.grade,
+  });
+
+  factory _ExamRowRenderData.from(Exam exam, L localizations) {
+    final grade = switch (exam.grade.state) {
+      ExamGradeState.NotGraded => '',
+      ExamGradeState.Graded => exam.grade.gradeValue,
+      ExamGradeState.Passed => localizations.examPassed,
+      ExamGradeState.Failed => localizations.examNotPassed,
+    };
+
+    return _ExamRowRenderData(
+      name: exam.name,
+      semester: exam.semester,
+      grade: grade,
+    );
+  }
+}
+
+class _ExamResultsSliver extends StatelessWidget {
+  final _ExamResultsRenderData data;
+  final _ExamTableLayout tableLayout;
+
+  const _ExamResultsSliver({required this.data, required this.tableLayout});
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) {
+          final moduleIndex = data.moduleIndexFor(index);
+          final module = data.modules[moduleIndex];
+          final rowIndex = index - data.moduleStarts[moduleIndex];
+
+          if (rowIndex == 0) {
+            return _ExamModuleHeader(
+              key: ValueKey<String>('dualis_exam_module_header_$moduleIndex'),
+              module: module,
+              tableLayout: tableLayout,
+            );
+          }
+
+          return _ExamRow(
+            key: ValueKey<String>(
+              'dualis_exam_row_${moduleIndex}_${rowIndex - 1}',
+            ),
+            row: module.rows[rowIndex - 1],
+            tableLayout: tableLayout,
+          );
+        },
+        childCount: data.childCount,
+        addAutomaticKeepAlives: false,
+      ),
+    );
+  }
+}
+
+class _ExamModuleHeader extends StatelessWidget {
+  final _ExamModuleRenderData module;
+  final _ExamTableLayout tableLayout;
+
+  const _ExamModuleHeader({
+    super.key,
+    required this.module,
+    required this.tableLayout,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      child: SizedBox(
+        height: 65,
+        width: tableLayout.tableWidth,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: DefaultTextStyle(
+            style: Theme.of(context).textTheme.titleSmall!,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                SizedBox(
+                  width: tableLayout.examWidth,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 10, bottom: 16),
+                    child: Text(
+                      module.name,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  width: tableLayout.creditsWidth,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 10, bottom: 16),
+                    child: Text(module.creditsHeader),
+                  ),
+                ),
+                SizedBox(
+                  width: tableLayout.gradeWidth,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 16, bottom: 16),
+                    child: Align(
+                      alignment: Alignment.centerRight,
+                      child: Text(
+                        module.displayGradeHeader
+                            ? L.of(context).dualisExamResultsGradeColumnHeader
+                            : '',
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
-          child: Align(
-            alignment: Alignment.bottomLeft,
+        ),
+      ),
+    );
+  }
+}
+
+class _ExamRow extends StatelessWidget {
+  final _ExamRowRenderData row;
+  final _ExamTableLayout tableLayout;
+
+  const _ExamRow({super.key, required this.row, required this.tableLayout});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          border: Border(top: Divider.createBorderSide(context)),
+        ),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 45, maxHeight: 72),
+          child: SizedBox(
+            width: tableLayout.tableWidth,
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(0, 0, 10, 16),
-              child: Text(
-                (module.name ?? ""),
-                style: Theme.of(context).textTheme.titleSmall,
-                softWrap: true,
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Row(
+                children: <Widget>[
+                  SizedBox(
+                    width: tableLayout.examWidth,
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 10),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            row.name,
+                            style: Theme.of(context).textTheme.bodySmall,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          if (row.semester.isNotEmpty)
+                            Text(
+                              row.semester,
+                              style: Theme.of(context).textTheme.bodySmall,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: tableLayout.creditsWidth),
+                  SizedBox(
+                    width: tableLayout.gradeWidth,
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 16),
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: Text(row.grade),
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),
         ),
-        numeric: false,
       ),
-      DataColumn(
-        label: ConstrainedBox(
-          constraints: BoxConstraints.expand(
-            width: displayWidth * 0.25,
-          ),
-          child: Align(
-            alignment: Alignment.bottomLeft,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(0, 0, 10, 16),
-              child: Text(
-                  "${L.of(context).dualisExamResultsCreditsColumnHeader}:  ${module.credits}"),
-            ),
-          ),
-        ),
-        numeric: true,
-      ),
-      DataColumn(
-        label: ConstrainedBox(
-          constraints: BoxConstraints.expand(
-            width: displayWidth * 0.25,
-          ),
-          child: Align(
-            alignment: Alignment.bottomRight,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(0, 0, 16, 16),
-              child: Text(
-                displayGradeHeader
-                    ? L.of(context).dualisExamResultsGradeColumnHeader
-                    : "",
-              ),
-            ),
-          ),
-        ),
-        numeric: true,
-      ),
-    ];
+    );
   }
 }
 
@@ -267,15 +448,14 @@ class _SemesterLoadingPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = Theme.of(context)
-        .colorScheme
-        .surfaceContainerHighest
-        .withValues(alpha: 0.78);
+    final color = Theme.of(
+      context,
+    ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.78);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
       child: Column(
-        children: List.generate(4, (index) {
+        children: List<Widget>.generate(4, (index) {
           return Padding(
             padding: const EdgeInsets.only(bottom: 10),
             child: Container(

--- a/lib/dualis/ui/study_overview/study_overview_page.dart
+++ b/lib/dualis/ui/study_overview/study_overview_page.dart
@@ -325,7 +325,7 @@ class _OverviewTableHeader extends StatelessWidget {
               width: _OverviewTableLayout.stateWidth,
               child: Tooltip(
                 message: localizations.dualisOverviewPassedColumnHeader,
-                child: const SizedBox.shrink(),
+                child: const SizedBox(width: double.infinity, height: 24),
               ),
             ),
           ],

--- a/lib/dualis/ui/study_overview/study_overview_page.dart
+++ b/lib/dualis/ui/study_overview/study_overview_page.dart
@@ -1,5 +1,10 @@
+import 'dart:math' as math;
+
 import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/dualis/model/module.dart';
+import 'package:dualmate/dualis/model/study_grades.dart';
 import 'package:dualmate/dualis/ui/viewmodels/study_grades_view_model.dart';
+import 'package:dualmate/dualis/ui/widgets/dualis_sliver_content_transition.dart';
 import 'package:dualmate/dualis/ui/widgets/grade_state_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
@@ -12,27 +17,59 @@ class StudyOverviewPage extends StatelessWidget {
 
     return RefreshIndicator(
       onRefresh: () => viewModel.refreshData(force: true),
-      child: SizedBox(
-        height: double.infinity,
-        child: SingleChildScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          scrollDirection: Axis.vertical,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              buildGpaCredits(context),
-              buildModules(context),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final tableLayout = _OverviewTableLayout.fromWidth(
+            constraints.maxWidth,
+          );
+
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: <Widget>[
+              SliverToBoxAdapter(child: buildGpaCredits(context)),
+              SliverToBoxAdapter(child: buildModulesTitle(context)),
+              PropertyChangeConsumer<StudyGradesViewModel, String>(
+                properties: const ['allModules', 'isLoadingAllModules'],
+                builder:
+                    (
+                      BuildContext context,
+                      StudyGradesViewModel? model,
+                      Set<String>? properties,
+                    ) {
+                      if (model == null) {
+                        return const SliverToBoxAdapter(
+                          child: SizedBox.shrink(),
+                        );
+                      }
+
+                      final showLoading =
+                          model.isLoadingAllModules && model.allModules.isEmpty;
+                      return DualisSliverContentTransition(
+                        showLoading: showLoading,
+                        contentKey: model.allModules,
+                        loadingBuilder: (_) => const SliverToBoxAdapter(
+                          child: _OverviewModulesLoadingPlaceholder(
+                            key: ValueKey<String>('dualis_modules_loading'),
+                          ),
+                        ),
+                        contentBuilder: (_) => _OverviewModulesSliver(
+                          key: ValueKey<String>(
+                            'dualis_modules_ready_${model.allModules.length}',
+                          ),
+                          modules: model.allModules,
+                          tableLayout: tableLayout,
+                        ),
+                      );
+                    },
+              ),
             ],
-          ),
-        ),
+          );
+        },
       ),
     );
   }
 
-  Widget buildGpaCredits(
-    BuildContext context,
-  ) {
+  Widget buildGpaCredits(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
       child: Column(
@@ -43,194 +80,326 @@ class StudyOverviewPage extends StatelessWidget {
             style: Theme.of(context).textTheme.titleLarge,
           ),
           PropertyChangeConsumer<StudyGradesViewModel, String>(
-            properties: const ["studyGrades", "isLoadingStudyGrades"],
-            builder: (
-              BuildContext context,
-              StudyGradesViewModel? model,
-              Set<String>? properties,
-            ) {
-              if (model == null) return const SizedBox.shrink();
-              return AnimatedSwitcher(
-                duration: const Duration(milliseconds: 220),
-                switchInCurve: Curves.easeOut,
-                switchOutCurve: Curves.easeIn,
-                child: model.isLoadingStudyGrades
-                    ? const _OverviewSummaryLoadingPlaceholder(
-                        key:
-                            ValueKey<String>('dualis_overview_summary_loading'),
-                      )
-                    : Column(
-                        key: const ValueKey<String>('dualis_overview_summary'),
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: <Widget>[
-                          Padding(
-                            padding: const EdgeInsets.fromLTRB(0, 16, 0, 0),
-                            child: Row(
-                              textBaseline: TextBaseline.alphabetic,
-                              crossAxisAlignment: CrossAxisAlignment.baseline,
-                              children: <Widget>[
-                                Text(
-                                  model.studyGrades.gpaTotal.toString(),
-                                  style:
-                                      Theme.of(context).textTheme.displaySmall,
-                                ),
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.fromLTRB(16, 0, 0, 0),
-                                  child: Text(
-                                    L.of(context).dualisOverviewGpaTotalModules,
-                                  ),
-                                ),
-                              ],
+            properties: const ['studyGrades', 'isLoadingStudyGrades'],
+            builder:
+                (
+                  BuildContext context,
+                  StudyGradesViewModel? model,
+                  Set<String>? properties,
+                ) {
+                  if (model == null) return const SizedBox.shrink();
+
+                  final summary = _OverviewSummaryValues.from(
+                    model.studyGrades,
+                  );
+                  return AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 220),
+                    switchInCurve: Curves.easeOut,
+                    switchOutCurve: Curves.easeIn,
+                    child: model.isLoadingStudyGrades
+                        ? const _OverviewSummaryLoadingPlaceholder(
+                            key: ValueKey<String>(
+                              'dualis_overview_summary_loading',
                             ),
-                          ),
-                          Row(
-                            textBaseline: TextBaseline.alphabetic,
-                            crossAxisAlignment: CrossAxisAlignment.baseline,
-                            children: <Widget>[
-                              Text(
-                                model.studyGrades.gpaMainModules.toString(),
-                                style: Theme.of(context).textTheme.displaySmall,
-                              ),
-                              Padding(
-                                padding: const EdgeInsets.fromLTRB(16, 0, 0, 0),
-                                child: Text(
-                                  L.of(context).dualisOverviewGpaMainModules,
-                                ),
-                              ),
-                            ],
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
-                            child: Row(
-                              textBaseline: TextBaseline.alphabetic,
-                              crossAxisAlignment: CrossAxisAlignment.baseline,
-                              children: <Widget>[
-                                Text(
-                                  "${model.studyGrades.creditsGained} / ${model.studyGrades.creditsTotal}",
-                                  style:
-                                      Theme.of(context).textTheme.displaySmall,
-                                ),
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.fromLTRB(16, 0, 0, 0),
-                                  child: Text(
-                                    L.of(context).dualisOverviewCredits,
-                                  ),
-                                ),
-                              ],
+                          )
+                        : _OverviewSummary(
+                            key: const ValueKey<String>(
+                              'dualis_overview_summary',
                             ),
+                            values: summary,
                           ),
-                        ],
-                      ),
-              );
-            },
+                  );
+                },
           ),
         ],
       ),
     );
   }
 
-  Widget buildModules(BuildContext context) {
+  Widget buildModulesTitle(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(0, 24, 0, 0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
-            child: Text(
-              L.of(context).dualisOverviewModuleGrades,
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-          ),
-          PropertyChangeConsumer<StudyGradesViewModel, String>(
-            properties: const ["allModules", "isLoadingAllModules"],
-            builder: (
-              BuildContext context,
-              StudyGradesViewModel? model,
-              Set<String>? properties,
-            ) {
-              if (model == null) return const SizedBox.shrink();
-              final showLoading =
-                  model.isLoadingAllModules && model.allModules.isEmpty;
-              return AnimatedSwitcher(
-                duration: const Duration(milliseconds: 220),
-                switchInCurve: Curves.easeOut,
-                switchOutCurve: Curves.easeIn,
-                child: showLoading
-                    ? const _OverviewModulesLoadingPlaceholder(
-                        key: ValueKey<String>('dualis_modules_loading'),
-                      )
-                    : SizedBox(
-                        key: ValueKey<String>(
-                          'dualis_modules_ready_${model.allModules.length}',
-                        ),
-                        child: buildModulesDataTable(context, model),
-                      ),
-              );
-            },
-          ),
-        ],
+      padding: const EdgeInsets.fromLTRB(0, 48, 0, 16),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Text(
+          L.of(context).dualisOverviewModuleGrades,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
       ),
     );
   }
+}
 
-  Padding buildProgressIndicator() {
-    return const Padding(
-      padding: EdgeInsets.all(24),
-      child: Center(child: CircularProgressIndicator()),
+class _OverviewSummaryValues {
+  final String totalGpa;
+  final String mainModulesGpa;
+  final String credits;
+
+  const _OverviewSummaryValues({
+    required this.totalGpa,
+    required this.mainModulesGpa,
+    required this.credits,
+  });
+
+  factory _OverviewSummaryValues.from(StudyGrades grades) {
+    return _OverviewSummaryValues(
+      totalGpa: grades.gpaTotal.toString(),
+      mainModulesGpa: grades.gpaMainModules.toString(),
+      credits: '${grades.creditsGained} / ${grades.creditsTotal}',
     );
   }
+}
 
-  Widget buildModulesDataTable(
-    BuildContext context,
-    StudyGradesViewModel model,
-  ) {
-    var dataRows = <DataRow>[];
+class _OverviewSummary extends StatelessWidget {
+  final _OverviewSummaryValues values;
 
-    for (var module in model.allModules) {
-      dataRows.add(
-        DataRow(
-          cells: <DataCell>[
-            DataCell(Text(module.name)),
-            DataCell(Text(module.credits)),
-            DataCell(Text(module.grade)),
-            DataCell(GradeStateIcon(state: module.state)),
+  const _OverviewSummary({super.key, required this.values});
+
+  @override
+  Widget build(BuildContext context) {
+    final displayStyle = Theme.of(context).textTheme.displaySmall;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.only(top: 16),
+          child: _OverviewMetricRow(
+            value: values.totalGpa,
+            label: L.of(context).dualisOverviewGpaTotalModules,
+            valueStyle: displayStyle,
+          ),
+        ),
+        _OverviewMetricRow(
+          value: values.mainModulesGpa,
+          label: L.of(context).dualisOverviewGpaMainModules,
+          valueStyle: displayStyle,
+        ),
+        Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: _OverviewMetricRow(
+            value: values.credits,
+            label: L.of(context).dualisOverviewCredits,
+            valueStyle: displayStyle,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OverviewMetricRow extends StatelessWidget {
+  final String value;
+  final String label;
+  final TextStyle? valueStyle;
+
+  const _OverviewMetricRow({
+    required this.value,
+    required this.label,
+    required this.valueStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      textBaseline: TextBaseline.alphabetic,
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      children: <Widget>[
+        Text(value, style: valueStyle),
+        Padding(padding: const EdgeInsets.only(left: 16), child: Text(label)),
+      ],
+    );
+  }
+}
+
+class _OverviewTableLayout {
+  static const double horizontalMargin = 24;
+  static const double columnSpacing = 10;
+  static const double creditsWidth = 48;
+  static const double gradeWidth = 48;
+  static const double stateWidth = 32;
+
+  final double moduleWidth;
+  final double tableWidth;
+
+  const _OverviewTableLayout({
+    required this.moduleWidth,
+    required this.tableWidth,
+  });
+
+  factory _OverviewTableLayout.fromWidth(double width) {
+    final tableWidth = math.max(0.0, width).toDouble();
+    final moduleWidth = math
+        .max(
+          0,
+          tableWidth -
+              (horizontalMargin * 2) -
+              (columnSpacing * 3) -
+              creditsWidth -
+              gradeWidth -
+              stateWidth,
+        )
+        .toDouble();
+    return _OverviewTableLayout(
+      moduleWidth: moduleWidth,
+      tableWidth: tableWidth,
+    );
+  }
+}
+
+class _OverviewModulesSliver extends StatelessWidget {
+  final List<Module> modules;
+  final _OverviewTableLayout tableLayout;
+
+  const _OverviewModulesSliver({
+    super.key,
+    required this.modules,
+    required this.tableLayout,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) {
+          if (index == 0) {
+            return _OverviewTableHeader(
+              key: const ValueKey<String>('dualis_overview_table_header'),
+              tableLayout: tableLayout,
+            );
+          }
+
+          final module = modules[index - 1];
+          return _OverviewModuleRow(
+            key: ValueKey<String>('dualis_overview_module_row_${index - 1}'),
+            module: module,
+            tableLayout: tableLayout,
+          );
+        },
+        childCount: modules.length + 1,
+        addAutomaticKeepAlives: false,
+      ),
+    );
+  }
+}
+
+class _OverviewTableHeader extends StatelessWidget {
+  final _OverviewTableLayout tableLayout;
+
+  const _OverviewTableHeader({super.key, required this.tableLayout});
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = L.of(context);
+    return SizedBox(
+      height: 50,
+      width: tableLayout.tableWidth,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: _OverviewTableLayout.horizontalMargin,
+        ),
+        child: Row(
+          children: <Widget>[
+            SizedBox(
+              width: tableLayout.moduleWidth,
+              child: Text(localizations.dualisOverviewModuleColumnHeader),
+            ),
+            const SizedBox(width: _OverviewTableLayout.columnSpacing),
+            SizedBox(
+              width: _OverviewTableLayout.creditsWidth,
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Text(localizations.dualisOverviewCreditsColumnHeader),
+              ),
+            ),
+            const SizedBox(width: _OverviewTableLayout.columnSpacing),
+            SizedBox(
+              width: _OverviewTableLayout.gradeWidth,
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Text(localizations.dualisOverviewGradeColumnHeader),
+              ),
+            ),
+            const SizedBox(width: _OverviewTableLayout.columnSpacing),
+            SizedBox(
+              width: _OverviewTableLayout.stateWidth,
+              child: Tooltip(
+                message: localizations.dualisOverviewPassedColumnHeader,
+                child: const SizedBox.shrink(),
+              ),
+            ),
           ],
         ),
-      );
-    }
-
-    return DataTable(
-      columnSpacing: 10,
-      headingRowHeight: 50,
-      rows: dataRows,
-      columns: buildDataTableColumns(context),
+      ),
     );
   }
+}
 
-  List<DataColumn> buildDataTableColumns(BuildContext context) {
-    return <DataColumn>[
-      DataColumn(
-        label: Text(L.of(context).dualisOverviewModuleColumnHeader),
-        numeric: false,
+class _OverviewModuleRow extends StatelessWidget {
+  final Module module;
+  final _OverviewTableLayout tableLayout;
+
+  const _OverviewModuleRow({
+    super.key,
+    required this.module,
+    required this.tableLayout,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          border: Border(top: Divider.createBorderSide(context)),
+        ),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 48, maxHeight: 72),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: _OverviewTableLayout.horizontalMargin,
+            ),
+            child: Row(
+              children: <Widget>[
+                SizedBox(
+                  width: tableLayout.moduleWidth,
+                  child: Text(
+                    module.name,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: _OverviewTableLayout.columnSpacing),
+                SizedBox(
+                  width: _OverviewTableLayout.creditsWidth,
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: Text(module.credits),
+                  ),
+                ),
+                const SizedBox(width: _OverviewTableLayout.columnSpacing),
+                SizedBox(
+                  width: _OverviewTableLayout.gradeWidth,
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: Text(module.grade),
+                  ),
+                ),
+                const SizedBox(width: _OverviewTableLayout.columnSpacing),
+                SizedBox(
+                  width: _OverviewTableLayout.stateWidth,
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: GradeStateIcon(state: module.state),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
-      DataColumn(
-        label: Text(L.of(context).dualisOverviewCreditsColumnHeader),
-        numeric: true,
-      ),
-      DataColumn(
-        label: Text(L.of(context).dualisOverviewGradeColumnHeader),
-        numeric: true,
-      ),
-      DataColumn(
-        label: const Text(""),
-        numeric: true,
-        tooltip: L.of(context).dualisOverviewPassedColumnHeader,
-      ),
-    ];
+    );
   }
 }
 
@@ -259,13 +428,12 @@ class _MetricLoadingRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = Theme.of(context)
-        .colorScheme
-        .surfaceContainerHighest
-        .withValues(alpha: 0.78);
+    final color = Theme.of(
+      context,
+    ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.78);
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
+      children: <Widget>[
         Container(
           width: 86,
           height: 36,
@@ -294,15 +462,14 @@ class _OverviewModulesLoadingPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = Theme.of(context)
-        .colorScheme
-        .surfaceContainerHighest
-        .withValues(alpha: 0.78);
+    final color = Theme.of(
+      context,
+    ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.78);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 0, 24, 16),
       child: Column(
-        children: List.generate(5, (index) {
+        children: List<Widget>.generate(5, (index) {
           return Padding(
             padding: const EdgeInsets.only(bottom: 10),
             child: Container(

--- a/lib/dualis/ui/widgets/dualis_sliver_content_transition.dart
+++ b/lib/dualis/ui/widgets/dualis_sliver_content_transition.dart
@@ -45,7 +45,8 @@ class _DualisSliverContentTransitionState
   void didUpdateWidget(covariant DualisSliverContentTransition oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (widget.showLoading != oldWidget.showLoading) {
+    if (widget.showLoading != oldWidget.showLoading ||
+        widget.contentKey != oldWidget.contentKey) {
       _controller.forward(from: 0);
     }
   }

--- a/lib/dualis/ui/widgets/dualis_sliver_content_transition.dart
+++ b/lib/dualis/ui/widgets/dualis_sliver_content_transition.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+typedef DualisSliverBuilder = Widget Function(BuildContext context);
+
+/// Fades one sliver tree in at a time without keeping the previous table alive.
+class DualisSliverContentTransition extends StatefulWidget {
+  final bool showLoading;
+  final Object? contentKey;
+  final DualisSliverBuilder loadingBuilder;
+  final DualisSliverBuilder contentBuilder;
+  final Duration duration;
+
+  const DualisSliverContentTransition({
+    super.key,
+    required this.showLoading,
+    required this.contentKey,
+    required this.loadingBuilder,
+    required this.contentBuilder,
+    this.duration = const Duration(milliseconds: 220),
+  });
+
+  @override
+  State<DualisSliverContentTransition> createState() =>
+      _DualisSliverContentTransitionState();
+}
+
+class _DualisSliverContentTransitionState
+    extends State<DualisSliverContentTransition>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+      value: 1,
+    );
+    _opacity = CurvedAnimation(parent: _controller, curve: Curves.easeOut);
+  }
+
+  @override
+  void didUpdateWidget(covariant DualisSliverContentTransition oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.showLoading != oldWidget.showLoading) {
+      _controller.forward(from: 0);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final builder = widget.showLoading
+        ? widget.loadingBuilder
+        : widget.contentBuilder;
+    return SliverFadeTransition(
+      opacity: _opacity,
+      sliver: KeyedSubtree(
+        key: ValueKey<Object?>(widget.contentKey),
+        child: builder(context),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}

--- a/lib/ui/pager_widget.dart
+++ b/lib/ui/pager_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:kiwi/kiwi.dart';
@@ -33,6 +35,8 @@ class _PagerWidgetState extends State<PagerWidget> {
   int _currentPage = 0;
   final Set<int> _loadedPages = <int>{};
   final Map<int, Widget> _pageCache = {};
+  int? _pendingPageToPersist;
+  bool _pagePersistenceScheduled = false;
 
   @override
   void initState() {
@@ -73,9 +77,7 @@ class _PagerWidgetState extends State<PagerWidget> {
       ),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentPage,
-        onTap: (int index) async {
-          await setActivePage(index);
-        },
+        onTap: setActivePage,
         items: buildBottomNavigationBarItems(),
       ),
     );
@@ -86,16 +88,13 @@ class _PagerWidgetState extends State<PagerWidget> {
 
     for (var page in widget.pages) {
       bottomNavigationBarItems.add(
-        BottomNavigationBarItem(
-          icon: page.icon,
-          label: page.text,
-        ),
+        BottomNavigationBarItem(icon: page.icon, label: page.text),
       );
     }
     return bottomNavigationBarItems;
   }
 
-  Future<void> setActivePage(int page, {bool force = false}) async {
+  void setActivePage(int page, {bool force = false}) {
     if (page < 0 || page >= widget.pages.length) {
       return;
     }
@@ -105,8 +104,30 @@ class _PagerWidgetState extends State<PagerWidget> {
       _loadedPages.add(page);
     });
     if (widget.pagesId != null) {
-      await preferencesProvider.set("${widget.pagesId}_active_page", page);
+      _schedulePagePersistence(page);
     }
+  }
+
+  void _schedulePagePersistence(int page) {
+    _pendingPageToPersist = page;
+    if (_pagePersistenceScheduled) {
+      return;
+    }
+
+    _pagePersistenceScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pagePersistenceScheduled = false;
+      final pageToPersist = _pendingPageToPersist;
+      _pendingPageToPersist = null;
+      final pagesId = widget.pagesId;
+      if (pageToPersist == null || pagesId == null) {
+        return;
+      }
+
+      unawaited(
+        preferencesProvider.set("${pagesId}_active_page", pageToPersist),
+      );
+    });
   }
 
   Future<void> loadActivePage() async {
@@ -129,7 +150,7 @@ class _PagerWidgetState extends State<PagerWidget> {
   void _handleForcedPage() async {
     final forced = widget.forcedPage?.value;
     if (forced == null) return;
-    await setActivePage(forced, force: true);
+    setActivePage(forced, force: true);
     widget.forcedPage?.value = null;
   }
 

--- a/lib/ui/pager_widget.dart
+++ b/lib/ui/pager_widget.dart
@@ -94,7 +94,7 @@ class _PagerWidgetState extends State<PagerWidget> {
     return bottomNavigationBarItems;
   }
 
-  void setActivePage(int page, {bool force = false}) {
+  void setActivePage(int page) {
     if (page < 0 || page >= widget.pages.length) {
       return;
     }
@@ -150,7 +150,7 @@ class _PagerWidgetState extends State<PagerWidget> {
   void _handleForcedPage() async {
     final forced = widget.forcedPage?.value;
     if (forced == null) return;
-    setActivePage(forced, force: true);
+    setActivePage(forced);
     widget.forcedPage?.value = null;
   }
 

--- a/test/dualis/ui/dualis_lazy_rendering_test.dart
+++ b/test/dualis/ui/dualis_lazy_rendering_test.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+
+import 'package:dualmate/common/data/preferences/preferences_access.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/dualis/model/exam.dart';
+import 'package:dualmate/dualis/model/exam_grade.dart';
+import 'package:dualmate/dualis/model/module.dart';
+import 'package:dualmate/dualis/model/semester.dart';
+import 'package:dualmate/dualis/model/study_grades.dart';
+import 'package:dualmate/dualis/service/dualis_service.dart';
+import 'package:dualmate/dualis/ui/exam_results_page/exam_results_page.dart';
+import 'package:dualmate/dualis/ui/study_overview/study_overview_page.dart';
+import 'package:dualmate/dualis/ui/viewmodels/study_grades_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:property_change_notifier/property_change_notifier.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('overview module rows are built lazily', (tester) async {
+    final viewModel = _buildViewModel(
+      _ImmediateDualisService(
+        modules: List<Module>.generate(
+          100,
+          (index) => Module(
+            const <Exam>[],
+            'module-$index',
+            'Module $index',
+            '5',
+            '1.3',
+            ExamState.Passed,
+          ),
+        ),
+      ),
+    );
+    addTearDown(viewModel.dispose);
+
+    await viewModel.loadAllModules();
+    await tester.pumpWidget(_wrapOverview(viewModel));
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey<String>('dualis_overview_module_row_0')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('dualis_overview_module_row_99')),
+      findsNothing,
+    );
+    expect(find.byType(DataTable), findsNothing);
+  });
+
+  testWidgets('exam rows keep long labels safe without eager DataTable rows', (
+    tester,
+  ) async {
+    const longExamName =
+        'Kombinierte Pruefung mit Klausur und sehr langem Modulnamen';
+    final viewModel = _buildViewModel(
+      _ImmediateDualisService(
+        semester: Semester('SoSe 2026', [
+          Module(
+            List<Exam>.generate(
+              100,
+              (index) => Exam(
+                index == 0 ? longExamName : 'Exam $index',
+                ExamGrade.graded('1,7'),
+                ExamState.Passed,
+                'SoSe 2026',
+              ),
+            ),
+            'module-1',
+            'Schluesselqualifikationen',
+            '5,0',
+            '1,7',
+            ExamState.Passed,
+          ),
+        ]),
+      ),
+    );
+    addTearDown(viewModel.dispose);
+
+    await viewModel.loadSemester('SoSe 2026');
+    await tester.pumpWidget(_wrapExamResults(viewModel));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(longExamName), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('dualis_exam_row_0_0')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('dualis_exam_row_0_99')),
+      findsNothing,
+    );
+    expect(find.byType(DataTable), findsNothing);
+  });
+
+  testWidgets('semester loading transitions to lazy exam content', (
+    tester,
+  ) async {
+    final service = _BlockingSemesterService();
+    final viewModel = _buildViewModel(service);
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(_wrapExamResults(viewModel));
+    unawaited(viewModel.loadSemester('WS 2026'));
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey<String>('dualis_semester_loading')),
+      findsOneWidget,
+    );
+
+    service.complete(
+      Semester('WS 2026', [
+        Module(
+          const <Exam>[],
+          'module-2',
+          'Databases',
+          '5',
+          '2.0',
+          ExamState.Passed,
+        ),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>('dualis_semester_loading')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('dualis_exam_module_header_0')),
+      findsOneWidget,
+    );
+  });
+}
+
+StudyGradesViewModel _buildViewModel(DualisService service) {
+  return StudyGradesViewModel(
+    PreferencesProvider(_MapPreferencesAccess(), _MapSecureStorageAccess()),
+    service,
+  );
+}
+
+Widget _wrapOverview(StudyGradesViewModel viewModel) {
+  return _wrapPage(viewModel, StudyOverviewPage());
+}
+
+Widget _wrapExamResults(StudyGradesViewModel viewModel) {
+  return _wrapPage(viewModel, ExamResultsPage());
+}
+
+Widget _wrapPage(StudyGradesViewModel viewModel, Widget page) {
+  return ChangeNotifierProvider<StudyGradesViewModel>.value(
+    value: viewModel,
+    child: MaterialApp(
+      localizationsDelegates: const [
+        LocalizationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('de')],
+      home: Scaffold(
+        body: PropertyChangeProvider<StudyGradesViewModel, String>(
+          value: viewModel,
+          child: page,
+        ),
+      ),
+    ),
+  );
+}
+
+class _ImmediateDualisService extends DualisService {
+  final List<Module> modules;
+  final Semester? semester;
+
+  _ImmediateDualisService({this.modules = const [], this.semester});
+
+  @override
+  Future<LoginResult> login(
+    String username,
+    String password, [
+    CancellationToken? cancellationToken,
+  ]) async => LoginResult.LoggedIn;
+
+  @override
+  Future<List<Module>> queryAllModules([
+    CancellationToken? cancellationToken,
+  ]) async => modules;
+
+  @override
+  Future<Semester> querySemester(
+    String name, [
+    CancellationToken? cancellationToken,
+  ]) async => semester ?? Semester(name, const <Module>[]);
+
+  @override
+  Future<List<String>> querySemesterNames([
+    CancellationToken? cancellationToken,
+  ]) async => const <String>[];
+
+  @override
+  Future<StudyGrades> queryStudyGrades([
+    CancellationToken? cancellationToken,
+  ]) async => StudyGrades(0, 0, 0, 0);
+
+  @override
+  Future<void> logout([CancellationToken? cancellationToken]) async {}
+
+  @override
+  void clearCache() {}
+}
+
+class _BlockingSemesterService extends _ImmediateDualisService {
+  final Completer<Semester> _semesterCompleter = Completer<Semester>();
+
+  @override
+  Future<Semester> querySemester(
+    String name, [
+    CancellationToken? cancellationToken,
+  ]) => _semesterCompleter.future;
+
+  void complete(Semester semester) {
+    _semesterCompleter.complete(semester);
+  }
+}
+
+class _MapPreferencesAccess extends PreferencesAccess {
+  final Map<String, Object?> values = <String, Object?>{};
+
+  @override
+  Future<void> set<T>(String key, T value) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<T?> get<T>(String key) async => values[key] as T?;
+}
+
+class _MapSecureStorageAccess extends SecureStorageAccess {
+  @override
+  Future<void> set(String key, String value) async {}
+
+  @override
+  Future<String?> get(String key) async => null;
+}

--- a/test/dualis/ui/dualis_sliver_content_transition_test.dart
+++ b/test/dualis/ui/dualis_sliver_content_transition_test.dart
@@ -1,0 +1,54 @@
+import 'package:dualmate/dualis/ui/widgets/dualis_sliver_content_transition.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('content-key changes restart the fade', (tester) async {
+    Widget build(Object contentKey, String label) {
+      return MaterialApp(
+        home: CustomScrollView(
+          slivers: [
+            DualisSliverContentTransition(
+              showLoading: false,
+              contentKey: contentKey,
+              loadingBuilder: (_) =>
+                  const SliverToBoxAdapter(child: Text('loading')),
+              contentBuilder: (_) => SliverToBoxAdapter(child: Text(label)),
+            ),
+          ],
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build('first', 'first content'));
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .widget<SliverFadeTransition>(find.byType(SliverFadeTransition))
+          .opacity
+          .value,
+      1,
+    );
+
+    await tester.pumpWidget(build('second', 'second content'));
+    await tester.pump();
+
+    expect(find.text('second content'), findsOneWidget);
+    expect(
+      tester
+          .widget<SliverFadeTransition>(find.byType(SliverFadeTransition))
+          .opacity
+          .value,
+      0,
+    );
+
+    await tester.pump(const Duration(milliseconds: 220));
+    expect(
+      tester
+          .widget<SliverFadeTransition>(find.byType(SliverFadeTransition))
+          .opacity
+          .value,
+      1,
+    );
+  });
+}

--- a/test/dualis/ui/dualis_tab_persistence_test.dart
+++ b/test/dualis/ui/dualis_tab_persistence_test.dart
@@ -1,0 +1,183 @@
+import 'package:dualmate/common/data/preferences/preferences_access.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/preferences/secure_storage_access.dart';
+import 'package:dualmate/ui/pager_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kiwi/kiwi.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    KiwiContainer().clear();
+  });
+
+  tearDown(() {
+    KiwiContainer().clear();
+  });
+
+  testWidgets(
+    'Dualis tab selection is immediate and persisted after the frame',
+    (tester) async {
+      final preferencesAccess = _TrackingPreferencesAccess();
+      KiwiContainer().registerInstance<PreferencesProvider>(
+        PreferencesProvider(preferencesAccess, _FakeSecureStorageAccess()),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PagerWidget(
+            pagesId: 'dualis_pager',
+            pages: [
+              PageDefinition(
+                text: 'Overview',
+                icon: const Icon(Icons.dashboard),
+                builder: (_) => const Text('overview_content'),
+              ),
+              PageDefinition(
+                text: 'Exams',
+                icon: const Icon(Icons.book),
+                builder: (_) => const Text('exams_content'),
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final bottomNavigationBar = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      bottomNavigationBar.onTap!(1);
+      expect(preferencesAccess.writes, isEmpty);
+
+      await tester.pump();
+      expect(find.text('exams_content'), findsOneWidget);
+      expect(preferencesAccess.writes, hasLength(1));
+      expect(preferencesAccess.writes.single.key, 'dualis_pager_active_page');
+      expect(preferencesAccess.writes.single.value, 1);
+
+      final switchedBackNavigationBar = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      switchedBackNavigationBar.onTap!(0);
+      expect(preferencesAccess.writes, hasLength(1));
+
+      await tester.pump();
+      expect(find.text('overview_content'), findsOneWidget);
+
+      expect(
+        preferencesAccess.writes.map((entry) => entry.key),
+        everyElement('dualis_pager_active_page'),
+      );
+      expect(preferencesAccess.writes.map((entry) => entry.value), <Object>[
+        1,
+        0,
+      ]);
+    },
+  );
+
+  testWidgets('pending tab selection persists when pager is disposed', (
+    tester,
+  ) async {
+    final preferencesAccess = _TrackingPreferencesAccess();
+    KiwiContainer().registerInstance<PreferencesProvider>(
+      PreferencesProvider(preferencesAccess, _FakeSecureStorageAccess()),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PagerWidget(
+          pagesId: 'dualis_pager',
+          pages: [
+            PageDefinition(
+              text: 'Overview',
+              icon: const Icon(Icons.dashboard),
+              builder: (_) => const Text('overview_content'),
+            ),
+            PageDefinition(
+              text: 'Exams',
+              icon: const Icon(Icons.book),
+              builder: (_) => const Text('exams_content'),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pump();
+
+    tester.widget<BottomNavigationBar>(find.byType(BottomNavigationBar)).onTap!(
+      1,
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(preferencesAccess.writes, hasLength(1));
+    expect(preferencesAccess.writes.single.key, 'dualis_pager_active_page');
+    expect(preferencesAccess.writes.single.value, 1);
+  });
+
+  testWidgets('rapid tab selections persist only the latest page', (
+    tester,
+  ) async {
+    final preferencesAccess = _TrackingPreferencesAccess();
+    KiwiContainer().registerInstance<PreferencesProvider>(
+      PreferencesProvider(preferencesAccess, _FakeSecureStorageAccess()),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PagerWidget(
+          pagesId: 'dualis_pager',
+          pages: [
+            PageDefinition(
+              text: 'Overview',
+              icon: const Icon(Icons.dashboard),
+              builder: (_) => const Text('overview_content'),
+            ),
+            PageDefinition(
+              text: 'Exams',
+              icon: const Icon(Icons.book),
+              builder: (_) => const Text('exams_content'),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final navigationBar = tester.widget<BottomNavigationBar>(
+      find.byType(BottomNavigationBar),
+    );
+    navigationBar.onTap!(1);
+    navigationBar.onTap!(0);
+    expect(preferencesAccess.writes, isEmpty);
+
+    await tester.pump();
+
+    expect(preferencesAccess.writes, hasLength(1));
+    expect(preferencesAccess.writes.single.key, 'dualis_pager_active_page');
+    expect(preferencesAccess.writes.single.value, 0);
+  });
+}
+
+class _TrackingPreferencesAccess extends PreferencesAccess {
+  final List<MapEntry<String, Object>> writes = <MapEntry<String, Object>>[];
+
+  @override
+  Future<void> set<T>(String key, T value) async {
+    writes.add(MapEntry<String, Object>(key, value as Object));
+  }
+
+  @override
+  Future<T?> get<T>(String key) async => null;
+}
+
+class _FakeSecureStorageAccess extends SecureStorageAccess {
+  @override
+  Future<void> set(String key, String value) async {}
+
+  @override
+  Future<String?> get(String key) async => null;
+}

--- a/test/dualis/ui/study_overview_loading_animation_test.dart
+++ b/test/dualis/ui/study_overview_loading_animation_test.dart
@@ -59,6 +59,11 @@ void main() {
       findsOneWidget,
     );
     expect(find.byType(DataTable), findsNothing);
+
+    final tooltip = tester.widget<Tooltip>(find.byType(Tooltip).last);
+    final tooltipTarget = tester.getSize(find.byWidget(tooltip.child!));
+    expect(tooltipTarget.width, greaterThan(0));
+    expect(tooltipTarget.height, greaterThan(0));
   });
 
   testWidgets('shows loading placeholder while semester modules are fetched', (

--- a/test/dualis/ui/study_overview_loading_animation_test.dart
+++ b/test/dualis/ui/study_overview_loading_animation_test.dart
@@ -45,14 +45,7 @@ void main() {
     );
 
     dualisService.completeModules([
-      Module(
-        const <Exam>[],
-        'M1',
-        'Algorithms',
-        '5',
-        '1.3',
-        ExamState.Passed,
-      ),
+      Module(const <Exam>[], 'M1', 'Algorithms', '5', '1.3', ExamState.Passed),
     ]);
 
     await tester.pumpAndSettle();
@@ -61,7 +54,11 @@ void main() {
       find.byKey(const ValueKey<String>('dualis_modules_loading')),
       findsNothing,
     );
-    expect(find.byType(DataTable), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('dualis_overview_module_row_0')),
+      findsOneWidget,
+    );
+    expect(find.byType(DataTable), findsNothing);
   });
 
   testWidgets('shows loading placeholder while semester modules are fetched', (
@@ -87,19 +84,9 @@ void main() {
 
     dualisService.completeSemester(
       'WS2026',
-      Semester(
-        'WS2026',
-        [
-          Module(
-            const <Exam>[],
-            'M2',
-            'Databases',
-            '5',
-            '2.0',
-            ExamState.Passed,
-          ),
-        ],
-      ),
+      Semester('WS2026', [
+        Module(const <Exam>[], 'M2', 'Databases', '5', '2.0', ExamState.Passed),
+      ]),
     );
 
     await tester.pumpAndSettle();
@@ -108,7 +95,11 @@ void main() {
       find.byKey(const ValueKey<String>('dualis_semester_loading')),
       findsNothing,
     );
-    expect(find.byType(DataTable), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('dualis_exam_module_header_0')),
+      findsOneWidget,
+    );
+    expect(find.byType(DataTable), findsNothing);
   });
 
   testWidgets('exam rows do not overflow with long wrapped labels', (
@@ -129,26 +120,23 @@ void main() {
 
     dualisService.completeSemester(
       'SoSe 2026',
-      Semester(
-        'SoSe 2026',
-        [
-          Module(
-            [
-              Exam(
-                'Kombinierte Pruefung mit Klausur (<50 %) (100%)',
-                ExamGrade.graded('1,7'),
-                ExamState.Passed,
-                'SoSe 2026',
-              ),
-            ],
-            'M3',
-            'Schluesselqualifikationen',
-            '5,0',
-            '1,7',
-            ExamState.Passed,
-          ),
-        ],
-      ),
+      Semester('SoSe 2026', [
+        Module(
+          [
+            Exam(
+              'Kombinierte Pruefung mit Klausur (<50 %) (100%)',
+              ExamGrade.graded('1,7'),
+              ExamState.Passed,
+              'SoSe 2026',
+            ),
+          ],
+          'M3',
+          'Schluesselqualifikationen',
+          '5,0',
+          '1,7',
+          ExamState.Passed,
+        ),
+      ]),
     );
 
     await tester.pumpAndSettle();
@@ -160,7 +148,11 @@ void main() {
     }
 
     expect(exceptions, isEmpty);
-    expect(find.byType(DataTable), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('dualis_exam_row_0_0')),
+      findsOneWidget,
+    );
+    expect(find.byType(DataTable), findsNothing);
     expect(find.textContaining('Kombinierte Pruefung'), findsOneWidget);
   });
 }
@@ -223,9 +215,7 @@ class _BlockingDualisService extends DualisService {
   }
 
   @override
-  Future<List<Module>> queryAllModules([
-    CancellationToken? cancellationToken,
-  ]) {
+  Future<List<Module>> queryAllModules([CancellationToken? cancellationToken]) {
     return _allModulesCompleter.future;
   }
 
@@ -254,9 +244,7 @@ class _BlockingDualisService extends DualisService {
   }
 
   @override
-  Future<void> logout([
-    CancellationToken? cancellationToken,
-  ]) async {}
+  Future<void> logout([CancellationToken? cancellationToken]) async {}
 
   @override
   void clearCache() {}
@@ -269,8 +257,10 @@ class _BlockingDualisService extends DualisService {
   }
 
   void completeSemester(String name, Semester semester) {
-    final completer =
-        _semesterCompleters.putIfAbsent(name, () => Completer<Semester>());
+    final completer = _semesterCompleters.putIfAbsent(
+      name,
+      () => Completer<Semester>(),
+    );
     if (completer.isCompleted) {
       return;
     }

--- a/test/ui/pager_widget_test.dart
+++ b/test/ui/pager_widget_test.dart
@@ -17,66 +17,65 @@ void main() {
     KiwiContainer().clear();
   });
 
-  testWidgets(
-    'Dualis tab selection is immediate and persisted after the frame',
-    (tester) async {
-      final preferencesAccess = _TrackingPreferencesAccess();
-      KiwiContainer().registerInstance<PreferencesProvider>(
-        PreferencesProvider(preferencesAccess, _FakeSecureStorageAccess()),
-      );
+  testWidgets('tab selection is immediate and persisted after the frame', (
+    tester,
+  ) async {
+    final preferencesAccess = _TrackingPreferencesAccess();
+    KiwiContainer().registerInstance<PreferencesProvider>(
+      PreferencesProvider(preferencesAccess, _FakeSecureStorageAccess()),
+    );
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PagerWidget(
-            pagesId: 'dualis_pager',
-            pages: [
-              PageDefinition(
-                text: 'Overview',
-                icon: const Icon(Icons.dashboard),
-                builder: (_) => const Text('overview_content'),
-              ),
-              PageDefinition(
-                text: 'Exams',
-                icon: const Icon(Icons.book),
-                builder: (_) => const Text('exams_content'),
-              ),
-            ],
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PagerWidget(
+          pagesId: 'dualis_pager',
+          pages: [
+            PageDefinition(
+              text: 'Overview',
+              icon: const Icon(Icons.dashboard),
+              builder: (_) => const Text('overview_content'),
+            ),
+            PageDefinition(
+              text: 'Exams',
+              icon: const Icon(Icons.book),
+              builder: (_) => const Text('exams_content'),
+            ),
+          ],
         ),
-      );
-      await tester.pump();
+      ),
+    );
+    await tester.pump();
 
-      final bottomNavigationBar = tester.widget<BottomNavigationBar>(
-        find.byType(BottomNavigationBar),
-      );
-      bottomNavigationBar.onTap!(1);
-      expect(preferencesAccess.writes, isEmpty);
+    final bottomNavigationBar = tester.widget<BottomNavigationBar>(
+      find.byType(BottomNavigationBar),
+    );
+    bottomNavigationBar.onTap!(1);
+    expect(preferencesAccess.writes, isEmpty);
 
-      await tester.pump();
-      expect(find.text('exams_content'), findsOneWidget);
-      expect(preferencesAccess.writes, hasLength(1));
-      expect(preferencesAccess.writes.single.key, 'dualis_pager_active_page');
-      expect(preferencesAccess.writes.single.value, 1);
+    await tester.pump();
+    expect(find.text('exams_content'), findsOneWidget);
+    expect(preferencesAccess.writes, hasLength(1));
+    expect(preferencesAccess.writes.single.key, 'dualis_pager_active_page');
+    expect(preferencesAccess.writes.single.value, 1);
 
-      final switchedBackNavigationBar = tester.widget<BottomNavigationBar>(
-        find.byType(BottomNavigationBar),
-      );
-      switchedBackNavigationBar.onTap!(0);
-      expect(preferencesAccess.writes, hasLength(1));
+    final switchedBackNavigationBar = tester.widget<BottomNavigationBar>(
+      find.byType(BottomNavigationBar),
+    );
+    switchedBackNavigationBar.onTap!(0);
+    expect(preferencesAccess.writes, hasLength(1));
 
-      await tester.pump();
-      expect(find.text('overview_content'), findsOneWidget);
+    await tester.pump();
+    expect(find.text('overview_content'), findsOneWidget);
 
-      expect(
-        preferencesAccess.writes.map((entry) => entry.key),
-        everyElement('dualis_pager_active_page'),
-      );
-      expect(preferencesAccess.writes.map((entry) => entry.value), <Object>[
-        1,
-        0,
-      ]);
-    },
-  );
+    expect(
+      preferencesAccess.writes.map((entry) => entry.key),
+      everyElement('dualis_pager_active_page'),
+    );
+    expect(preferencesAccess.writes.map((entry) => entry.value), <Object>[
+      1,
+      0,
+    ]);
+  });
 
   testWidgets('pending tab selection persists when pager is disposed', (
     tester,


### PR DESCRIPTION
## Summary

- replace eager overview and exam `DataTable` trees with fixed-width lazy slivers
- keep module/exam wrapping, grouping, row heights, loading placeholders, and readiness keys
- construct localized sliver content in `build`, not `initState`
- defer and coalesce Dualis tab persistence without losing pending writes on disposal

## Pixel 8 Pro results

Three current-`v2` control runs and three final branch runs at 120 Hz / 1.0x animations:

- drawer → populated Dualis p95: **18.79 → 16.54 ms**
- drawer → populated Dualis p99/worst: **36.82 → 25.73 ms**
- frames over 16.67 ms: **3 → 2**
- frames over 33 ms: **1 → 0**
- result scrolling remains effectively neutral
- tab-switch median worst frame: **40.67 → 31.22 ms**
- tab-switch frames over 33 ms: **1 → 0**

## Validation

- full `flutter analyze`
- `flutter test test/dualis` — 36 tests passed
- three-run current-`v2` Pixel control
- three-run final branch Pixel diagnostic
- all Dualis final-state, session-restore, and scroll-progression checks passed

Documentation: `docs/solutions/performance/dualis-lazy-table-rendering-20260712.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned study overview and exam results pages with smoother scrolling and improved responsive layouts.
  * Added animated transitions between loading states and displayed content.
  * Improved readability of module, exam, grade, and credit information across screen sizes.

* **Performance**
  * Large module and exam lists now render more efficiently, improving responsiveness.

* **Bug Fixes**
  * Tab selections are saved reliably without delaying navigation, including rapid changes or closing the page immediately afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->