### PR TITLE
Prepare cold navigation sections during idle time

### DIFF
--- a/docs/solutions/performance/interaction-aware-cold-navigation-preparation-20260712.md
+++ b/docs/solutions/performance/interaction-aware-cold-navigation-preparation-20260712.md
@@ -98,11 +98,11 @@ Tests verify that:
 # Validation
 
 - full `flutter analyze` — clean;
-- `flutter test test/canteen` — 53 tests passed;
+- `flutter test test/canteen` — 59 tests passed;
 - `flutter test test/date_management` — 29 tests passed;
-- `flutter test test/schedule` — 154 tests passed;
-- `flutter test test/ui` — 36 tests passed;
-- focused coordinator/navigation lifecycle tests — 11 tests passed;
+- `flutter test test/schedule` — 155 tests passed;
+- `flutter test test/ui` — 38 tests passed;
+- focused coordinator/navigation lifecycle and cache-only preparation tests passed;
 - Pixel 8 Pro profile mode at 120 Hz / 1.0x animations, using three current-`v2`
   control runs and three final branch runs.
 
@@ -132,3 +132,10 @@ by the separate Dates lazy-rendering PR. All navigation final states completed.
 - no performance-harness thresholds or fixture data were changed;
 - no production data source is replaced with fixture behavior;
 - network refresh remains available after the relevant page is active.
+
+# Stacking
+
+This change is based on the approved Canteen rendering branch so the navigation
+preparation hook extends the stable Canteen shell instead of replacing its
+initialization lifecycle. Merge PR #97 before this branch, then retarget this PR
+to `v2`.

--- a/docs/solutions/performance/interaction-aware-cold-navigation-preparation-20260712.md
+++ b/docs/solutions/performance/interaction-aware-cold-navigation-preparation-20260712.md
@@ -1,0 +1,134 @@
+---
+title: Prepare cold navigation sections during interaction-aware idle time
+date: 2026-07-12
+type: fix
+---
+
+# Summary
+
+Cold drawer navigation previously protected the closing animation with a fixed
+260 ms delay, but still created destination view models and started cache work in
+the activation frame. Startup background tasks also used independent fixed
+timers, so they could begin while the user was scrolling or opening a route.
+
+This change separates local section preparation from widget activation and
+serializes deferred startup work through an interaction-aware idle coordinator.
+The existing drawer animation and delay remain unchanged.
+
+# Interaction-aware idle coordinator
+
+`InteractionIdleCoordinator` owns a FIFO queue for deferred work.
+
+- Tasks run one at a time.
+- Duplicate task IDs share the same queued task.
+- Queued work waits while explicit pointer, scroll, drawer, or route-transition
+  leases are active.
+- After the last interaction ends, navigation idle waiters require one complete
+  interaction-free frame. Background tasks additionally wait through a 180 ms
+  quiet period so they do not immediately compete with the animation tail.
+- A clean frame is also required between serialized tasks so several cache reads
+  cannot start in the same frame.
+- Unrelated repeating animations, such as indeterminate loading indicators, do
+  not block the queue indefinitely.
+- Queued tasks can be cancelled when their owner is disposed; already-running
+  futures are allowed to complete safely.
+
+# Section prepare and activate lifecycle
+
+`NavigationEntry` now has distinct phases:
+
+1. `prepare()` creates the section-owned view model and starts local preparation
+   without mounting widgets.
+2. `activate()` mounts the provider and route subtree.
+3. The existing `IndexedStack` keeps activated sections alive as before.
+
+Preparation is opportunistic. Navigation never waits for a network-backed future
+before showing the selected destination. A preparation that finishes after
+activation cannot move the entry lifecycle backwards from `active`.
+
+# Feature preparation policy
+
+Preparation is intentionally restricted to local work:
+
+- **Schedule:** constructs the shared weekly view model and reads the visible
+  week from the local schedule cache. The existing delayed refresh remains owned
+  by the view model.
+- **Canteen:** loads the selected location and current-week local cache with
+  network refresh disabled. The visible page retains its existing refresh and
+  adjacent-prefetch behavior.
+- **Dates:** reads source and selection preferences only. Date cache/remote
+  updates begin from the page's existing delayed initialization after activation.
+- **Dualis:** session restoration remains tied to actual page visibility and is
+  not proactively started by the navigation coordinator.
+
+Merely opening the drawer does not prepare every cold section. Selecting a cold
+section starts only that section's preparation on close, then activates it after
+the preserved drawer-close delay and an interaction-free frame even if its
+preparation future is still running.
+
+# Startup orchestration
+
+The root background, foreground-heavy, app-launch-dialog, and Canteen prewarm
+jobs retain their existing minimum delays. Their deadlines are now minimums:
+active pointer, scroll, drawer, or route interactions postpone execution.
+
+The former independent Schedule cache warmup was removed because Schedule
+preparation now owns that cache read. The Canteen startup prewarm reuses the same
+navigation-entry preparation future instead of creating a second initialization
+path.
+
+# Regression coverage
+
+Tests verify that:
+
+- task IDs deduplicate and tasks remain strictly serialized;
+- one clean frame separates queued tasks;
+- pointer/scroll/drawer/route leases postpone work;
+- a repeating loading animation cannot starve the queue;
+- cancelled tasks and idle waiters complete safely on disposal;
+- a cold section is not mounted during drawer close;
+- merely opening the drawer does not start every section preparation;
+- a destination mounts without waiting for a blocked preparation future;
+- scroll interaction leases release after scrolling settles;
+- entry preparation runs once and cannot overwrite the `active` lifecycle;
+- Canteen preparation reads cache without a network refresh;
+- Dates preparation reads preferences without a remote request;
+- the initial Schedule placeholder and delayed mount contract remain intact.
+
+# Validation
+
+- full `flutter analyze` — clean;
+- `flutter test test/canteen` — 53 tests passed;
+- `flutter test test/date_management` — 29 tests passed;
+- `flutter test test/schedule` — 154 tests passed;
+- `flutter test test/ui` — 36 tests passed;
+- focused coordinator/navigation lifecycle tests — 11 tests passed;
+- Pixel 8 Pro profile mode at 120 Hz / 1.0x animations, using three current-`v2`
+  control runs and three final branch runs.
+
+Median Pixel results:
+
+| Scenario | Metric | Current `v2` | Final branch |
+| --- | --- | ---: | ---: |
+| Drawer → Canteen | frames > 8.33 ms | 25.00% | 13.33% |
+| Drawer → Canteen | p95 | 25.48 ms | 10.21 ms |
+| Drawer → Canteen | frames > 16.67 ms | 3 | 1 |
+| Drawer → Canteen | consecutive misses | 3 | 1 |
+| Drawer → Dates | p95 | 18.96 ms | 13.46 ms |
+| Drawer → Dates | p99 / worst | 36.67 ms | 26.83 ms |
+| Drawer → Dates | frames > 33 ms | 1 | 0 |
+| Drawer → Dualis | frames > 8.33 ms | 23.53% | 10.81% |
+| Drawer → Dualis | p95 | 18.79 ms | 14.19 ms |
+| Drawer → Dualis | p99 / worst | 36.82 ms | 19.89 ms |
+| Drawer → Dualis | frames > 33 ms | 1 | 0 |
+
+The remaining Dates loading-progression warning is the known baseline issue fixed
+by the separate Dates lazy-rendering PR. All navigation final states completed.
+
+# Constraints preserved
+
+- no animation was removed or shortened;
+- the drawer still closes before destination activation;
+- no performance-harness thresholds or fixture data were changed;
+- no production data source is replaced with fixture behavior;
+- network refresh remains available after the relevant page is active.

--- a/lib/canteen/ui/canteen_navigation_entry.dart
+++ b/lib/canteen/ui/canteen_navigation_entry.dart
@@ -8,8 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:kiwi/kiwi.dart';
 
 class CanteenNavigationEntry extends NavigationEntry<CanteenViewModel> {
-  late CanteenViewModel _viewModel;
-
   @override
   Widget icon(BuildContext context) {
     return Icon(Icons.restaurant_menu);
@@ -17,11 +15,15 @@ class CanteenNavigationEntry extends NavigationEntry<CanteenViewModel> {
 
   @override
   CanteenViewModel initViewModel() {
-    _viewModel = CanteenViewModel(
+    return CanteenViewModel(
       KiwiContainer().resolve(),
       KiwiContainer().resolve(),
     );
-    return _viewModel;
+  }
+
+  @override
+  Future<void> prepareSection() async {
+    await viewModel().prepareForNavigation();
   }
 
   @override
@@ -36,6 +38,7 @@ class CanteenNavigationEntry extends NavigationEntry<CanteenViewModel> {
 
   @override
   List<Widget> appBarActions(BuildContext context) {
+    final model = viewModel();
     return [
       MenuAnchor(
         menuChildren: [
@@ -43,16 +46,16 @@ class CanteenNavigationEntry extends NavigationEntry<CanteenViewModel> {
             leadingIcon: const Icon(Icons.restaurant_outlined),
             onPressed: () async {
               await SelectCanteenLocationDialog(
-                _viewModel.locationService,
+                model.locationService,
               ).show(context);
-              await _viewModel.reloadSelectedLocation();
+              await model.reloadSelectedLocation();
             },
             child: Text(L.of(context).settingsSetupCanteenLocation),
           ),
           MenuItemButton(
             leadingIcon: const Icon(Icons.help_outline),
             onPressed: () async {
-              await CanteenHelpDialog(_viewModel).show(context);
+              await CanteenHelpDialog(model).show(context);
             },
             child: Text(L.of(context).helpButtonTooltip),
           ),

--- a/lib/canteen/ui/viewmodels/canteen_view_model.dart
+++ b/lib/canteen/ui/viewmodels/canteen_view_model.dart
@@ -46,6 +46,21 @@ class CanteenViewModel extends BaseViewModel {
   CanteenViewModel(this._provider, this._locationService)
     : todayWeekStart = toStartOfDay(toMonday(DateTime.now()));
 
+  Future<void> prepareForNavigation() async {
+    if (isPerformanceFixtureMode) {
+      await _loadPerformanceFixtureData();
+      return;
+    }
+
+    await _loadSelectedLocation();
+    if (isDisposed || hasWeekData(todayWeekStart)) return;
+    await loadWeek(
+      todayWeekStart,
+      allowNetworkRefresh: false,
+      prefetchNextWeek: false,
+    );
+  }
+
   void initialize() {
     if (_initialized) return;
     _initialized = true;

--- a/lib/common/appstart/interaction_idle_coordinator.dart
+++ b/lib/common/appstart/interaction_idle_coordinator.dart
@@ -119,6 +119,7 @@ class InteractionIdleCoordinator {
     _tasksById[taskId] = task;
     _queue.add(task);
     _idleFrameObserved = false;
+    _ensureInitialQuietPeriodTimer();
 
     if (delay > Duration.zero) {
       task.timer = Timer(delay, () {
@@ -243,6 +244,21 @@ class InteractionIdleCoordinator {
   }
 
   bool get _hasReadyTask => _queue.any((task) => !task.cancelled && task.ready);
+
+  void _ensureInitialQuietPeriodTimer() {
+    if (_taskQuietPeriod == Duration.zero ||
+        _taskQuietElapsed ||
+        hasActiveInteraction ||
+        _taskQuietTimer != null) {
+      return;
+    }
+    _taskQuietTimer = Timer(_taskQuietPeriod, () {
+      if (_disposed) return;
+      _taskQuietTimer = null;
+      _taskQuietElapsed = true;
+      _wake();
+    });
+  }
 
   bool get _taskQuietPeriodElapsed => _taskQuietElapsed;
 

--- a/lib/common/appstart/interaction_idle_coordinator.dart
+++ b/lib/common/appstart/interaction_idle_coordinator.dart
@@ -1,0 +1,416 @@
+import 'dart:async';
+
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+typedef IdleTaskAction = FutureOr<void> Function();
+
+/// Coordinates work that is safe to run only when the user and the frame
+/// scheduler are idle.
+///
+/// Interaction ids are counted rather than represented by one boolean. This
+/// lets overlapping pointer, scroll, route, and animation signals release
+/// independently without allowing an old signal to make the app look idle.
+class InteractionIdleCoordinator {
+  InteractionIdleCoordinator({
+    bool Function()? isFrameActive,
+    Duration taskQuietPeriod = Duration.zero,
+  }) : _isFrameActive = isFrameActive ?? _neverFrameBlocked,
+       _taskQuietPeriod = taskQuietPeriod,
+       _taskQuietElapsed = taskQuietPeriod == Duration.zero;
+
+  static final InteractionIdleCoordinator instance = InteractionIdleCoordinator(
+    taskQuietPeriod: const Duration(milliseconds: 180),
+  );
+
+  final bool Function() _isFrameActive;
+  final Duration _taskQuietPeriod;
+  final Map<String, int> _activeInteractions = <String, int>{};
+  final List<_QueuedIdleTask> _queue = <_QueuedIdleTask>[];
+  final Map<String, _QueuedIdleTask> _tasksById = <String, _QueuedIdleTask>{};
+  final List<Completer<void>> _idleWaiters = <Completer<void>>[];
+
+  bool _pumpScheduled = false;
+  bool _frameWaitScheduled = false;
+  bool _idleFrameScheduled = false;
+  bool _idleFrameObserved = false;
+  bool _taskRunning = false;
+  bool _disposed = false;
+  bool _taskQuietElapsed;
+  Timer? _taskQuietTimer;
+
+  bool get isDisposed => _disposed;
+
+  bool get hasActiveInteraction => _activeInteractions.isNotEmpty;
+
+  bool get isIdle => !hasActiveInteraction && !_isFrameActive();
+
+  static bool _neverFrameBlocked() => false;
+
+  /// Starts an interaction and returns a lease that can be released exactly
+  /// once by its owner.
+  InteractionLease beginInteraction(String interactionId) {
+    if (_disposed) {
+      return InteractionLease._(() {});
+    }
+
+    _activeInteractions.update(
+      interactionId,
+      (count) => count + 1,
+      ifAbsent: () => 1,
+    );
+    _taskQuietTimer?.cancel();
+    _taskQuietTimer = null;
+    if (_taskQuietPeriod > Duration.zero) {
+      _taskQuietElapsed = false;
+    }
+    _idleFrameObserved = false;
+    _wake();
+    return InteractionLease._(() => endInteraction(interactionId));
+  }
+
+  void endInteraction(String interactionId) {
+    if (_disposed) return;
+
+    final count = _activeInteractions[interactionId];
+    if (count == null) return;
+    if (count <= 1) {
+      _activeInteractions.remove(interactionId);
+    } else {
+      _activeInteractions[interactionId] = count - 1;
+    }
+    if (!hasActiveInteraction) {
+      _taskQuietTimer?.cancel();
+      if (_taskQuietPeriod == Duration.zero) {
+        _taskQuietElapsed = true;
+      } else {
+        _taskQuietElapsed = false;
+        _taskQuietTimer = Timer(_taskQuietPeriod, () {
+          _taskQuietTimer = null;
+          _taskQuietElapsed = true;
+          _wake();
+        });
+      }
+    }
+    _idleFrameObserved = false;
+    _wake();
+  }
+
+  /// Schedules one task. Tasks are FIFO and strictly serialized, so section
+  /// preparation cannot fan out several cache/database reads at once.
+  ///
+  /// A task remains queued while an interaction or frame animation is active.
+  /// [delay] preserves existing startup timing without making that timing the
+  /// only signal used to decide whether work is safe to run.
+  InteractionIdleTask schedule(
+    String taskId,
+    IdleTaskAction action, {
+    Duration delay = Duration.zero,
+  }) {
+    final existing = _tasksById[taskId];
+    if (existing != null) return existing.handle;
+
+    final task = _QueuedIdleTask(
+      coordinator: this,
+      id: taskId,
+      action: action,
+      ready: delay == Duration.zero,
+    );
+    _tasksById[taskId] = task;
+    _queue.add(task);
+    _idleFrameObserved = false;
+
+    if (delay > Duration.zero) {
+      task.timer = Timer(delay, () {
+        if (task.cancelled || _disposed) return;
+        task.ready = true;
+        _wake();
+      });
+    }
+
+    _wake();
+    return task.handle;
+  }
+
+  Future<void> waitForIdle() {
+    if (_disposed || (isIdle && _idleFrameObserved)) {
+      return Future<void>.value();
+    }
+
+    final completer = Completer<void>();
+    _idleWaiters.add(completer);
+    _wake();
+    return completer.future;
+  }
+
+  /// Wakes the coordinator after an externally observed frame-state change.
+  /// This is useful for scroll/animation adapters and deterministic tests.
+  void notifyFrameStateChanged() => _wake();
+
+  void _wake() {
+    if (_disposed || _pumpScheduled) return;
+    _pumpScheduled = true;
+    scheduleMicrotask(() {
+      _pumpScheduled = false;
+      _pump();
+    });
+  }
+
+  void _pump() {
+    if (_disposed) return;
+
+    if (hasActiveInteraction) {
+      _idleFrameObserved = false;
+      return;
+    }
+
+    if (_isFrameActive()) {
+      _idleFrameObserved = false;
+      _waitForNextFrameIfNeeded();
+      return;
+    }
+
+    if (!_idleFrameObserved) {
+      if (_idleWaiters.isEmpty && _hasReadyTask && !_taskQuietPeriodElapsed) {
+        return;
+      }
+      _waitForInteractionFreeFrame();
+      return;
+    }
+
+    _completeIdleWaiters();
+    if (_taskRunning) return;
+
+    _QueuedIdleTask? nextTask;
+    for (final task in _queue) {
+      if (!task.cancelled && task.ready) {
+        nextTask = task;
+        break;
+      }
+    }
+    if (nextTask == null) return;
+    if (!_taskQuietPeriodElapsed) {
+      return;
+    }
+
+    _queue.remove(nextTask);
+    _taskRunning = true;
+    nextTask.started = true;
+    unawaited(_runTask(nextTask));
+  }
+
+  Future<void> _runTask(_QueuedIdleTask task) async {
+    try {
+      if (!task.cancelled && !_disposed) {
+        await task.action();
+      }
+      task.complete();
+    } catch (error, trace) {
+      task.completeError(error, trace);
+    } finally {
+      if (identical(_tasksById[task.id], task)) {
+        _tasksById.remove(task.id);
+      }
+      _taskRunning = false;
+      _idleFrameObserved = false;
+      _pump();
+    }
+  }
+
+  void _waitForNextFrameIfNeeded() {
+    if (_frameWaitScheduled) return;
+    _frameWaitScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _frameWaitScheduled = false;
+      _wake();
+    });
+  }
+
+  void _waitForInteractionFreeFrame() {
+    if (_idleFrameScheduled) return;
+    _idleFrameScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _idleFrameScheduled = false;
+      if (_disposed) return;
+      if (hasActiveInteraction || _isFrameActive()) {
+        _idleFrameObserved = false;
+      } else {
+        _idleFrameObserved = true;
+      }
+      _wake();
+    });
+    SchedulerBinding.instance.scheduleFrame();
+  }
+
+  bool get _hasReadyTask => _queue.any((task) => !task.cancelled && task.ready);
+
+  bool get _taskQuietPeriodElapsed => _taskQuietElapsed;
+
+  void _completeIdleWaiters() {
+    if (!isIdle || !_idleFrameObserved) return;
+    final waiters = List<Completer<void>>.from(_idleWaiters);
+    _idleWaiters.clear();
+    for (final waiter in waiters) {
+      if (!waiter.isCompleted) waiter.complete();
+    }
+  }
+
+  void _cancel(_QueuedIdleTask task) {
+    if (task.cancelled) return;
+    task.cancelled = true;
+    task.timer?.cancel();
+    _queue.remove(task);
+    _tasksById.remove(task.id);
+    if (!task.started) task.complete();
+    _wake();
+  }
+
+  /// Stops queued work owned by this coordinator. A task already running is
+  /// allowed to finish because Dart futures cannot be force-cancelled safely.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _taskQuietTimer?.cancel();
+    _taskQuietTimer = null;
+    for (final task in List<_QueuedIdleTask>.from(_queue)) {
+      task.cancelled = true;
+      task.timer?.cancel();
+      task.complete();
+    }
+    _queue.clear();
+    _tasksById.clear();
+    for (final waiter in _idleWaiters) {
+      if (!waiter.isCompleted) waiter.complete();
+    }
+    _idleWaiters.clear();
+  }
+}
+
+/// Bridges root route transitions into the shared idle coordinator.
+class InteractionAwareNavigatorObserver extends NavigatorObserver {
+  InteractionAwareNavigatorObserver(this.coordinator);
+
+  final InteractionIdleCoordinator coordinator;
+  final Map<Route<dynamic>, InteractionLease> _routeLeases =
+      <Route<dynamic>, InteractionLease>{};
+  final Map<Route<dynamic>, AnimationStatusListener> _routeListeners =
+      <Route<dynamic>, AnimationStatusListener>{};
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _trackRoute(route, 'push', AnimationStatus.completed);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    _trackRoute(route, 'pop', AnimationStatus.dismissed);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (oldRoute != null) _releaseRoute(oldRoute);
+    if (newRoute != null) {
+      _trackRoute(newRoute, 'replace', AnimationStatus.completed);
+    }
+  }
+
+  void _trackRoute(
+    Route<dynamic> route,
+    String phase,
+    AnimationStatus settledStatus,
+  ) {
+    _releaseRoute(route);
+    final lease = coordinator.beginInteraction(
+      'route.${phase}.${identityHashCode(route)}',
+    );
+    _routeLeases[route] = lease;
+    final animation = route is ModalRoute<dynamic> ? route.animation : null;
+    if (animation == null || animation.status == settledStatus) {
+      scheduleMicrotask(() => _releaseRoute(route));
+      return;
+    }
+
+    void onStatusChanged(AnimationStatus status) {
+      if (status != settledStatus) return;
+      _releaseRoute(route);
+    }
+
+    _routeListeners[route] = onStatusChanged;
+    animation.addStatusListener(onStatusChanged);
+  }
+
+  void _releaseRoute(Route<dynamic> route) {
+    final listener = _routeListeners.remove(route);
+    final animation = route is ModalRoute<dynamic> ? route.animation : null;
+    if (listener != null && animation != null) {
+      animation.removeStatusListener(listener);
+    }
+    _routeLeases.remove(route)?.release();
+  }
+
+  void dispose() {
+    for (final route in List<Route<dynamic>>.from(_routeLeases.keys)) {
+      _releaseRoute(route);
+    }
+    _routeListeners.clear();
+  }
+}
+
+class InteractionLease {
+  InteractionLease._(this._release);
+
+  final void Function() _release;
+  bool _released = false;
+
+  bool get isReleased => _released;
+
+  void release() {
+    if (_released) return;
+    _released = true;
+    _release();
+  }
+}
+
+class InteractionIdleTask {
+  InteractionIdleTask._(this._queued);
+
+  final _QueuedIdleTask _queued;
+
+  Future<void> get future => _queued.completer.future;
+  bool get isCancelled => _queued.cancelled;
+  bool get isStarted => _queued.started;
+
+  void cancel() => _queued.coordinator._cancel(_queued);
+}
+
+class _QueuedIdleTask {
+  _QueuedIdleTask({
+    required this.coordinator,
+    required this.id,
+    required this.action,
+    required this.ready,
+  }) {
+    handle = InteractionIdleTask._(this);
+  }
+
+  final InteractionIdleCoordinator coordinator;
+  final String id;
+  final IdleTaskAction action;
+  final Completer<void> completer = Completer<void>();
+  late final InteractionIdleTask handle;
+  Timer? timer;
+  bool ready;
+  bool started = false;
+  bool cancelled = false;
+
+  void complete() {
+    if (!completer.isCompleted) completer.complete();
+  }
+
+  void completeError(Object error, StackTrace trace) {
+    if (!completer.isCompleted) completer.completeError(error, trace);
+  }
+}

--- a/lib/date_management/ui/date_management_navigation_entry.dart
+++ b/lib/date_management/ui/date_management_navigation_entry.dart
@@ -12,8 +12,6 @@ import 'package:property_change_notifier/property_change_notifier.dart';
 
 class DateManagementNavigationEntry
     extends NavigationEntry<DateManagementViewModel> {
-  DateManagementViewModel? _viewModel;
-
   @override
   Widget icon(BuildContext context) {
     return Icon(Icons.date_range);
@@ -26,12 +24,16 @@ class DateManagementNavigationEntry
 
   @override
   DateManagementViewModel initViewModel() {
-    _viewModel ??= DateManagementViewModel(
+    return DateManagementViewModel(
       KiwiContainer().resolve(),
       KiwiContainer().resolve(),
       KiwiContainer().resolve(),
     );
-    return _viewModel!;
+  }
+
+  @override
+  Future<void> prepareSection() async {
+    await viewModel().prepare();
   }
 
   @override

--- a/lib/date_management/ui/viewmodels/date_management_view_model.dart
+++ b/lib/date_management/ui/viewmodels/date_management_view_model.dart
@@ -116,7 +116,8 @@ class DateManagementViewModel extends BaseViewModel {
   bool _isLoading = false;
   bool get isLoading => _isLoading;
 
-  bool _initialized = false;
+  Future<void>? _preparationFuture;
+  Future<void>? _pageInitializationFuture;
 
   bool _isReloadingPreferences = false;
 
@@ -172,12 +173,39 @@ class DateManagementViewModel extends BaseViewModel {
   }
 
   void initialize() {
-    if (_initialized) return;
-    _initialized = true;
-    _loadDefaultSelection().catchError((error, trace) {
+    unawaited(_initializeForPage());
+  }
+
+  Future<void> prepare() {
+    final existingPreparation = _preparationFuture;
+    if (existingPreparation != null) {
+      return existingPreparation;
+    }
+
+    final preparation = _loadDefaultSelection(loadData: false).catchError((
+      error,
+      trace,
+    ) {
       print("Failed to load default selection: $error");
       print(trace);
     });
+    _preparationFuture = preparation;
+    return preparation;
+  }
+
+  Future<void> _initializeForPage() {
+    final existingInitialization = _pageInitializationFuture;
+    if (existingInitialization != null) {
+      return existingInitialization;
+    }
+
+    final initialization = () async {
+      await prepare();
+      if (_isDisposed) return;
+      await updateDates();
+    }();
+    _pageInitializationFuture = initialization;
+    return initialization;
   }
 
   void _buildYearsArray() {
@@ -505,7 +533,7 @@ class DateManagementViewModel extends BaseViewModel {
     _preferencesProvider.setLastViewedDateEntryYear(year);
   }
 
-  Future<void> _loadDefaultSelection() async {
+  Future<void> _loadDefaultSelection({required bool loadData}) async {
     _useDhMineForDates = await _preferencesProvider.getUseDhMineForDates();
     if (_isDisposed) return;
     _notifySafely("useDhMineForDates");
@@ -534,7 +562,9 @@ class DateManagementViewModel extends BaseViewModel {
       setCurrentSelectedYear(_currentSelectedYear);
     }
 
-    await updateDates();
+    if (loadData) {
+      await updateDates();
+    }
   }
 
   DateRange _buildInitialRaplaWindow() {

--- a/lib/schedule/ui/schedule_navigation_entry.dart
+++ b/lib/schedule/ui/schedule_navigation_entry.dart
@@ -26,7 +26,7 @@ class ScheduleNavigationEntry extends NavigationEntry<ScheduleViewModel> {
 
   @override
   Future<void> prepareSection() async {
-    viewModel().initialize();
+    viewModel();
     await SchedulePage.prepareForActivation();
   }
 

--- a/lib/schedule/ui/schedule_navigation_entry.dart
+++ b/lib/schedule/ui/schedule_navigation_entry.dart
@@ -14,8 +14,6 @@ import 'package:kiwi/kiwi.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 
 class ScheduleNavigationEntry extends NavigationEntry<ScheduleViewModel> {
-  late ScheduleViewModel _viewModel;
-
   @override
   Widget icon(BuildContext context) {
     return Icon(Icons.calendar_today);
@@ -23,10 +21,13 @@ class ScheduleNavigationEntry extends NavigationEntry<ScheduleViewModel> {
 
   @override
   ScheduleViewModel initViewModel() {
-    _viewModel = ScheduleViewModel(
-      KiwiContainer().resolve(),
-    );
-    return _viewModel;
+    return ScheduleViewModel(KiwiContainer().resolve());
+  }
+
+  @override
+  Future<void> prepareSection() async {
+    viewModel().initialize();
+    await SchedulePage.prepareForActivation();
   }
 
   @override
@@ -47,84 +48,81 @@ class ScheduleNavigationEntry extends NavigationEntry<ScheduleViewModel> {
         value: viewModel,
         child: PropertyChangeConsumer<ScheduleViewModel, String>(
           properties: const ["didSetupProperly"],
-          builder: (
-            BuildContext _,
-            ScheduleViewModel? __,
-            Set<String>? ___,
-          ) =>
+          builder: (BuildContext _, ScheduleViewModel? __, Set<String>? ___) =>
               viewModel.didSetupProperly
-                  ? Container()
-                  : IconButton(
-                      icon: Icon(Icons.help_outline),
-                      onPressed: () async {
-                        await ScheduleHelpDialog().show(context);
-                      },
-                      tooltip: L.of(context).helpButtonTooltip,
-                    ),
+              ? Container()
+              : IconButton(
+                  icon: Icon(Icons.help_outline),
+                  onPressed: () async {
+                    await ScheduleHelpDialog().show(context);
+                  },
+                  tooltip: L.of(context).helpButtonTooltip,
+                ),
         ),
       ),
       PropertyChangeProvider<ScheduleViewModel, String>(
         value: viewModel,
         child: PropertyChangeConsumer<ScheduleViewModel, String>(
           properties: const ["didSetupProperly"],
-          builder: (
-            BuildContext _,
-            ScheduleViewModel? __,
-            Set<String>? ___,
-          ) =>
+          builder: (BuildContext _, ScheduleViewModel? __, Set<String>? ___) =>
               viewModel.didSetupProperly
-                  ? IconButton(
-                      icon: Icon(Icons.filter_alt),
-                      onPressed: () async {
-                        final scheduleEntryRepository =
-                            KiwiContainer().resolve<ScheduleEntryRepository>();
-                        final scheduleFilterRepository =
-                            KiwiContainer().resolve<ScheduleFilterRepository>();
-                        final preloadFuture = FilterViewModel.preloadStates(
-                          scheduleEntryRepository,
-                          scheduleFilterRepository,
-                        );
-                        final didChangeFilters =
-                            await Navigator.of(context).push<bool>(
+              ? IconButton(
+                  icon: Icon(Icons.filter_alt),
+                  onPressed: () async {
+                    final scheduleEntryRepository = KiwiContainer()
+                        .resolve<ScheduleEntryRepository>();
+                    final scheduleFilterRepository = KiwiContainer()
+                        .resolve<ScheduleFilterRepository>();
+                    final preloadFuture = FilterViewModel.preloadStates(
+                      scheduleEntryRepository,
+                      scheduleFilterRepository,
+                    );
+                    final didChangeFilters = await Navigator.of(context)
+                        .push<bool>(
                           PageRouteBuilder<bool>(
-                            transitionDuration:
-                                const Duration(milliseconds: 180),
-                            reverseTransitionDuration:
-                                const Duration(milliseconds: 160),
+                            transitionDuration: const Duration(
+                              milliseconds: 180,
+                            ),
+                            reverseTransitionDuration: const Duration(
+                              milliseconds: 160,
+                            ),
                             pageBuilder:
                                 (context, animation, secondaryAnimation) =>
                                     ScheduleFilterPage(
-                              preloadFuture: preloadFuture,
-                            ),
-                            transitionsBuilder: (context, animation,
-                                secondaryAnimation, child) {
-                              final opacityTween = Tween<double>(
-                                begin: 0,
-                                end: 1,
-                              ).chain(
-                                CurveTween(curve: Curves.easeOutCubic),
-                              );
+                                      preloadFuture: preloadFuture,
+                                    ),
+                            transitionsBuilder:
+                                (
+                                  context,
+                                  animation,
+                                  secondaryAnimation,
+                                  child,
+                                ) {
+                                  final opacityTween =
+                                      Tween<double>(begin: 0, end: 1).chain(
+                                        CurveTween(curve: Curves.easeOutCubic),
+                                      );
 
-                              return FadeTransition(
-                                opacity: animation.drive(opacityTween),
-                                child: child,
-                              );
-                            },
+                                  return FadeTransition(
+                                    opacity: animation.drive(opacityTween),
+                                    child: child,
+                                  );
+                                },
                           ),
                         );
-                        if (didChangeFilters == true) {
-                          final scheduleProvider =
-                              KiwiContainer().resolve<ScheduleProvider>();
-                          final scheduleSourceProvider =
-                              KiwiContainer().resolve<ScheduleSourceProvider>();
-                          scheduleProvider.invalidateScheduleCache();
-                          scheduleSourceProvider.fireScheduleSourceChanged();
-                        }
-                      },
-                    )
-                  : Container(),
+                    if (didChangeFilters == true) {
+                      final scheduleProvider = KiwiContainer()
+                          .resolve<ScheduleProvider>();
+                      final scheduleSourceProvider = KiwiContainer()
+                          .resolve<ScheduleSourceProvider>();
+                      scheduleProvider.invalidateScheduleCache();
+                      scheduleSourceProvider.fireScheduleSourceChanged();
+                    }
+                  },
+                )
+              : Container(),
         ),
-      )
+      ),
     ];
   }
 

--- a/lib/schedule/ui/schedule_page.dart
+++ b/lib/schedule/ui/schedule_page.dart
@@ -25,6 +25,14 @@ class SchedulePage extends StatefulWidget {
     _sharedWeeklyScheduleViewModel = null;
   }
 
+  static Future<void> prepareForActivation() {
+    SchedulePage._sharedWeeklyScheduleViewModel ??= WeeklyScheduleViewModel(
+      KiwiContainer().resolve(),
+      KiwiContainer().resolve(),
+    );
+    return SchedulePage._sharedWeeklyScheduleViewModel!.initialize();
+  }
+
   @override
   _SchedulePageState createState() => _SchedulePageState();
 }

--- a/lib/schedule/ui/schedule_page.dart
+++ b/lib/schedule/ui/schedule_page.dart
@@ -30,7 +30,7 @@ class SchedulePage extends StatefulWidget {
       KiwiContainer().resolve(),
       KiwiContainer().resolve(),
     );
-    return SchedulePage._sharedWeeklyScheduleViewModel!.initialize();
+    return SchedulePage._sharedWeeklyScheduleViewModel!.prepareCachedSchedule();
   }
 
   @override

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -134,6 +134,21 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     return toStartOfDay(toDayOfWeek(now, DateTime.monday));
   }
 
+  Future<void> prepareCachedSchedule() async {
+    if (_isDisposed) return;
+    final start = toStartOfDay(toDayOfWeek(now, DateTime.monday));
+    final end = toNextWeek(start);
+    currentDateStart = start;
+    currentDateEnd = end;
+
+    final cachedSchedule =
+        _lastCachedSchedule ??
+        await scheduleProvider.getCachedSchedule(start, end);
+    if (_isDisposed) return;
+    _applyVisibleSchedule(cachedSchedule, start, end);
+    _lastCachedSchedule = cachedSchedule;
+  }
+
   Future<void> initialize() async {
     if (_initialized) return;
     _initialized = true;

--- a/lib/ui/main_page.dart
+++ b/lib/ui/main_page.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 
+import 'package:dualmate/common/appstart/interaction_idle_coordinator.dart';
+import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/ui/app_launch_dialogs.dart';
 import 'package:dualmate/common/util/platform_util.dart';
-import 'package:dualmate/ui/navigation/navigation_entry.dart';
 import 'package:dualmate/ui/navigation/main_section_controller.dart';
+import 'package:dualmate/ui/navigation/navigation_entry.dart';
 import 'package:dualmate/ui/navigation/router.dart';
 import 'package:dualmate/ui/navigation_drawer.dart';
-import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:flutter/material.dart';
 import 'package:kiwi/kiwi.dart';
 import 'package:provider/provider.dart';
@@ -19,11 +20,15 @@ import 'package:provider/provider.dart';
 class MainPage extends StatefulWidget {
   final String? initialRoute;
   final bool showAppLaunchDialogs;
+  final List<NavigationEntry>? entries;
+  final InteractionIdleCoordinator? interactionCoordinator;
 
   const MainPage({
     Key? key,
     this.initialRoute,
     this.showAppLaunchDialogs = true,
+    this.entries,
+    this.interactionCoordinator,
   }) : super(key: key);
 
   @override
@@ -31,38 +36,52 @@ class MainPage extends StatefulWidget {
 }
 
 class _MainPageState extends State<MainPage> {
-  static const Duration _drawerCloseNavigationDelay =
-      Duration(milliseconds: 260);
+  static const Duration _drawerCloseNavigationDelay = Duration(
+    milliseconds: 260,
+  );
   static const Duration _initialSectionLoadDelay = Duration(milliseconds: 220);
 
+  late final InteractionIdleCoordinator _interactionCoordinator;
   bool _appLaunchDialogsShown = false;
   int? _pendingDrawerNavigationIndex;
   Timer? _initialSectionLoadTimer;
   Timer? _pendingNavigationTimer;
   int _pendingNavigationGeneration = 0;
+  int _activationGeneration = 0;
   final ValueNotifier<int> _currentEntryIndex = ValueNotifier<int>(0);
   final ValueNotifier<bool> _isDrawerOpen = ValueNotifier<bool>(false);
-  final Map<int, Widget> _sectionCache = {};
+  final Map<int, Widget> _sectionCache = <int, Widget>{};
   final Set<int> _loadedSections = <int>{};
+  final Set<int> _preparedSections = <int>{};
+  final Map<int, InteractionIdleTask> _preparationTasks =
+      <int, InteractionIdleTask>{};
+  final Map<int, InteractionLease> _pointerLeases = <int, InteractionLease>{};
+  final Set<String> _activeScrollInteractions = <String>{};
+  InteractionLease? _drawerAnimationLease;
+  Timer? _drawerAnimationTimer;
 
-  NavigationEntry get currentEntry =>
-      navigationEntries[_currentEntryIndex.value];
+  List<NavigationEntry> get _entries => widget.entries ?? navigationEntries;
+
+  NavigationEntry get currentEntry => _entries[_currentEntryIndex.value];
 
   @override
   void initState() {
     super.initState();
+    _interactionCoordinator =
+        widget.interactionCoordinator ?? InteractionIdleCoordinator.instance;
     final initialIndex = _targetIndexForRoute(widget.initialRoute);
     if (initialIndex != null) {
       _currentEntryIndex.value = initialIndex;
     }
-    MainSectionController.instance.routeSignal
-        .addListener(_handleExternalRouteRequest);
+    MainSectionController.instance.routeSignal.addListener(
+      _handleExternalRouteRequest,
+    );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _initialSectionLoadTimer?.cancel();
       _initialSectionLoadTimer = Timer(_initialSectionLoadDelay, () {
         if (!mounted) return;
-        _ensureCurrentSectionLoaded();
+        _requestSectionActivation(_currentEntryIndex.value);
       });
       _handleExternalRouteRequest();
     });
@@ -70,10 +89,25 @@ class _MainPageState extends State<MainPage> {
 
   @override
   void dispose() {
-    MainSectionController.instance.routeSignal
-        .removeListener(_handleExternalRouteRequest);
+    MainSectionController.instance.routeSignal.removeListener(
+      _handleExternalRouteRequest,
+    );
     _initialSectionLoadTimer?.cancel();
     _cancelPendingNavigation(clearPendingIndex: true);
+    for (final task in _preparationTasks.values) {
+      task.cancel();
+    }
+    for (final lease in _pointerLeases.values) {
+      lease.release();
+    }
+    _pointerLeases.clear();
+    for (final interactionId in _activeScrollInteractions) {
+      _interactionCoordinator.endInteraction(interactionId);
+    }
+    _activeScrollInteractions.clear();
+    _drawerAnimationTimer?.cancel();
+    _drawerAnimationLease?.release();
+    _drawerAnimationLease = null;
     _isDrawerOpen.dispose();
     _currentEntryIndex.dispose();
     super.dispose();
@@ -81,7 +115,7 @@ class _MainPageState extends State<MainPage> {
 
   @override
   Widget build(BuildContext context) {
-    _showAppLaunchDialogsIfNeeded(context);
+    _showAppLaunchDialogsIfNeeded();
 
     return ChangeNotifierProvider.value(
       value: _currentEntryIndex,
@@ -89,15 +123,10 @@ class _MainPageState extends State<MainPage> {
         builder: (BuildContext context, value, Widget? child) {
           final body = _buildSectionStack(context);
           final drawerEntries = _buildDrawerEntries();
-          Widget content;
-
           if (PlatformUtil.isTablet()) {
-            content = buildTabletLayout(context, body, drawerEntries);
-          } else {
-            content = buildPhoneLayout(context, body, drawerEntries);
+            return buildTabletLayout(context, body, drawerEntries);
           }
-
-          return content;
+          return buildPhoneLayout(context, body, drawerEntries);
         },
       ),
     );
@@ -115,7 +144,7 @@ class _MainPageState extends State<MainPage> {
     return IndexedStack(
       index: _currentEntryIndex.value,
       children: List.generate(
-        navigationEntries.length,
+        _entries.length,
         (index) => _buildSection(context, index),
       ),
     );
@@ -128,8 +157,8 @@ class _MainPageState extends State<MainPage> {
     return _sectionCache.putIfAbsent(
       index,
       () => KeyedSubtree(
-        key: ValueKey<String>("main_section_${navigationEntries[index].route}"),
-        child: navigationEntries[index].buildRoute(context),
+        key: ValueKey<String>("main_section_${_entries[index].route}"),
+        child: _entries[index].activate(context),
       ),
     );
   }
@@ -139,47 +168,60 @@ class _MainPageState extends State<MainPage> {
     Widget body,
     List<DrawerNavigationEntry> drawerEntries,
   ) {
-    return PopScope(
-      canPop: true,
-      child: Scaffold(
-        onDrawerChanged: (isOpen) {
-          if (_isDrawerOpen.value == isOpen) {
-            return;
-          }
-          _isDrawerOpen.value = isOpen;
-          if (!isOpen) {
-            _applyPendingDrawerNavigation();
-          }
-        },
-        appBar: AppBar(
-          backgroundColor: Colors.transparent,
-          actionsIconTheme: Theme.of(context).iconTheme,
-          elevation: 0,
-          iconTheme: Theme.of(context).iconTheme,
-          title: Text(currentEntry.title(context)),
-          actions: _loadedSections.contains(_currentEntryIndex.value)
-              ? currentEntry.appBarActions(context)
-              : const <Widget>[],
-          toolbarTextStyle: Theme.of(context).textTheme.bodyMedium,
-          titleTextStyle: Theme.of(context).textTheme.titleLarge,
-        ),
-        body: ValueListenableBuilder<bool>(
-          valueListenable: _isDrawerOpen,
-          child: body,
-          builder: (context, isDrawerOpen, child) {
-            return RepaintBoundary(
-              child: TickerMode(
-                enabled: !isDrawerOpen,
-                child: child ?? const SizedBox.shrink(),
+    return Listener(
+      onPointerDown: (event) {
+        _pointerLeases[event.pointer] = _interactionCoordinator
+            .beginInteraction('pointer.${event.pointer}');
+      },
+      onPointerUp: (event) => _pointerLeases.remove(event.pointer)?.release(),
+      onPointerCancel: (event) =>
+          _pointerLeases.remove(event.pointer)?.release(),
+      child: NotificationListener<ScrollNotification>(
+        onNotification: _handleScrollNotification,
+        child: PopScope(
+          canPop: true,
+          child: Scaffold(
+            onDrawerChanged: (isOpen) {
+              if (_isDrawerOpen.value == isOpen) {
+                return;
+              }
+              _isDrawerOpen.value = isOpen;
+              _trackDrawerAnimation();
+              if (!isOpen) {
+                _applyPendingDrawerNavigation();
+              }
+            },
+            appBar: AppBar(
+              backgroundColor: Colors.transparent,
+              actionsIconTheme: Theme.of(context).iconTheme,
+              elevation: 0,
+              iconTheme: Theme.of(context).iconTheme,
+              title: Text(currentEntry.title(context)),
+              actions: _loadedSections.contains(_currentEntryIndex.value)
+                  ? currentEntry.appBarActions(context)
+                  : const <Widget>[],
+              toolbarTextStyle: Theme.of(context).textTheme.bodyMedium,
+              titleTextStyle: Theme.of(context).textTheme.titleLarge,
+            ),
+            body: ValueListenableBuilder<bool>(
+              valueListenable: _isDrawerOpen,
+              child: body,
+              builder: (context, isDrawerOpen, child) {
+                return RepaintBoundary(
+                  child: TickerMode(
+                    enabled: !isDrawerOpen,
+                    child: child ?? const SizedBox.shrink(),
+                  ),
+                );
+              },
+            ),
+            drawer: RepaintBoundary(
+              child: MyNavigationDrawer(
+                selectedIndex: _currentEntryIndex.value,
+                onTap: _onNavigationTapped,
+                entries: drawerEntries,
               ),
-            );
-          },
-        ),
-        drawer: RepaintBoundary(
-          child: MyNavigationDrawer(
-            selectedIndex: _currentEntryIndex.value,
-            onTap: _onNavigationTapped,
-            entries: drawerEntries,
+            ),
           ),
         ),
       ),
@@ -191,61 +233,94 @@ class _MainPageState extends State<MainPage> {
     Widget body,
     List<DrawerNavigationEntry> drawerEntries,
   ) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        actionsIconTheme: Theme.of(context).iconTheme,
-        elevation: 0,
-        iconTheme: Theme.of(context).iconTheme,
-        title: Text(currentEntry.title(context)),
-        actions: _loadedSections.contains(_currentEntryIndex.value)
-            ? currentEntry.appBarActions(context)
-            : const <Widget>[],
-        toolbarTextStyle: Theme.of(context).textTheme.bodyMedium,
-        titleTextStyle: Theme.of(context).textTheme.titleLarge,
-      ),
-      body: Row(
-        children: [
-          SizedBox(
-            height: double.infinity,
-            width: 250,
-            child: MyNavigationDrawer(
-              selectedIndex: _currentEntryIndex.value,
-              onTap: _onNavigationTapped,
-              entries: drawerEntries,
-              isInDrawer: false,
-            ),
+    return Listener(
+      onPointerDown: (event) {
+        _pointerLeases[event.pointer] = _interactionCoordinator
+            .beginInteraction('pointer.${event.pointer}');
+      },
+      onPointerUp: (event) => _pointerLeases.remove(event.pointer)?.release(),
+      onPointerCancel: (event) =>
+          _pointerLeases.remove(event.pointer)?.release(),
+      child: NotificationListener<ScrollNotification>(
+        onNotification: _handleScrollNotification,
+        child: Scaffold(
+          appBar: AppBar(
+            backgroundColor: Colors.transparent,
+            actionsIconTheme: Theme.of(context).iconTheme,
+            elevation: 0,
+            iconTheme: Theme.of(context).iconTheme,
+            title: Text(currentEntry.title(context)),
+            actions: _loadedSections.contains(_currentEntryIndex.value)
+                ? currentEntry.appBarActions(context)
+                : const <Widget>[],
+            toolbarTextStyle: Theme.of(context).textTheme.bodyMedium,
+            titleTextStyle: Theme.of(context).textTheme.titleLarge,
           ),
-          Container(
-            color: Theme.of(context).dividerColor,
-            width: 1,
+          body: Row(
+            children: [
+              SizedBox(
+                height: double.infinity,
+                width: 250,
+                child: MyNavigationDrawer(
+                  selectedIndex: _currentEntryIndex.value,
+                  onTap: _onNavigationTapped,
+                  entries: drawerEntries,
+                  isInDrawer: false,
+                ),
+              ),
+              Container(color: Theme.of(context).dividerColor, width: 1),
+              Expanded(child: RepaintBoundary(child: body), flex: 3),
+            ],
           ),
-          Expanded(
-            child: RepaintBoundary(child: body),
-            flex: 3,
-          ),
-        ],
+        ),
       ),
     );
   }
 
   List<DrawerNavigationEntry> _buildDrawerEntries() {
-    var drawerEntries = <DrawerNavigationEntry>[];
+    return <DrawerNavigationEntry>[
+      for (final entry in _entries)
+        DrawerNavigationEntry(
+          entry.icon(context),
+          entry.title(context),
+          entry.route,
+        ),
+    ];
+  }
 
-    for (var entry in navigationEntries) {
-      drawerEntries.add(DrawerNavigationEntry(
-        entry.icon(context),
-        entry.title(context),
-        entry.route,
-      ));
+  bool _handleScrollNotification(ScrollNotification notification) {
+    final interactionId =
+        'scroll.${identityHashCode(notification.context ?? notification.metrics)}';
+    if (notification is ScrollStartNotification) {
+      if (_activeScrollInteractions.add(interactionId)) {
+        _interactionCoordinator.beginInteraction(interactionId);
+      }
+    } else if (notification is ScrollEndNotification) {
+      if (_activeScrollInteractions.remove(interactionId)) {
+        _interactionCoordinator.endInteraction(interactionId);
+      }
     }
+    return false;
+  }
 
-    return drawerEntries;
+  void _trackDrawerAnimation() {
+    _drawerAnimationTimer?.cancel();
+    _drawerAnimationLease?.release();
+    final lease = _interactionCoordinator.beginInteraction('drawer.animation');
+    _drawerAnimationLease = lease;
+    _drawerAnimationTimer = Timer(_drawerCloseNavigationDelay, () {
+      lease.release();
+      if (identical(_drawerAnimationLease, lease)) {
+        _drawerAnimationLease = null;
+      }
+    });
   }
 
   void _onNavigationTapped(int index, bool fromDrawer) {
-    PerformanceTelemetry.instance
-        .markNavEvent(name: "drawer.tab.${navigationEntries[index].route}");
+    if (index < 0 || index >= _entries.length) return;
+    PerformanceTelemetry.instance.markNavEvent(
+      name: "drawer.tab.${_entries[index].route}",
+    );
 
     if (fromDrawer) {
       _cancelPendingNavigation();
@@ -253,7 +328,7 @@ class _MainPageState extends State<MainPage> {
       return;
     }
 
-    _setCurrentEntryIndex(index);
+    _requestSectionActivation(index);
   }
 
   void _applyPendingDrawerNavigation() {
@@ -265,6 +340,7 @@ class _MainPageState extends State<MainPage> {
 
     _cancelPendingNavigation();
     final generation = _pendingNavigationGeneration;
+    final preparation = _prepareSection(pendingIndex);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || generation != _pendingNavigationGeneration) {
@@ -275,7 +351,13 @@ class _MainPageState extends State<MainPage> {
         if (!mounted || generation != _pendingNavigationGeneration) {
           return;
         }
-        _setCurrentEntryIndex(pendingIndex);
+        unawaited(
+          _activateAfterPreparation(
+            pendingIndex,
+            preparation,
+            ++_activationGeneration,
+          ),
+        );
       });
     });
   }
@@ -283,28 +365,73 @@ class _MainPageState extends State<MainPage> {
   void _setCurrentEntryFromRoute(String? route) {
     final targetIndex = _targetIndexForRoute(route);
     if (targetIndex == null) return;
-    _setCurrentEntryIndex(targetIndex);
+    _requestSectionActivation(targetIndex);
   }
 
   int? _targetIndexForRoute(String? route) {
     if (route == null) return null;
-
-    final targetIndex =
-        navigationEntries.indexWhere((entry) => entry.route == route);
-    if (targetIndex < 0) {
-      return null;
-    }
-
-    return targetIndex;
+    final targetIndex = _entries.indexWhere((entry) => entry.route == route);
+    return targetIndex < 0 ? null : targetIndex;
   }
 
-  void _setCurrentEntryIndex(int index) {
+  void _requestSectionActivation(int index) {
+    if (index < 0 || index >= _entries.length) return;
+    _initialSectionLoadTimer?.cancel();
     _cancelPendingNavigation(clearPendingIndex: true);
-    if (index < 0 || index >= navigationEntries.length) return;
-    if (_loadedSections.add(index) && mounted) {
+    final generation = ++_activationGeneration;
+    final preparation = _prepareSection(index);
+    unawaited(_activateAfterPreparation(index, preparation, generation));
+  }
+
+  Future<void> _activateAfterPreparation(
+    int index,
+    Future<void> preparation,
+    int generation,
+  ) async {
+    // Preparation is opportunistic. It may complete before activation, or it
+    // may continue on the section-owned view model after the page is mounted.
+    // Navigation must never wait on a network-backed preparation future.
+    unawaited(preparation.catchError((_) {}));
+
+    if (!mounted || generation != _activationGeneration) return;
+    await _interactionCoordinator.waitForIdle();
+    if (!mounted || generation != _activationGeneration) return;
+
+    if (_loadedSections.add(index)) {
       setState(() {});
     }
     _currentEntryIndex.value = index;
+  }
+
+  Future<void> _prepareSection(int index) {
+    if (_preparedSections.contains(index)) return Future<void>.value();
+    final existing = _preparationTasks[index];
+    if (existing != null) return existing.future;
+
+    final entry = _entries[index];
+    final task = _interactionCoordinator.schedule(
+      'navigation.prepare.${identityHashCode(this)}.${entry.route}',
+      () async {
+        await entry.prepare();
+        _preparedSections.add(index);
+      },
+    );
+    _preparationTasks[index] = task;
+    unawaited(
+      task.future.then<void>(
+        (_) {
+          if (identical(_preparationTasks[index], task)) {
+            _preparationTasks.remove(index);
+          }
+        },
+        onError: (Object _, StackTrace __) {
+          if (identical(_preparationTasks[index], task)) {
+            _preparationTasks.remove(index);
+          }
+        },
+      ),
+    );
+    return task.future;
   }
 
   void _cancelPendingNavigation({bool clearPendingIndex = false}) {
@@ -316,37 +443,20 @@ class _MainPageState extends State<MainPage> {
     }
   }
 
-  void _ensureCurrentSectionLoaded() {
-    if (_loadedSections.contains(_currentEntryIndex.value)) {
-      return;
-    }
-
-    setState(() {
-      _loadedSections.add(_currentEntryIndex.value);
-    });
-  }
-
   void _handleExternalRouteRequest() {
     final route = MainSectionController.instance.consumePendingRoute();
     if (route == null) return;
     _setCurrentEntryFromRoute(route);
   }
 
-  void _showAppLaunchDialogsIfNeeded(BuildContext context) {
-    if (!widget.showAppLaunchDialogs) {
-      return;
-    }
-
-    if (!_appLaunchDialogsShown) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Future.delayed(const Duration(milliseconds: 1200), () {
-          if (!mounted) return;
-          AppLaunchDialog(KiwiContainer().resolve())
-              .showAppLaunchDialogs(context);
-        });
-      });
-
-      _appLaunchDialogsShown = true;
-    }
+  void _showAppLaunchDialogsIfNeeded() {
+    if (!widget.showAppLaunchDialogs || _appLaunchDialogsShown) return;
+    _appLaunchDialogsShown = true;
+    _interactionCoordinator.schedule('startup.appLaunchDialogs', () async {
+      if (!mounted) return;
+      await AppLaunchDialog(
+        KiwiContainer().resolve(),
+      ).showAppLaunchDialogs(context);
+    }, delay: const Duration(milliseconds: 1200));
   }
 }

--- a/lib/ui/navigation/navigation_entry.dart
+++ b/lib/ui/navigation/navigation_entry.dart
@@ -4,6 +4,8 @@ import 'package:provider/provider.dart';
 
 abstract class NavigationEntry<T extends BaseViewModel> {
   T? _viewModel;
+  Future<void>? _preparation;
+  NavigationEntryLifecycle _lifecycle = NavigationEntryLifecycle.cold;
 
   String get route;
 
@@ -11,22 +13,67 @@ abstract class NavigationEntry<T extends BaseViewModel> {
 
   Widget icon(BuildContext context);
 
-  Widget buildRoute(BuildContext context) {
-    var model = viewModel();
-    return ChangeNotifierProvider<T>.value(
-      value: model,
-      child: build(context),
-    );
+  NavigationEntryLifecycle get lifecycle => _lifecycle;
+
+  Future<void> prepare() {
+    _resetDisposedViewModel();
+    final existingPreparation = _preparation;
+    if (existingPreparation != null) {
+      return existingPreparation;
+    }
+
+    _lifecycle = NavigationEntryLifecycle.preparing;
+    final preparation = _prepare();
+    _preparation = preparation;
+    return preparation;
   }
+
+  Future<void> _prepare() async {
+    try {
+      viewModel();
+      await prepareSection();
+      if (_lifecycle != NavigationEntryLifecycle.active) {
+        _lifecycle = NavigationEntryLifecycle.prepared;
+      }
+    } catch (_) {
+      if (_lifecycle != NavigationEntryLifecycle.active) {
+        _lifecycle = NavigationEntryLifecycle.failed;
+      }
+      _preparation = null;
+      rethrow;
+    }
+  }
+
+  /// Hook for section-owned view-model/cache preparation. It must not mount
+  /// widgets; activation is the only lifecycle phase that builds a route.
+  Future<void> prepareSection() async {}
+
+  Widget activate(BuildContext context) {
+    final model = viewModel();
+    _lifecycle = NavigationEntryLifecycle.active;
+    return ChangeNotifierProvider<T>.value(value: model, child: build(context));
+  }
+
+  Widget buildRoute(BuildContext context) => activate(context);
 
   Widget build(BuildContext context);
 
   T viewModel() {
+    _resetDisposedViewModel();
     _viewModel ??= initViewModel();
     return _viewModel!;
+  }
+
+  void _resetDisposedViewModel() {
+    if (!(_viewModel?.isDisposed ?? false)) return;
+    _viewModel = null;
+    _preparation = null;
+    _lifecycle = NavigationEntryLifecycle.cold;
   }
 
   T initViewModel();
 
   List<Widget> appBarActions(BuildContext context) => [];
 }
+
+enum NavigationEntryLifecycle { cold, preparing, prepared, active, failed }

--- a/lib/ui/navigation/navigation_entry.dart
+++ b/lib/ui/navigation/navigation_entry.dart
@@ -22,7 +22,9 @@ abstract class NavigationEntry<T extends BaseViewModel> {
       return existingPreparation;
     }
 
-    _lifecycle = NavigationEntryLifecycle.preparing;
+    if (_lifecycle != NavigationEntryLifecycle.active) {
+      _lifecycle = NavigationEntryLifecycle.preparing;
+    }
     final preparation = _prepare();
     _preparation = preparation;
     return preparation;

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -6,6 +6,7 @@ import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/logging/perf_overlay_controller.dart';
 import 'package:dualmate/common/logging/sentry_scrubber.dart';
+import 'package:dualmate/common/appstart/interaction_idle_coordinator.dart';
 import 'package:dualmate/common/ui/colors.dart';
 import 'package:dualmate/common/ui/viewmodels/root_view_model.dart';
 import 'package:dualmate/common/appstart/app_initializer.dart';
@@ -14,8 +15,6 @@ import 'package:dualmate/common/appstart/locale_preference_sync.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/util/launch_intent.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
-import 'package:dualmate/schedule/business/schedule_provider.dart';
-import 'package:dualmate/common/util/date_utils.dart';
 import 'package:kiwi/kiwi.dart';
 import 'package:flutter/services.dart';
 import 'package:dualmate/ui/navigation/main_section_controller.dart';
@@ -24,7 +23,6 @@ import 'package:dualmate/ui/navigation/router.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -70,6 +68,12 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
   bool _onboardingDeferredInitListenerAttached = false;
   Stopwatch? _deferredInitStopwatch;
   LocalePreferenceSync? _localePreferenceSync;
+  final InteractionIdleCoordinator _interactionCoordinator =
+      InteractionIdleCoordinator.instance;
+  late final InteractionAwareNavigatorObserver _interactionNavigatorObserver;
+  InteractionIdleTask? _backgroundInitializationTask;
+  InteractionIdleTask? _foregroundHeavyInitializationTask;
+  InteractionIdleTask? _canteenPreparationTask;
   static const MethodChannel _navigationChannel = MethodChannel(
     'com.fariszr.dualmate/navigation',
   );
@@ -80,6 +84,9 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    _interactionNavigatorObserver = InteractionAwareNavigatorObserver(
+      _interactionCoordinator,
+    );
     WidgetsBinding.instance.addObserver(this);
     _navigationChannel.setMethodCallHandler(_handleNavigationCall);
     _fetchLaunchRoute();
@@ -100,6 +107,10 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     unawaited(_setAppAttended(false));
     _localePreferenceSync?.detach();
     _detachOnboardingDeferredInitListener();
+    _backgroundInitializationTask?.cancel();
+    _foregroundHeavyInitializationTask?.cancel();
+    _canteenPreparationTask?.cancel();
+    _interactionNavigatorObserver.dispose();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -292,7 +303,11 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
       await overrides.apply(KiwiContainer().resolve<PreferencesProvider>());
       _debugRootLog("Root init: applied debug startup overrides");
     } catch (error, trace) {
-      _debugRootError("Root init: debug startup overrides failed", error, trace);
+      _debugRootError(
+        "Root init: debug startup overrides failed",
+        error,
+        trace,
+      );
       unawaited(
         AppDiagnostics.instance.reportCaughtException(
           error,
@@ -415,6 +430,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
                       additionalInfoProvider: (_, __) =>
                           const <String, dynamic>{'source': 'navigator'},
                     ),
+                    _interactionNavigatorObserver,
                     rootNavigationObserver,
                   ],
                   localizationsDelegates: [
@@ -458,37 +474,39 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
 
   Future<void> _runDeferredInitialization(Stopwatch stopwatch) async {
     try {
-      // Allow first-frame interaction and navigation transitions to settle.
-      await Future.delayed(_deferredBackgroundInitDelay);
-      if (!mounted) return;
-      await SchedulerBinding.instance.scheduleTask<void>(
+      _backgroundInitializationTask = _interactionCoordinator.schedule(
+        'startup.backgroundInit',
         () async {
           if (!mounted) return;
           await initializeAppBackground(false);
         },
-        Priority.idle,
-        debugLabel: 'startup.backgroundInit',
+        delay: _deferredBackgroundInitDelay,
       );
+      await _backgroundInitializationTask!.future;
+      if (!mounted) return;
       _debugRootLog(
         "Root init: deferred background ${stopwatch.elapsedMilliseconds}ms",
       );
-      SchedulerBinding.instance.scheduleTask<void>(
+      // Keep the old delays, but make their deadlines minimums. Interaction
+      // and route/content animations can postpone the work safely.
+      _foregroundHeavyInitializationTask = _interactionCoordinator.schedule(
+        'startup.foregroundHeavyInit',
         () {
-          unawaited(_prewarmScheduleCache());
+          if (!mounted) return Future<void>.value();
+          return _runForegroundHeavyInitialization();
         },
-        Priority.idle,
-        debugLabel: 'startup.scheduleCachePrewarm',
+        delay: _foregroundHeavyInitDelay,
       );
-      // Delay foreground-heavy tasks to keep startup animations responsive.
-      Future.delayed(_foregroundHeavyInitDelay, () {
-        if (!mounted) return;
-        _runForegroundHeavyInitialization();
-      });
-      // Defer canteen prewarm further and run at idle priority.
-      Future.delayed(_foregroundCanteenPrewarmDelay, () {
-        if (!mounted) return;
-        _scheduleIdleCanteenPrewarm();
-      });
+      // Canteen's page-level preparation owns its cache read. Reusing the
+      // navigation entry here avoids a second startup refresh path.
+      _canteenPreparationTask = _interactionCoordinator.schedule(
+        'startup.canteenPreparation',
+        () {
+          if (!mounted) return Future<void>.value();
+          return _runCanteenPrewarm();
+        },
+        delay: _foregroundCanteenPrewarmDelay,
+      );
     } catch (error, trace) {
       _debugRootError("Root init: deferred background failed", error, trace);
       unawaited(
@@ -524,19 +542,12 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     }
   }
 
-  void _scheduleIdleCanteenPrewarm() {
-    SchedulerBinding.instance.scheduleTask<void>(
-      () {
-        unawaited(_runCanteenPrewarm());
-      },
-      Priority.idle,
-      debugLabel: 'startup.canteenPrewarm',
-    );
-  }
-
   Future<void> _runCanteenPrewarm() async {
     try {
-      await prewarmCanteenIfStale();
+      final canteenEntry = navigationEntries.firstWhere(
+        (entry) => entry.route == 'canteen',
+      );
+      await canteenEntry.prepare();
     } catch (error, trace) {
       _debugRootError("Root init: canteen prewarm failed", error, trace);
       unawaited(
@@ -547,28 +558,6 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
           tags: {'feature': 'canteen'},
           contexts: {
             'canteen': {'phase': 'startup_prewarm'},
-          },
-        ),
-      );
-    }
-  }
-
-  Future<void> _prewarmScheduleCache() async {
-    try {
-      final scheduleProvider = KiwiContainer().resolve<ScheduleProvider>();
-      final start = toStartOfDay(toDayOfWeek(DateTime.now(), DateTime.monday));
-      final end = toNextWeek(start);
-      await scheduleProvider.warmScheduleCache(start, end);
-    } catch (error, trace) {
-      _debugRootError("Root init: schedule cache warm failed", error, trace);
-      unawaited(
-        AppDiagnostics.instance.reportCaughtException(
-          error,
-          trace,
-          message: 'Root init: schedule cache warm failed',
-          tags: {'feature': 'schedule'},
-          contexts: {
-            'schedule': {'phase': 'startup_cache_warm'},
           },
         ),
       );

--- a/test/canteen/ui/viewmodels/canteen_startup_loading_policy_test.dart
+++ b/test/canteen/ui/viewmodels/canteen_startup_loading_policy_test.dart
@@ -17,6 +17,19 @@ import '../../test_canteen_location_service.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  test('prepare warms the current cache without a network refresh', () async {
+    final weekStart = toStartOfDay(toMonday(DateTime.now()));
+    final provider = _TrackingCanteenProvider();
+    final model = CanteenViewModel(provider, TestCanteenLocationService());
+    addTearDown(model.dispose);
+
+    await model.prepareForNavigation();
+
+    expect(provider.cachedWeekRequests, <DateTime>[weekStart]);
+    expect(provider.refreshWeekRequests, isEmpty);
+    expect(provider.refreshWeekIfStaleRequests, isEmpty);
+  });
+
   test('primeVisibleWeek loads only the requested week immediately', () async {
     final monday = DateTime(2026, 2, 9);
     final weekStart = toStartOfDay(toMonday(monday));

--- a/test/common/appstart/interaction_idle_coordinator_test.dart
+++ b/test/common/appstart/interaction_idle_coordinator_test.dart
@@ -126,6 +126,25 @@ void main() {
     expect(events, <String>['first', 'second']);
   });
 
+  testWidgets('initial quiet period elapses without an interaction lease', (
+    tester,
+  ) async {
+    final coordinator = InteractionIdleCoordinator(
+      taskQuietPeriod: const Duration(milliseconds: 180),
+    );
+    addTearDown(coordinator.dispose);
+    var ran = false;
+    final task = coordinator.schedule('initial-quiet', () => ran = true);
+
+    await tester.pump(const Duration(milliseconds: 179));
+    expect(ran, isFalse);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    await _pumpIdleCycle(tester);
+    await task.future;
+    expect(ran, isTrue);
+  });
+
   testWidgets('background tasks wait for the post-interaction quiet period', (
     tester,
   ) async {

--- a/test/common/appstart/interaction_idle_coordinator_test.dart
+++ b/test/common/appstart/interaction_idle_coordinator_test.dart
@@ -1,0 +1,178 @@
+import 'package:dualmate/common/appstart/interaction_idle_coordinator.dart';
+import 'package:flutter/animation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('serializes tasks and waits for interaction leases', (
+    tester,
+  ) async {
+    var frameActive = false;
+    final coordinator = InteractionIdleCoordinator(
+      isFrameActive: () => frameActive,
+    );
+    final events = <String>[];
+
+    final first = coordinator.schedule('first', () {
+      events.add('first');
+    });
+    coordinator.schedule('second', () => events.add('second'));
+
+    final lease = coordinator.beginInteraction('drawer');
+    await tester.pump();
+    expect(events, isEmpty);
+
+    lease.release();
+    await _pumpIdleCycle(tester);
+    await first.future;
+    await _pumpIdleCycle(tester);
+
+    expect(events, ['first', 'second']);
+    coordinator.dispose();
+  });
+
+  testWidgets('postpones tasks while an injected frame gate is active', (
+    tester,
+  ) async {
+    var frameActive = true;
+    final coordinator = InteractionIdleCoordinator(
+      isFrameActive: () => frameActive,
+    );
+    var ran = false;
+    final task = coordinator.schedule('animation-gated', () => ran = true);
+
+    await tester.pump();
+    expect(ran, isFalse);
+
+    frameActive = false;
+    coordinator.notifyFrameStateChanged();
+    await _pumpIdleCycle(tester);
+    await task.future;
+    expect(ran, isTrue);
+    coordinator.dispose();
+  });
+
+  testWidgets('cancels queued work and releases waiters on disposal', (
+    tester,
+  ) async {
+    final coordinator = InteractionIdleCoordinator(isFrameActive: () => true);
+    var ran = false;
+    final task = coordinator.schedule('cancelled', () => ran = true);
+    final idle = coordinator.waitForIdle();
+
+    task.cancel();
+    coordinator.dispose();
+    await task.future;
+    await idle;
+
+    expect(task.isCancelled, isTrue);
+    expect(ran, isFalse);
+  });
+
+  testWidgets('deduplicates task ids while a task is queued', (tester) async {
+    final coordinator = InteractionIdleCoordinator();
+    var calls = 0;
+    final first = coordinator.schedule('same', () => calls++);
+    final second = coordinator.schedule('same', () => calls++);
+
+    expect(identical(first, second), isTrue);
+    await _pumpIdleCycle(tester);
+    await first.future;
+    expect(calls, 1);
+    coordinator.dispose();
+  });
+
+  testWidgets('a repeating unrelated animation does not starve idle work', (
+    tester,
+  ) async {
+    final controller = AnimationController(
+      vsync: tester,
+      duration: const Duration(milliseconds: 100),
+    )..repeat();
+    final coordinator = InteractionIdleCoordinator();
+    var ran = false;
+
+    final task = coordinator.schedule('spinner-safe', () {
+      ran = true;
+    });
+    await _pumpIdleCycle(tester);
+    await task.future;
+
+    expect(ran, isTrue);
+    controller.dispose();
+    coordinator.dispose();
+  });
+
+  testWidgets('serial tasks receive an interaction-free frame gap', (
+    tester,
+  ) async {
+    final coordinator = InteractionIdleCoordinator();
+    addTearDown(coordinator.dispose);
+    final events = <String>[];
+    var secondRan = false;
+
+    final first = coordinator.schedule('first', () => events.add('first'));
+    final second = coordinator.schedule('second', () {
+      secondRan = true;
+      events.add('second');
+    });
+
+    await _pumpIdleCycle(tester);
+    await first.future;
+    expect(events, <String>['first']);
+    expect(secondRan, isFalse);
+
+    await _pumpIdleCycle(tester);
+    await second.future;
+    expect(events, <String>['first', 'second']);
+  });
+
+  testWidgets('background tasks wait for the post-interaction quiet period', (
+    tester,
+  ) async {
+    final coordinator = InteractionIdleCoordinator(
+      taskQuietPeriod: const Duration(milliseconds: 180),
+    );
+    addTearDown(coordinator.dispose);
+    var ran = false;
+    final task = coordinator.schedule('quiet-task', () => ran = true);
+    final lease = coordinator.beginInteraction('drawer');
+
+    lease.release();
+    await tester.pump(const Duration(milliseconds: 179));
+    expect(ran, isFalse);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    await _pumpIdleCycle(tester);
+    await task.future;
+    expect(ran, isTrue);
+  });
+
+  testWidgets('idle waiters do not inherit the background task quiet period', (
+    tester,
+  ) async {
+    final coordinator = InteractionIdleCoordinator(
+      taskQuietPeriod: const Duration(milliseconds: 180),
+    );
+    addTearDown(coordinator.dispose);
+    var taskRan = false;
+    final task = coordinator.schedule('deferred-task', () => taskRan = true);
+    final lease = coordinator.beginInteraction('drawer');
+    lease.release();
+
+    final idle = coordinator.waitForIdle();
+    await _pumpIdleCycle(tester);
+    await idle;
+
+    expect(taskRan, isFalse);
+
+    await tester.pump(const Duration(milliseconds: 180));
+    await _pumpIdleCycle(tester);
+    await task.future;
+    expect(taskRan, isTrue);
+  });
+}
+
+Future<void> _pumpIdleCycle(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump();
+}

--- a/test/date_management/ui/viewmodels/date_management_fixture_error_state_test.dart
+++ b/test/date_management/ui/viewmodels/date_management_fixture_error_state_test.dart
@@ -25,6 +25,30 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  test('prepare loads preferences without a remote date request', () async {
+    final preferences = PreferencesProvider(
+      _FakePreferencesAccess({
+        PreferencesProvider.UseDhMineForDates: true,
+        PreferencesProvider.RaplaUrlKey: '',
+        PreferencesProvider.LastViewedDateEntryDatabase: '',
+        PreferencesProvider.LastViewedDateEntryYear: DateTime.now().year
+            .toString(),
+      }),
+      _FakeSecureStorageAccess(),
+    );
+    final dateEntryProvider = _ThrowingDateEntryProvider();
+    final viewModel = DateManagementViewModel(
+      dateEntryProvider,
+      preferences,
+      _StubRaplaProvider(preferences),
+    );
+    addTearDown(viewModel.dispose);
+
+    await viewModel.prepare();
+
+    expect(dateEntryProvider.remoteRequests, 0);
+  });
+
   test(
     'fixture mode: successful cached DhMine load does not show error state',
     () async {
@@ -40,8 +64,8 @@ void main() {
           PreferencesProvider.UseDhMineForDates: true,
           PreferencesProvider.RaplaUrlKey: '',
           PreferencesProvider.LastViewedDateEntryDatabase: '',
-          PreferencesProvider.LastViewedDateEntryYear:
-              DateTime.now().year.toString(),
+          PreferencesProvider.LastViewedDateEntryYear: DateTime.now().year
+              .toString(),
         }),
         _FakeSecureStorageAccess(),
       );
@@ -59,9 +83,13 @@ void main() {
       viewModel.initialize();
       await Future<void>.delayed(const Duration(milliseconds: 200));
 
-      expect(viewModel.updateFailed, isFalse,
-          reason: 'Fixture mode must not report an error when the remote '
-              'fetch is intentionally skipped.');
+      expect(
+        viewModel.updateFailed,
+        isFalse,
+        reason:
+            'Fixture mode must not report an error when the remote '
+            'fetch is intentionally skipped.',
+      );
     },
   );
 }
@@ -96,8 +124,10 @@ class _FakeSecureStorageAccess extends SecureStorageAccess {
 }
 
 class _ThrowingDateEntryProvider extends DateEntryProvider {
+  int remoteRequests = 0;
+
   _ThrowingDateEntryProvider()
-      : super(_StubDateManagementService(), _StubDateEntryRepository());
+    : super(_StubDateManagementService(), _StubDateEntryRepository());
 
   @override
   Future<List<DateEntry>> getCachedDateEntries(
@@ -111,6 +141,7 @@ class _ThrowingDateEntryProvider extends DateEntryProvider {
     DateSearchParameters parameters,
     CancellationToken cancellationToken,
   ) async {
+    remoteRequests += 1;
     throw ServiceRequestFailed('simulated network failure');
   }
 }
@@ -129,11 +160,11 @@ class _StubDateEntryRepository extends DateEntryRepository {
 
 class _StubRaplaProvider extends RaplaImportantEventsProvider {
   _StubRaplaProvider(PreferencesProvider preferences)
-      : super(
-          preferences,
-          _StubScheduleProvider(preferences),
-          _StubScheduleSourceProvider(preferences),
-        );
+    : super(
+        preferences,
+        _StubScheduleProvider(preferences),
+        _StubScheduleSourceProvider(preferences),
+      );
 
   @override
   Future<List<ImportantEvent>> getCachedImportantEvents(
@@ -151,13 +182,13 @@ class _StubRaplaProvider extends RaplaImportantEventsProvider {
 
 class _StubScheduleProvider extends ScheduleProvider {
   _StubScheduleProvider(PreferencesProvider preferences)
-      : super(
-          _StubScheduleSourceProvider(preferences),
-          _StubScheduleEntryRepository(),
-          _StubScheduleQueryInfoRepository(),
-          preferences,
-          _StubScheduleFilterRepository(),
-        );
+    : super(
+        _StubScheduleSourceProvider(preferences),
+        _StubScheduleEntryRepository(),
+        _StubScheduleQueryInfoRepository(),
+        preferences,
+        _StubScheduleFilterRepository(),
+      );
 
   @override
   Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async =>
@@ -169,18 +200,17 @@ class _StubScheduleProvider extends ScheduleProvider {
     DateTime end,
     CancellationToken cancellationToken, {
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
-  }) async =>
-      ScheduleQueryResult(Schedule(), <ParseError>[]);
+  }) async => ScheduleQueryResult(Schedule(), <ParseError>[]);
 }
 
 class _StubScheduleSourceProvider extends ScheduleSourceProvider {
   _StubScheduleSourceProvider(PreferencesProvider preferences)
-      : super(
-          preferences,
-          false,
-          _StubScheduleEntryRepository(),
-          _StubScheduleQueryInfoRepository(),
-        );
+    : super(
+        preferences,
+        false,
+        _StubScheduleEntryRepository(),
+        _StubScheduleQueryInfoRepository(),
+      );
 
   @override
   Future<bool> setupScheduleSource() async => true;
@@ -197,7 +227,8 @@ class _StubScheduleFilterRepository extends ScheduleFilterRepository {
   _StubScheduleFilterRepository() : super(_StubDatabaseAccess());
 }
 
-class _StubScheduleQueryInfoRepository extends ScheduleQueryInformationRepository {
+class _StubScheduleQueryInfoRepository
+    extends ScheduleQueryInformationRepository {
   _StubScheduleQueryInfoRepository() : super(_StubDatabaseAccess());
 }
 

--- a/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_background_refresh_test.dart
@@ -13,6 +13,27 @@ import 'package:dualmate/schedule/ui/viewmodels/weekly_schedule_view_model.dart'
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('cache-only preparation never starts a network refresh', () async {
+    final provider = _CountingScheduleProvider(<ScheduleEntry>[
+      _entry(DateTime(2026, 2, 9), 'CACHED'),
+    ]);
+    final sourceProvider = _FakeScheduleSourceProvider();
+    final viewModel = WeeklyScheduleViewModel(
+      provider,
+      sourceProvider,
+      nowProvider: () => DateTime(2026, 2, 10),
+    );
+    addTearDown(viewModel.dispose);
+
+    await viewModel.prepareCachedSchedule();
+
+    expect(provider.updatedScheduleRequests, 0);
+    expect(
+      viewModel.weekSchedule?.entries.map((entry) => entry.title),
+      contains('Course_CACHED'),
+    );
+  });
+
   test(
     'background range refresh keeps the currently visible week anchored',
     () async {

--- a/test/ui/main_page_navigation_preparation_test.dart
+++ b/test/ui/main_page_navigation_preparation_test.dart
@@ -1,0 +1,230 @@
+import 'dart:async';
+
+import 'package:dualmate/common/appstart/interaction_idle_coordinator.dart';
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/common/ui/viewmodels/base_view_model.dart';
+import 'package:dualmate/ui/main_page.dart';
+import 'package:dualmate/ui/navigation/navigation_entry.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('does not mount a cold section during drawer close', (
+    tester,
+  ) async {
+    _usePhoneViewport(tester);
+    final coordinator = InteractionIdleCoordinator();
+    final schedule = _FakeEntry('schedule');
+    final heavy = _FakeEntry('heavy');
+
+    await tester.pumpWidget(
+      _buildApp(
+        MainPage(
+          initialRoute: 'schedule',
+          showAppLaunchDialogs: false,
+          entries: [schedule, heavy],
+          interactionCoordinator: coordinator,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+    await tester.pump();
+    expect(schedule.buildCount, 1);
+
+    await tester.tap(find.byTooltip('Open navigation menu'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey<String>('drawer_item_heavy')));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(heavy.buildCount, 0);
+
+    await tester.pump(const Duration(milliseconds: 700));
+    await tester.pump();
+    await tester.pump();
+    expect(heavy.buildCount, 1);
+
+    coordinator.dispose();
+  });
+
+  testWidgets('opening the drawer does not prepare every cold section', (
+    tester,
+  ) async {
+    _usePhoneViewport(tester);
+    final coordinator = InteractionIdleCoordinator();
+    final schedule = _FakeEntry('schedule');
+    final heavy = _FakeEntry('heavy');
+
+    await tester.pumpWidget(
+      _buildApp(
+        MainPage(
+          initialRoute: 'schedule',
+          showAppLaunchDialogs: false,
+          entries: [schedule, heavy],
+          interactionCoordinator: coordinator,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Open navigation menu'));
+    await tester.pumpAndSettle();
+
+    expect(heavy.preparationStarted, isFalse);
+    expect(heavy.buildCount, 0);
+    coordinator.dispose();
+  });
+
+  testWidgets('cold navigation does not wait for preparation to finish', (
+    tester,
+  ) async {
+    _usePhoneViewport(tester);
+    final coordinator = InteractionIdleCoordinator();
+    final preparationGate = Completer<void>();
+    final schedule = _FakeEntry('schedule');
+    final heavy = _FakeEntry('heavy', preparationGate: preparationGate);
+
+    await tester.pumpWidget(
+      _buildApp(
+        MainPage(
+          initialRoute: 'schedule',
+          showAppLaunchDialogs: false,
+          entries: [schedule, heavy],
+          interactionCoordinator: coordinator,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+    await tester.pump();
+    expect(schedule.buildCount, 1);
+
+    await tester.tap(find.byTooltip('Open navigation menu'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey<String>('drawer_item_heavy')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    for (var index = 0; index < 5; index++) {
+      await tester.pump();
+    }
+    await coordinator.waitForIdle();
+    await tester.pump();
+
+    expect(heavy.preparationStarted, isTrue);
+    expect(heavy.preparationCompleted, isFalse);
+    expect(heavy.buildCount, 1);
+    expect(
+      find.byKey(const ValueKey<String>('main_section_heavy')),
+      findsOneWidget,
+    );
+
+    preparationGate.complete();
+    await tester.pump();
+    coordinator.dispose();
+  });
+
+  testWidgets('scroll interaction lease is released after scrolling', (
+    tester,
+  ) async {
+    _usePhoneViewport(tester);
+    final coordinator = InteractionIdleCoordinator();
+    final schedule = _FakeEntry('schedule', scrollable: true);
+
+    await tester.pumpWidget(
+      _buildApp(
+        MainPage(
+          initialRoute: 'schedule',
+          showAppLaunchDialogs: false,
+          entries: [schedule],
+          interactionCoordinator: coordinator,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+    await tester.pump();
+
+    await tester.drag(
+      find.byKey(const ValueKey<String>('scrollable_schedule')),
+      const Offset(0, -200),
+    );
+    await tester.pumpAndSettle();
+
+    expect(coordinator.hasActiveInteraction, isFalse);
+    coordinator.dispose();
+  });
+}
+
+void _usePhoneViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(400, 800);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+Widget _buildApp(Widget home) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      LocalizationDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+      DefaultCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('en'), Locale('de')],
+    home: home,
+  );
+}
+
+class _FakeEntry extends NavigationEntry<_FakeViewModel> {
+  _FakeEntry(this._route, {this.preparationGate, this.scrollable = false});
+
+  final String _route;
+  final Completer<void>? preparationGate;
+  final bool scrollable;
+  int buildCount = 0;
+  bool preparationStarted = false;
+  bool preparationCompleted = false;
+
+  @override
+  String get route => _route;
+
+  @override
+  String title(BuildContext context) => _route;
+
+  @override
+  Widget icon(BuildContext context) => const Icon(Icons.circle);
+
+  @override
+  _FakeViewModel initViewModel() => _FakeViewModel();
+
+  @override
+  Future<void> prepareSection() async {
+    preparationStarted = true;
+    final gate = preparationGate;
+    if (gate != null) {
+      await gate.future;
+    }
+    preparationCompleted = true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    buildCount++;
+    if (scrollable) {
+      return ListView.builder(
+        key: ValueKey<String>('scrollable_$_route'),
+        itemCount: 40,
+        itemBuilder: (_, index) =>
+            SizedBox(height: 48, child: Text('$_route-$index')),
+      );
+    }
+    return Text(_route);
+  }
+}
+
+class _FakeViewModel extends BaseViewModel {}

--- a/test/ui/main_page_startup_placeholder_test.dart
+++ b/test/ui/main_page_startup_placeholder_test.dart
@@ -1,6 +1,7 @@
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/ui/schedule_navigation_entry.dart';
 import 'package:dualmate/schedule/ui/schedule_page.dart';
 import 'package:dualmate/ui/main_page.dart';
@@ -34,10 +35,7 @@ void main() {
         GlobalCupertinoLocalizations.delegate,
         DefaultCupertinoLocalizations.delegate,
       ],
-      supportedLocales: const [
-        Locale('en'),
-        Locale('de'),
-      ],
+      supportedLocales: const [Locale('en'), Locale('de')],
       home: const MainPage(
         initialRoute: 'schedule',
         showAppLaunchDialogs: false,
@@ -45,22 +43,30 @@ void main() {
     );
   }
 
-  testWidgets('shows a placeholder before the initial section mounts',
-      (tester) async {
+  testWidgets('shows a placeholder before the initial section mounts', (
+    tester,
+  ) async {
     await tester.pumpWidget(buildTestApp());
 
-    expect(find.byKey(const ValueKey<String>('main_page_initial_placeholder')),
-        findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('main_page_initial_placeholder')),
+      findsOneWidget,
+    );
   });
 
-  testWidgets('mounts the initial section after the startup delay',
-      (tester) async {
+  testWidgets('mounts the initial section after the startup delay', (
+    tester,
+  ) async {
     await tester.pumpWidget(buildTestApp());
 
     await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+    await tester.pump();
 
-    expect(find.byKey(const ValueKey<String>('main_page_initial_placeholder')),
-        findsNothing);
+    expect(
+      find.byKey(const ValueKey<String>('main_page_initial_placeholder')),
+      findsNothing,
+    );
 
     // Tear down the mounted section so its deferred timers are cancelled
     // before the binding checks for pending timers. The schedule view model is
@@ -79,6 +85,11 @@ void main() {
 }
 
 class _FakeScheduleProvider implements ScheduleProvider {
+  @override
+  Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
+    return Schedule();
+  }
+
   @override
   dynamic noSuchMethod(Invocation invocation) {
     throw UnsupportedError('Unexpected ScheduleProvider call: $invocation');

--- a/test/ui/main_page_startup_placeholder_test.dart
+++ b/test/ui/main_page_startup_placeholder_test.dart
@@ -80,6 +80,8 @@ void main() {
         .first
         .viewModel()
         .dispose();
+    await tester.pump(const Duration(milliseconds: 180));
+    await tester.pump();
     await tester.pump();
   });
 }

--- a/test/ui/navigation_entry_lifecycle_test.dart
+++ b/test/ui/navigation_entry_lifecycle_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:dualmate/common/ui/viewmodels/base_view_model.dart';
+import 'package:dualmate/ui/navigation/navigation_entry.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('prepares once before activation and does not build early', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    final entry = _FakeNavigationEntry(preparationGate: gate);
+
+    final preparation = entry.prepare();
+    expect(identical(preparation, entry.prepare()), isTrue);
+    expect(entry.events, ['viewModel', 'prepare']);
+    expect(entry.lifecycle, NavigationEntryLifecycle.preparing);
+    gate.complete();
+    await preparation;
+    expect(entry.lifecycle, NavigationEntryLifecycle.prepared);
+    expect(entry.events, ['viewModel', 'prepare', 'prepared']);
+
+    await tester.pumpWidget(
+      MaterialApp(home: Builder(builder: (context) => entry.activate(context))),
+    );
+    expect(find.text('prepared route'), findsOneWidget);
+    expect(entry.events, ['viewModel', 'prepare', 'prepared', 'build']);
+    expect(entry.lifecycle, NavigationEntryLifecycle.active);
+  });
+
+  testWidgets('activation stays active while preparation finishes later', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    final entry = _FakeNavigationEntry(preparationGate: gate);
+    final preparation = entry.prepare();
+
+    await tester.pumpWidget(
+      MaterialApp(home: Builder(builder: (context) => entry.activate(context))),
+    );
+    expect(entry.lifecycle, NavigationEntryLifecycle.active);
+    expect(find.text('prepared route'), findsOneWidget);
+
+    gate.complete();
+    await preparation;
+    expect(entry.lifecycle, NavigationEntryLifecycle.active);
+  });
+}
+
+class _FakeNavigationEntry extends NavigationEntry<_FakeViewModel> {
+  _FakeNavigationEntry({this.preparationGate});
+
+  final Completer<void>? preparationGate;
+  final List<String> events = <String>[];
+
+  @override
+  String get route => 'fake';
+
+  @override
+  String title(BuildContext context) => 'Fake';
+
+  @override
+  Widget icon(BuildContext context) => const Icon(Icons.circle);
+
+  @override
+  _FakeViewModel initViewModel() {
+    events.add('viewModel');
+    return _FakeViewModel();
+  }
+
+  @override
+  Future<void> prepareSection() async {
+    events.add('prepare');
+    final gate = preparationGate;
+    if (gate != null) {
+      await gate.future;
+    }
+    events.add('prepared');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    events.add('build');
+    return const Text('prepared route');
+  }
+}
+
+class _FakeViewModel extends BaseViewModel {}

--- a/test/ui/navigation_entry_lifecycle_test.dart
+++ b/test/ui/navigation_entry_lifecycle_test.dart
@@ -29,6 +29,24 @@ void main() {
     expect(entry.lifecycle, NavigationEntryLifecycle.active);
   });
 
+  testWidgets('late preparation never regresses an active entry lifecycle', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    final entry = _FakeNavigationEntry(preparationGate: gate);
+
+    await tester.pumpWidget(
+      MaterialApp(home: Builder(builder: (context) => entry.activate(context))),
+    );
+    expect(entry.lifecycle, NavigationEntryLifecycle.active);
+
+    final preparation = entry.prepare();
+    expect(entry.lifecycle, NavigationEntryLifecycle.active);
+    gate.complete();
+    await preparation;
+    expect(entry.lifecycle, NavigationEntryLifecycle.active);
+  });
+
   testWidgets('activation stays active while preparation finishes later', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- add an interaction-aware FIFO coordinator for deferred startup and cache work
- separate navigation entry preparation from widget activation
- keep preparation cache-only and never block destination activation on network work
- defer work across pointer, scroll, drawer, and route transitions with a clean-frame gap
- deduplicate Schedule/Canteen startup warmups and preserve existing page-owned refresh behavior
- preserve active navigation lifecycles during late preparation

## Stack

This PR is intentionally based on **PR #97**. Merge #97 first, then retarget this PR to `v2` before merging.

## Pixel 8 Pro results

Three current-`v2` control runs and three final branch runs at 120 Hz / 1.0x animations:

- drawer → Canteen missed frames: **25.00% → 13.33%**
- drawer → Canteen p95: **25.48 → 10.21 ms**
- drawer → Dualis missed frames: **23.53% → 10.81%**
- drawer → Dualis p99/worst: **36.82 → 19.89 ms**
- drawer → Dates p99/worst: **36.67 → 26.83 ms**
- >33 ms frames for Dates and Dualis: **1 → 0**

## Validation

- full `flutter analyze`
- 59 Canteen tests passed
- 29 Dates tests passed
- 155 Schedule tests passed
- 38 generic UI tests passed
- focused coordinator/navigation/cache-only preparation tests passed
- three-run Pixel diagnostic completed with all navigation final states

Documentation: `docs/solutions/performance/interaction-aware-cold-navigation-preparation-20260712.md`
