### PR TITLE
Coalesce Schedule state and isolate raster layers

### DIFF
--- a/docs/solutions/performance/weekly-schedule-state-raster-refresh-20260712.md
+++ b/docs/solutions/performance/weekly-schedule-state-raster-refresh-20260712.md
@@ -1,0 +1,108 @@
+---
+title: Coalesce weekly schedule state and isolate raster layers
+date: 2026-07-12
+type: fix
+---
+
+# Summary
+
+The follow-up to PR #96 reduces the remaining weekly Schedule work observed
+on a Pixel 8 Pro at 120 Hz. PR #96 already keeps the PageView and entry tree
+stable during the 220 ms viewport transition; this change keeps equivalent
+cache/refresh results from notifying the page and prevents refresh completions
+from changing the settled page while a swipe is still active.
+
+# State and refresh behavior
+
+- `WeeklyScheduleViewModel` now publishes a versioned
+  `VisibleWeeklyScheduleSnapshot`. The snapshot copies the visible entry
+  sequence and compares render-relevant entry content, date range, and display
+  geometry. Replacing a cache object with equivalent content therefore does
+  not notify the weekly page.
+- Visible refreshes and cache reads carry both the schedule-source generation
+  and a visible-state request id. Results from an old source or an older page
+  request can still finish safely, but cannot become visible state.
+- The weekly page marks paging active on `ScrollStartNotification`. While the
+  PageView is moving, visible cache/refresh results are reduced to the latest
+  valid result for the currently visible week. The result is applied only after
+  the settled page is known; results for a different settled week are dropped.
+- Adjacent week prefetch and warmup continue to populate memory caches only.
+  They do not notify or replace the visible schedule.
+
+# Raster and layer boundaries
+
+The existing card styling, shadows, translucent past overlay, grid, current
+time indicator, interactions, and animations are unchanged. The paint tree now
+has explicit boundaries for the grid, stable entry layer, labels, past
+overlay, and current-time indicator. The grid itself separates static vertical
+column lines from viewport-dependent horizontal hour lines, so the static
+portion can be reused while the hour viewport changes.
+
+These boundaries isolate the large translucent overlay and changing grid from
+the stable entry layer. They are deliberately limited to layers with
+independent invalidation inputs; no blanket boundary was added around the
+whole schedule tree and no visual effect was removed.
+
+# Telemetry
+
+Frame jank detection now compares build and raster durations with the active
+display refresh budget (`1000 / refreshRateHz`). It uses microsecond durations
+so the 120 Hz 8.33 ms budget is not rounded to milliseconds. Detection remains
+in the frame-timing callback and does not add work to Schedule render paths.
+
+# Regression coverage
+
+Schedule tests cover equivalent-state notification suppression, latest cache
+then refresh result wins after paging settles, stale queued result rejection,
+grid painter invalidation isolation, layer boundary presence, and refresh-rate
+aware frame budgets. The existing PageView swipe, chevron, viewport animation,
+entry identity, card layout, and current-time indicator tests remain in scope.
+
+# Pixel 8 Pro results
+
+Device conditions:
+
+- Pixel 8 Pro in profile mode;
+- 120 Hz display;
+- Android animation scales at `1.0`;
+- deterministic offline fixture data;
+- three current-`v2` control runs and three final branch runs.
+
+Median comparison:
+
+| Scenario | Metric | Current `v2` | Final branch |
+| --- | --- | ---: | ---: |
+| Cold placeholder → populated | frames > 8.33 ms | 9.38% | 6.06% |
+| First populated swipe | frames > 8.33 ms | 20.45% | 14.89% |
+| First populated swipe | p99 | 32.33 ms | 25.85 ms |
+| Short → tall transition | frames > 8.33 ms | 25.58% | 22.22% |
+| Short → tall transition | p95 | 17.25 ms | 11.93 ms |
+| Short → tall transition | frames > 16.67 ms | 3 | 1 |
+| Settled populated swipe | frames > 8.33 ms | 22.92% | 12.24% |
+| Settled populated swipe | consecutive misses | 3 | 1 |
+| Database-cached navigation | frames > 8.33 ms | 17.95% | 7.20% |
+| Database-cached navigation | raster frames > 8.33 ms | 11.11% | 1.57% |
+| Rapid four-swipe burst | frames > 8.33 ms | 16.45% | 7.45% |
+| Rapid four-swipe burst | p95 | 16.00 ms | 9.89 ms |
+| Rapid four-swipe burst | consecutive misses | 3 | 1 |
+
+The short-to-tall transition's raster-only over-budget percentage increased
+from 9.30% to 17.78%, while its combined missed-frame rate, p95, p99, and
+frames above 16.67 ms all improved. The retained layer boundaries therefore
+reduce total interaction cost and tail latency, but that transition remains the
+main raster-focused follow-up area.
+
+All Schedule final-state and animation-progression checks passed in all three
+runs. The only diagnostic warning was the independent Dates loading transition,
+which is fixed by the separate Dates lazy-rendering PR.
+
+# Validation
+
+- full `flutter analyze` — clean;
+- `flutter test test/schedule test/common/logging/performance_telemetry_test.dart`
+  — 162 tests passed;
+- three-run current-`v2` Pixel control;
+- three-run final-branch Pixel diagnostic;
+- existing PageView gesture, viewport-animation, cache, refresh, current-time,
+  entry identity, and loading behavior retained;
+- no animation duration, fixture data, or performance threshold was reduced.

--- a/lib/common/logging/performance_telemetry.dart
+++ b/lib/common/logging/performance_telemetry.dart
@@ -35,10 +35,13 @@ class PerformanceTelemetry {
   }
 
   void _onFrameTimings(List<FrameTiming> timings) {
+    final frameBudgetMicros = _frameBudgetMicros();
     for (final timing in timings) {
       final build = timing.buildDuration.inMilliseconds;
       final raster = timing.rasterDuration.inMilliseconds;
-      final isJanky = build > 16 || raster > 16;
+      final isJanky =
+          timing.buildDuration.inMicroseconds > frameBudgetMicros ||
+          timing.rasterDuration.inMicroseconds > frameBudgetMicros;
       if (!isJanky) continue;
 
       final now = DateTime.now();
@@ -184,6 +187,18 @@ class PerformanceTelemetry {
     } catch (_) {
       return null;
     }
+  }
+
+  int _frameBudgetMicros() {
+    return frameBudgetMicrosForRefreshRate(_refreshRateHz());
+  }
+
+  @visibleForTesting
+  static int frameBudgetMicrosForRefreshRate(int? refreshRateHz) {
+    if (refreshRateHz == null || refreshRateHz <= 0) {
+      return (Duration.microsecondsPerSecond / 60).ceil();
+    }
+    return (Duration.microsecondsPerSecond / refreshRateHz).ceil();
   }
 
   String _deviceTier(int refreshRateHz) {

--- a/lib/common/logging/performance_telemetry.dart
+++ b/lib/common/logging/performance_telemetry.dart
@@ -37,11 +37,12 @@ class PerformanceTelemetry {
   void _onFrameTimings(List<FrameTiming> timings) {
     final frameBudgetMicros = _frameBudgetMicros();
     for (final timing in timings) {
-      final build = timing.buildDuration.inMilliseconds;
-      final raster = timing.rasterDuration.inMilliseconds;
+      final buildMicros = timing.buildDuration.inMicroseconds;
+      final rasterMicros = timing.rasterDuration.inMicroseconds;
+      final buildMs = buildMicros / Duration.microsecondsPerMillisecond;
+      final rasterMs = rasterMicros / Duration.microsecondsPerMillisecond;
       final isJanky =
-          timing.buildDuration.inMicroseconds > frameBudgetMicros ||
-          timing.rasterDuration.inMicroseconds > frameBudgetMicros;
+          buildMicros > frameBudgetMicros || rasterMicros > frameBudgetMicros;
       if (!isJanky) continue;
 
       final now = DateTime.now();
@@ -53,14 +54,14 @@ class PerformanceTelemetry {
 
       _lastJankFrameLogAt = now;
       developer.log(
-        'janky frame timing: build=${build}ms raster=${raster}ms',
+        'janky frame timing: build=${buildMs}ms raster=${rasterMs}ms',
         name: 'perf.frame',
       );
       unawaited(
         AppDiagnostics.instance.recordInfo(
           'perf.frame',
           'janky frame timing',
-          data: {'buildMs': build, 'rasterMs': raster},
+          data: {'buildMs': buildMs, 'rasterMs': rasterMs},
         ),
       );
     }

--- a/lib/schedule/ui/viewmodels/visible_weekly_schedule_snapshot.dart
+++ b/lib/schedule/ui/viewmodels/visible_weekly_schedule_snapshot.dart
@@ -1,0 +1,97 @@
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:flutter/foundation.dart';
+
+/// Immutable render-facing state for the currently visible schedule week.
+///
+/// Schedule is intentionally mutable for the cache and database layers. The
+/// weekly page, however, only needs a stable value to decide whether a visible
+/// render actually changed. Keeping a copied entry sequence here lets the
+/// view-model suppress equivalent cache results without relying on Schedule
+/// identity.
+@immutable
+class VisibleWeeklyScheduleSnapshot {
+  final int version;
+  final DateTime weekStart;
+  final DateTime weekEnd;
+  final DateTime displayStart;
+  final DateTime displayEnd;
+  final int displayStartHour;
+  final int displayEndHour;
+  final List<ScheduleEntry> entries;
+
+  VisibleWeeklyScheduleSnapshot({
+    required this.version,
+    required this.weekStart,
+    required this.weekEnd,
+    required this.displayStart,
+    required this.displayEnd,
+    required this.displayStartHour,
+    required this.displayEndHour,
+    required Iterable<ScheduleEntry> entries,
+  }) : entries = List<ScheduleEntry>.unmodifiable(entries);
+
+  VisibleWeeklyScheduleSnapshot withVersion(int nextVersion) {
+    return VisibleWeeklyScheduleSnapshot(
+      version: nextVersion,
+      weekStart: weekStart,
+      weekEnd: weekEnd,
+      displayStart: displayStart,
+      displayEnd: displayEnd,
+      displayStartHour: displayStartHour,
+      displayEndHour: displayEndHour,
+      entries: entries,
+    );
+  }
+
+  bool hasSameVisibleContent(VisibleWeeklyScheduleSnapshot other) {
+    if (weekStart != other.weekStart ||
+        weekEnd != other.weekEnd ||
+        displayStart != other.displayStart ||
+        displayEnd != other.displayEnd ||
+        displayStartHour != other.displayStartHour ||
+        displayEndHour != other.displayEndHour ||
+        entries.length != other.entries.length) {
+      return false;
+    }
+
+    for (var index = 0; index < entries.length; index++) {
+      if (!_hasSameVisibleEntry(entries[index], other.entries[index])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static bool _hasSameVisibleEntry(ScheduleEntry first, ScheduleEntry second) {
+    return first.start == second.start &&
+        first.end == second.end &&
+        first.title == second.title &&
+        first.details == second.details &&
+        first.professor == second.professor &&
+        first.room == second.room &&
+        first.type == second.type;
+  }
+
+  static VisibleWeeklyScheduleSnapshot fromSchedule({
+    required int version,
+    required DateTime weekStart,
+    required DateTime weekEnd,
+    required DateTime displayStart,
+    required DateTime displayEnd,
+    required int displayStartHour,
+    required int displayEndHour,
+    required Schedule? schedule,
+  }) {
+    return VisibleWeeklyScheduleSnapshot(
+      version: version,
+      weekStart: weekStart,
+      weekEnd: weekEnd,
+      displayStart: displayStart,
+      displayEnd: displayEnd,
+      displayStartHour: displayStartHour,
+      displayEndHour: displayEndHour,
+      entries: schedule?.entries ?? const <ScheduleEntry>[],
+    );
+  }
+}

--- a/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
+++ b/lib/schedule/ui/viewmodels/weekly_schedule_view_model.dart
@@ -18,6 +18,7 @@ import 'package:dualmate/schedule/model/schedule_source_type.dart';
 import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:dualmate/schedule/ui/viewmodels/schedule_freshness_gate.dart';
 import 'package:dualmate/schedule/ui/viewmodels/schedule_update_request_gate.dart';
+import 'package:dualmate/schedule/ui/viewmodels/visible_weekly_schedule_snapshot.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
 import 'package:flutter/foundation.dart';
 
@@ -82,9 +83,19 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   int _scheduleSourceGeneration = 0;
   Timer? _windowRefreshTimer;
 
+  VisibleWeeklyScheduleSnapshot? _visibleScheduleSnapshot;
+  int _visibleScheduleVersion = 0;
+  int _visibleScheduleResultSequence = 0;
+  bool _isVisiblePaging = false;
+  _QueuedVisibleScheduleResult? _queuedVisibleScheduleResult;
+  int _visibleStateRequestId = 0;
+
   String? scheduleUrl;
 
   DateTime get now => _nowProvider();
+
+  VisibleWeeklyScheduleSnapshot? get visibleScheduleSnapshot =>
+      _visibleScheduleSnapshot;
 
   bool get visibleWeekNeedsInitialFetch {
     if (!_hasCurrentDateRange) {
@@ -309,6 +320,33 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     }
   }
 
+  void beginVisiblePaging() {
+    if (_isDisposed) return;
+    _isVisiblePaging = true;
+    _queuedVisibleScheduleResult = null;
+  }
+
+  void endVisiblePaging(DateTime settledStart, DateTime settledEnd) {
+    if (!_isVisiblePaging) return;
+    _isVisiblePaging = false;
+
+    final queuedResult = _queuedVisibleScheduleResult;
+    _queuedVisibleScheduleResult = null;
+    if (queuedResult == null ||
+        queuedResult.start != settledStart ||
+        queuedResult.end != settledEnd ||
+        queuedResult.visibleStateRequestId != _visibleStateRequestId ||
+        !_isCurrentScheduleSourceGeneration(queuedResult.sourceGeneration)) {
+      return;
+    }
+
+    _applyVisibleScheduleNow(
+      queuedResult.schedule,
+      queuedResult.start,
+      queuedResult.end,
+    );
+  }
+
   void _setSchedule(Schedule? schedule, DateTime start, DateTime end) {
     if (schedule != null && initializeFailed) {
       initializeFailed = false;
@@ -333,44 +371,108 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     currentDateEnd = end;
     _evictDistantWindowData(start);
 
-    if (weekSchedule != null) {
-      var displayRange = resolveWeeklyDisplayRange(
+    late final WeeklyDisplayRange displayRange;
+    var nextDisplayStartHour = displayStartHour;
+    var nextDisplayEndHour = displayEndHour;
+
+    final visibleSchedule = weekSchedule;
+    if (visibleSchedule != null) {
+      displayRange = resolveWeeklyDisplayRange(
         currentDateStart,
-        weekSchedule,
+        visibleSchedule,
       );
-      clippedDateStart = displayRange.start;
-      clippedDateEnd = displayRange.end;
 
-      displayStartHour = weekSchedule?.getStartTime()?.hour ?? 23;
-      displayStartHour = min(7, displayStartHour);
+      nextDisplayStartHour = visibleSchedule.getStartTime()?.hour ?? 23;
+      nextDisplayStartHour = min(7, nextDisplayStartHour);
 
-      displayEndHour = weekSchedule?.getEndTime()?.hour ?? 0;
-      displayEndHour = max(displayEndHour + 1, 17);
+      nextDisplayEndHour = visibleSchedule.getEndTime()?.hour ?? 0;
+      nextDisplayEndHour = max(nextDisplayEndHour + 1, 17);
     } else {
-      var displayRange = resolveWeeklyDisplayRange(currentDateStart, null);
-      clippedDateStart = displayRange.start;
-      clippedDateEnd = displayRange.end;
+      displayRange = resolveWeeklyDisplayRange(currentDateStart, null);
     }
 
-    notifyIfMounted("weekSchedule");
+    clippedDateStart = displayRange.start;
+    clippedDateEnd = displayRange.end;
+    displayStartHour = nextDisplayStartHour;
+    displayEndHour = nextDisplayEndHour;
+
+    final previousSnapshot = _visibleScheduleSnapshot;
+    final nextSnapshot = VisibleWeeklyScheduleSnapshot.fromSchedule(
+      version: _visibleScheduleVersion + 1,
+      weekStart: currentDateStart,
+      weekEnd: currentDateEnd,
+      displayStart: displayRange.start,
+      displayEnd: displayRange.end,
+      displayStartHour: displayStartHour,
+      displayEndHour: displayEndHour,
+      schedule: weekSchedule,
+    );
+    final visibleSnapshotChanged =
+        previousSnapshot == null ||
+        !previousSnapshot.hasSameVisibleContent(nextSnapshot);
+    if (visibleSnapshotChanged) {
+      _visibleScheduleVersion += 1;
+      _visibleScheduleSnapshot = nextSnapshot.withVersion(
+        _visibleScheduleVersion,
+      );
+      notifyIfMounted("weekSchedule");
+    } else {
+      _visibleScheduleSnapshot = nextSnapshot.withVersion(
+        _visibleScheduleVersion,
+      );
+    }
+
     if (shouldWarmAdjacent && _lastWarmedWeekStart != start) {
       _lastWarmedWeekStart = start;
       unawaited(_warmAdjacentWeeks(start));
     }
   }
 
-  void _applyVisibleSchedule(Schedule? schedule, DateTime start, DateTime end) {
-    PerformanceTelemetry.instance.measureSync(
-      'schedule.state.apply',
-      args: {
-        'entryCount': schedule?.entries.length ?? 0,
-        'weekOffset': _weekOffsetFromCurrent(start),
-        'sourceType': _coarseSourceType(),
-      },
-      action: (_) {
-        _setSchedule(schedule, start, end);
-      },
-    );
+  void _applyVisibleSchedule(
+    Schedule? schedule,
+    DateTime start,
+    DateTime end, {
+    int? sourceGeneration,
+    int? visibleStateRequestId,
+  }) {
+    if (_isDisposed) return;
+    if (sourceGeneration != null &&
+        !_isCurrentScheduleSourceGeneration(sourceGeneration)) {
+      return;
+    }
+    if (visibleStateRequestId != null &&
+        visibleStateRequestId != _visibleStateRequestId) {
+      return;
+    }
+
+    if (_isVisiblePaging) {
+      if (currentDateStart != start || currentDateEnd != end) {
+        return;
+      }
+      final result = _QueuedVisibleScheduleResult(
+        schedule: schedule,
+        start: start,
+        end: end,
+        sourceGeneration: sourceGeneration ?? _scheduleSourceGeneration,
+        visibleStateRequestId: visibleStateRequestId ?? _visibleStateRequestId,
+        sequence: ++_visibleScheduleResultSequence,
+      );
+      final previous = _queuedVisibleScheduleResult;
+      if (previous == null || result.sequence >= previous.sequence) {
+        _queuedVisibleScheduleResult = result;
+      }
+      return;
+    }
+
+    _applyVisibleScheduleNow(schedule, start, end);
+  }
+
+  void _applyVisibleScheduleNow(
+    Schedule? schedule,
+    DateTime start,
+    DateTime end,
+  ) {
+    _setSchedule(schedule, start, end);
   }
 
   Future nextWeek() async {
@@ -440,6 +542,8 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     DateTime end, {
     bool Function()? isCurrentRequest,
   }) async {
+    final sourceGeneration = _scheduleSourceGeneration;
+    final visibleStateRequestId = ++_visibleStateRequestId;
     await PerformanceTelemetry.instance.measureTask(
       'schedule.week.change',
       args: {
@@ -466,10 +570,17 @@ class WeeklyScheduleViewModel extends BaseViewModel {
                   return schedule;
                 },
               );
-          if (_isDisposed) return;
+          if (!_isCurrentScheduleSourceGeneration(sourceGeneration)) return;
+          if (visibleStateRequestId != _visibleStateRequestId) return;
           if (isCurrentRequest != null && !isCurrentRequest()) return;
           _memoryWeekCache[cacheKey] = cachedSchedule;
-          _applyVisibleSchedule(cachedSchedule, start, end);
+          _applyVisibleSchedule(
+            cachedSchedule,
+            start,
+            end,
+            sourceGeneration: sourceGeneration,
+            visibleStateRequestId: visibleStateRequestId,
+          );
         } catch (error, trace) {
           _debugScheduleError("Failed to open cached week", error, trace);
           await reportException(error, trace);
@@ -504,6 +615,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     lastRequestedStart = start;
 
     final sourceGeneration = _scheduleSourceGeneration;
+    final visibleStateRequestId = _visibleStateRequestId;
     final refreshKey = _refreshKey(start, end, sourceGeneration);
     final inFlightRefresh = _refreshInFlightByWindow[refreshKey];
     if (inFlightRefresh != null) {
@@ -513,6 +625,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         sourceGeneration,
         inFlightRefresh,
         applyToVisibleState: applyToVisibleState,
+        visibleStateRequestId: visibleStateRequestId,
       );
       if (awaitRefresh) {
         await joinFuture;
@@ -562,6 +675,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         awaitRefresh: awaitRefresh,
         forceRefresh: force,
         sourceGeneration: sourceGeneration,
+        visibleStateRequestId: visibleStateRequestId,
         origin: applyToVisibleState
             ? ScheduleRefreshOrigin.userBrowsing
             : ScheduleRefreshOrigin.foregroundMaintenance,
@@ -582,6 +696,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     bool awaitRefresh = false,
     bool forceRefresh = false,
     required int sourceGeneration,
+    required int visibleStateRequestId,
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
   }) async {
     final task = PerformanceTelemetry.instance.startTask(
@@ -614,12 +729,19 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         return schedule;
       },
     );
-    _memoryWeekCache[cacheKey] = cachedSchedule;
     cancellationToken.throwIfCancelled();
+    if (!_isCurrentScheduleSourceGeneration(sourceGeneration)) return false;
+    _memoryWeekCache[cacheKey] = cachedSchedule;
     if (_isDisposed) return false;
 
     if (applyToVisibleState) {
-      _applyVisibleSchedule(cachedSchedule, start, end);
+      _applyVisibleSchedule(
+        cachedSchedule,
+        start,
+        end,
+        sourceGeneration: sourceGeneration,
+        visibleStateRequestId: visibleStateRequestId,
+      );
     }
 
     final nowValue = now;
@@ -644,6 +766,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       visibleUpdateRequestId: visibleUpdateRequestId,
       applyToVisibleState: applyToVisibleState,
       sourceGeneration: sourceGeneration,
+      visibleStateRequestId: visibleStateRequestId,
       origin: origin,
     );
 
@@ -664,6 +787,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     int? visibleUpdateRequestId,
     bool applyToVisibleState = true,
     required int sourceGeneration,
+    required int visibleStateRequestId,
     ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
   }) async {
     ScheduleQueryResult? updatedSchedule;
@@ -682,6 +806,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         if (updatedSchedule != null) {
           _freshnessGate.markFetched(start, end, now);
           _markWindowFetched(start, end, now);
+          _cacheUpdatedScheduleResult(start, end, updatedSchedule);
         }
       } on OperationCancelledException {
         return;
@@ -708,16 +833,21 @@ class WeeklyScheduleViewModel extends BaseViewModel {
         return;
       }
 
-      if (!applyToVisibleState) {
-        return;
-      }
-
-      if (currentDateStart != start || currentDateEnd != end) {
+      if (!applyToVisibleState ||
+          currentDateStart != start ||
+          currentDateEnd != end ||
+          visibleStateRequestId != _visibleStateRequestId) {
         return;
       }
 
       if (updatedSchedule != null) {
-        _applyUpdatedScheduleResult(start, end, updatedSchedule);
+        _applyUpdatedScheduleResult(
+          start,
+          end,
+          updatedSchedule,
+          sourceGeneration: sourceGeneration,
+          visibleStateRequestId: visibleStateRequestId,
+        );
       }
 
       if (updatedSchedule != null) {
@@ -776,6 +906,7 @@ class WeeklyScheduleViewModel extends BaseViewModel {
     int sourceGeneration,
     Future<ScheduleQueryResult?> refreshFuture, {
     bool applyToVisibleState = true,
+    required int visibleStateRequestId,
   }) async {
     int? visibleUpdateRequestId;
     if (applyToVisibleState) {
@@ -792,18 +923,27 @@ class WeeklyScheduleViewModel extends BaseViewModel {
       if (updatedSchedule != null) {
         _freshnessGate.markFetched(start, end, now);
         _markWindowFetched(start, end, now);
+        _cacheUpdatedScheduleResult(start, end, updatedSchedule);
       }
 
       if (_isDisposed || !applyToVisibleState) {
         return;
       }
 
-      if (currentDateStart != start || currentDateEnd != end) {
+      if (currentDateStart != start ||
+          currentDateEnd != end ||
+          visibleStateRequestId != _visibleStateRequestId) {
         return;
       }
 
       if (updatedSchedule != null) {
-        _applyUpdatedScheduleResult(start, end, updatedSchedule);
+        _applyUpdatedScheduleResult(
+          start,
+          end,
+          updatedSchedule,
+          sourceGeneration: sourceGeneration,
+          visibleStateRequestId: visibleStateRequestId,
+        );
         _entryRefreshGate.markFetched(start, end, now);
       }
 
@@ -838,21 +978,40 @@ class WeeklyScheduleViewModel extends BaseViewModel {
   void _applyUpdatedScheduleResult(
     DateTime start,
     DateTime end,
-    ScheduleQueryResult updatedSchedule,
-  ) {
-    var schedule = updatedSchedule.schedule;
-    _memoryWeekCache[_windowKey(start, end)] = schedule;
+    ScheduleQueryResult updatedSchedule, {
+    required int sourceGeneration,
+    required int visibleStateRequestId,
+  }) {
+    if (!_isCurrentScheduleSourceGeneration(sourceGeneration)) return;
+    final schedule = updatedSchedule.schedule;
+    _cacheUpdatedScheduleResult(start, end, updatedSchedule);
 
-    _applyVisibleSchedule(schedule, start, end);
+    _applyVisibleSchedule(
+      schedule,
+      start,
+      end,
+      sourceGeneration: sourceGeneration,
+      visibleStateRequestId: visibleStateRequestId,
+    );
 
-    _hasQueryErrors = updatedSchedule.hasError;
-    notifyIfMounted("hasQueryErrors");
+    if (_hasQueryErrors != updatedSchedule.hasError) {
+      _hasQueryErrors = updatedSchedule.hasError;
+      notifyIfMounted("hasQueryErrors");
+    }
 
     if (updatedSchedule.hasError) {
       _queryFailedCallback?.call();
     }
 
     scheduleUrl = schedule.urls.isNotEmpty ? schedule.urls[0] : null;
+  }
+
+  void _cacheUpdatedScheduleResult(
+    DateTime start,
+    DateTime end,
+    ScheduleQueryResult updatedSchedule,
+  ) {
+    _memoryWeekCache[_windowKey(start, end)] = updatedSchedule.schedule;
   }
 
   Future<ScheduleQueryResult?> _readScheduleFromServiceDeduped(
@@ -1235,6 +1394,24 @@ class WeeklyDisplayRange {
   final DateTime end;
 
   WeeklyDisplayRange(this.start, this.end);
+}
+
+class _QueuedVisibleScheduleResult {
+  final Schedule? schedule;
+  final DateTime start;
+  final DateTime end;
+  final int sourceGeneration;
+  final int visibleStateRequestId;
+  final int sequence;
+
+  const _QueuedVisibleScheduleResult({
+    required this.schedule,
+    required this.start,
+    required this.end,
+    required this.sourceGeneration,
+    required this.visibleStateRequestId,
+    required this.sequence,
+  });
 }
 
 bool _hasEntriesOnDay(Schedule schedule, DateTime dayStart) {

--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -355,6 +355,7 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
       onNotification: (notification) {
         if (notification is ScrollStartNotification) {
           _setPagerScrolling(true);
+          viewModel.beginVisiblePaging();
         }
         if (notification is ScrollEndNotification) {
           _setPagerScrolling(false);
@@ -403,13 +404,21 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
   }
 
   Future<void> _commitVisibleWeekFromPager() async {
-    if (_isApplyingWidgetPayload) return;
     final page = _weekPageController.hasClients
         ? (_weekPageController.page ?? _currentPageIndex.toDouble()).round()
         : _currentPageIndex;
     _currentPageIndex = page;
 
     final targetWeekStart = _weekStartForPage(page);
+    final targetWeekEnd = toNextWeek(targetWeekStart);
+    if (_isApplyingWidgetPayload) {
+      viewModel.endVisiblePaging(
+        viewModel.currentDateStart,
+        viewModel.currentDateEnd,
+      );
+      return;
+    }
+    viewModel.endVisiblePaging(targetWeekStart, targetWeekEnd);
     if (isAtSameDay(
       targetWeekStart,
       _normalizeWeekStart(viewModel.currentDateStart),

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_grid.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_grid.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-class ScheduleGrid extends CustomPaint {
+class ScheduleGrid extends StatelessWidget {
   final double fromHour;
   final double toHour;
   final double timeLabelsWidth;
@@ -9,77 +9,114 @@ class ScheduleGrid extends CustomPaint {
   final int columns;
   final Color gridLinesColor;
 
-  ScheduleGrid(this.fromHour, this.toHour, this.timeLabelsWidth,
-      this.dateLabelsHeight, this.columns, this.gridLinesColor)
-      : super(
-            painter: ScheduleGridCustomPaint(
-          fromHour,
-          toHour,
-          timeLabelsWidth,
-          dateLabelsHeight,
-          columns,
-          gridLinesColor,
-        ));
-}
-
-class ScheduleGridCustomPaint extends CustomPainter {
-  final double fromHour;
-  final double toHour;
-  final double timeLabelsWidth;
-  final double dateLabelsHeight;
-  final int columns;
-  final Color gridLineColor;
-
-  ScheduleGridCustomPaint(
+  const ScheduleGrid(
     this.fromHour,
     this.toHour,
     this.timeLabelsWidth,
     this.dateLabelsHeight,
+    this.columns,
+    this.gridLinesColor, {
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: <Widget>[
+        RepaintBoundary(
+          key: const ValueKey<String>('schedule-grid-static-columns'),
+          child: CustomPaint(
+            painter: ScheduleGridVerticalLinesPainter(
+              timeLabelsWidth,
+              columns,
+              gridLinesColor,
+            ),
+          ),
+        ),
+        RepaintBoundary(
+          key: const ValueKey<String>('schedule-grid-hour-lines'),
+          child: CustomPaint(
+            painter: ScheduleGridHorizontalLinesPainter(
+              fromHour,
+              toHour,
+              dateLabelsHeight,
+              gridLinesColor,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class ScheduleGridVerticalLinesPainter extends CustomPainter {
+  final double timeLabelsWidth;
+  final int columns;
+  final Color gridLineColor;
+
+  ScheduleGridVerticalLinesPainter(
+    this.timeLabelsWidth,
     this.columns,
     this.gridLineColor,
   );
 
   @override
   void paint(Canvas canvas, Size size) {
-    final secondaryPaint = Paint()
+    final paint = Paint()
       ..color = gridLineColor
       ..strokeWidth = 1;
-
-    drawHorizontalLines(size, canvas, secondaryPaint);
-    drawVerticalLines(size, canvas, secondaryPaint);
+    for (var i = 0; i < columns; i++) {
+      final x =
+          ((size.width - timeLabelsWidth) / columns) * i + timeLabelsWidth;
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+    }
   }
 
-  void drawHorizontalLines(Size size, Canvas canvas, Paint secondaryPaint) {
+  @override
+  bool shouldRepaint(covariant ScheduleGridVerticalLinesPainter oldDelegate) {
+    return timeLabelsWidth != oldDelegate.timeLabelsWidth ||
+        columns != oldDelegate.columns ||
+        gridLineColor != oldDelegate.gridLineColor;
+  }
+}
+
+class ScheduleGridHorizontalLinesPainter extends CustomPainter {
+  final double fromHour;
+  final double toHour;
+  final double dateLabelsHeight;
+  final Color gridLineColor;
+
+  ScheduleGridHorizontalLinesPainter(
+    this.fromHour,
+    this.toHour,
+    this.dateLabelsHeight,
+    this.gridLineColor,
+  );
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = gridLineColor
+      ..strokeWidth = 1;
     final visibleHours = toHour - fromHour;
     if (visibleHours <= 0) return;
 
     final visibleHeight = size.height - dateLabelsHeight;
     final firstHourMarker = fromHour.ceil();
     final lastHourMarker = toHour.floor();
-
     for (var marker = firstHourMarker; marker <= lastHourMarker; marker++) {
       final normalized = (marker - fromHour) / visibleHours;
       final y = (visibleHeight * normalized) + dateLabelsHeight;
-      canvas.drawLine(Offset(0, y), Offset(size.width, y), secondaryPaint);
-    }
-  }
-
-  void drawVerticalLines(Size size, Canvas canvas, Paint secondaryPaint) {
-    for (var i = 0; i < columns; i++) {
-      var x = ((size.width - timeLabelsWidth) / columns) * i + timeLabelsWidth;
-
-      canvas.drawLine(Offset(x, 0), Offset(x, size.height), secondaryPaint);
+      canvas.drawLine(Offset(0, y), Offset(size.width, y), paint);
     }
   }
 
   @override
-  bool shouldRepaint(CustomPainter oldDelegate) {
-    if (oldDelegate is! ScheduleGridCustomPaint) return true;
+  bool shouldRepaint(covariant ScheduleGridHorizontalLinesPainter oldDelegate) {
     return fromHour != oldDelegate.fromHour ||
         toHour != oldDelegate.toHour ||
-        timeLabelsWidth != oldDelegate.timeLabelsWidth ||
         dateLabelsHeight != oldDelegate.dateLabelsHeight ||
-        columns != oldDelegate.columns ||
         gridLineColor != oldDelegate.gridLineColor;
   }
 }

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart
@@ -132,28 +132,39 @@ class ScheduleWidget extends StatelessWidget {
     final staticLayers = Stack(
       fit: StackFit.expand,
       children: <Widget>[
-        Padding(
-          padding: EdgeInsets.fromLTRB(timeLabelsWidth, dayLabelsHeight, 0, 0),
-          child: _AnimatedScheduleEntryLayer(
-            renderData: renderData,
-            layoutProfile: layoutProfile,
-            viewport: viewport,
-            targetViewport: target,
-            onScheduleEntryTap: onScheduleEntryTap,
+        RepaintBoundary(
+          key: const ValueKey<String>('schedule-entry-layer'),
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              timeLabelsWidth,
+              dayLabelsHeight,
+              0,
+              0,
+            ),
+            child: _AnimatedScheduleEntryLayer(
+              renderData: renderData,
+              layoutProfile: layoutProfile,
+              viewport: viewport,
+              targetViewport: target,
+              onScheduleEntryTap: onScheduleEntryTap,
+            ),
           ),
         ),
-        Stack(
-          children: buildLabelWidgets(
-            context,
-            targetHourHeight,
-            width / days,
-            dayLabelsHeight,
-            timeLabelsWidth,
-            targetHourHeight,
-            targetMinuteHeight,
-            layoutProfile,
-            target.startHour,
-            target.endHour,
+        RepaintBoundary(
+          key: const ValueKey<String>('schedule-label-layer'),
+          child: Stack(
+            children: buildLabelWidgets(
+              context,
+              targetHourHeight,
+              width / days,
+              dayLabelsHeight,
+              timeLabelsWidth,
+              targetHourHeight,
+              targetMinuteHeight,
+              layoutProfile,
+              target.startHour,
+              target.endHour,
+            ),
           ),
         ),
       ],
@@ -188,38 +199,47 @@ class ScheduleWidget extends StatelessWidget {
               dayLabelsHeight,
               days,
               colorScheduleGridGridLines(context),
+              key: const ValueKey<String>('schedule-grid-layer'),
             ),
             child!,
-            Padding(
-              padding: EdgeInsets.fromLTRB(
-                timeLabelsWidth,
-                dayLabelsHeight,
-                0,
-                0,
-              ),
-              child: SchedulePastOverlay(
-                currentViewport.startHour,
-                currentViewport.endHour,
-                colorScheduleInPastOverlay(context),
-                displayStart,
-                displayEnd,
-                now,
-                days,
-              ),
-            ),
-            if (currentTimeIndicatorGeometry != null)
-              Padding(
+            RepaintBoundary(
+              key: const ValueKey<String>('schedule-past-overlay-layer'),
+              child: Padding(
                 padding: EdgeInsets.fromLTRB(
                   timeLabelsWidth,
                   dayLabelsHeight,
                   0,
                   0,
                 ),
-                child: ScheduleCurrentTimeIndicator(
-                  dayIndex: currentTimeIndicatorGeometry.dayIndex,
-                  columns: days,
-                  yOffset: currentTimeIndicatorGeometry.yOffset,
-                  color: colorCurrentTimeIndicator(context),
+                child: SchedulePastOverlay(
+                  currentViewport.startHour,
+                  currentViewport.endHour,
+                  colorScheduleInPastOverlay(context),
+                  displayStart,
+                  displayEnd,
+                  now,
+                  days,
+                ),
+              ),
+            ),
+            if (currentTimeIndicatorGeometry != null)
+              RepaintBoundary(
+                key: const ValueKey<String>(
+                  'schedule-current-time-indicator-layer',
+                ),
+                child: Padding(
+                  padding: EdgeInsets.fromLTRB(
+                    timeLabelsWidth,
+                    dayLabelsHeight,
+                    0,
+                    0,
+                  ),
+                  child: ScheduleCurrentTimeIndicator(
+                    dayIndex: currentTimeIndicatorGeometry.dayIndex,
+                    columns: days,
+                    yOffset: currentTimeIndicatorGeometry.yOffset,
+                    color: colorCurrentTimeIndicator(context),
+                  ),
                 ),
               ),
           ],
@@ -294,37 +314,62 @@ class ScheduleWidget extends StatelessWidget {
           dayLabelsHeight,
           days,
           colorScheduleGridGridLines(context),
+          key: const ValueKey<String>('schedule-grid-layer'),
         ),
-        Padding(
-          padding: EdgeInsets.fromLTRB(timeLabelsWidth, dayLabelsHeight, 0, 0),
-          child: Stack(clipBehavior: Clip.hardEdge, children: entryWidgets),
-        ),
-        Stack(children: labelWidgets),
-        Padding(
-          padding: EdgeInsets.fromLTRB(timeLabelsWidth, dayLabelsHeight, 0, 0),
-          child: SchedulePastOverlay(
-            displayStartHour,
-            displayEndHour,
-            colorScheduleInPastOverlay(context),
-            displayStart,
-            displayEnd,
-            now,
-            days,
-          ),
-        ),
-        if (currentTimeIndicatorGeometry != null)
-          Padding(
+        RepaintBoundary(
+          key: const ValueKey<String>('schedule-entry-layer'),
+          child: Padding(
             padding: EdgeInsets.fromLTRB(
               timeLabelsWidth,
               dayLabelsHeight,
               0,
               0,
             ),
-            child: ScheduleCurrentTimeIndicator(
-              dayIndex: currentTimeIndicatorGeometry.dayIndex,
-              columns: days,
-              yOffset: currentTimeIndicatorGeometry.yOffset,
-              color: colorCurrentTimeIndicator(context),
+            child: Stack(clipBehavior: Clip.hardEdge, children: entryWidgets),
+          ),
+        ),
+        RepaintBoundary(
+          key: const ValueKey<String>('schedule-label-layer'),
+          child: Stack(children: labelWidgets),
+        ),
+        RepaintBoundary(
+          key: const ValueKey<String>('schedule-past-overlay-layer'),
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              timeLabelsWidth,
+              dayLabelsHeight,
+              0,
+              0,
+            ),
+            child: SchedulePastOverlay(
+              displayStartHour,
+              displayEndHour,
+              colorScheduleInPastOverlay(context),
+              displayStart,
+              displayEnd,
+              now,
+              days,
+            ),
+          ),
+        ),
+        if (currentTimeIndicatorGeometry != null)
+          RepaintBoundary(
+            key: const ValueKey<String>(
+              'schedule-current-time-indicator-layer',
+            ),
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(
+                timeLabelsWidth,
+                dayLabelsHeight,
+                0,
+                0,
+              ),
+              child: ScheduleCurrentTimeIndicator(
+                dayIndex: currentTimeIndicatorGeometry.dayIndex,
+                columns: days,
+                yOffset: currentTimeIndicatorGeometry.yOffset,
+                color: colorCurrentTimeIndicator(context),
+              ),
             ),
           ),
       ],

--- a/test/common/logging/performance_telemetry_test.dart
+++ b/test/common/logging/performance_telemetry_test.dart
@@ -19,4 +19,10 @@ void main() {
       'parse_error',
     );
   });
+
+  test('frame budget follows the active display refresh rate', () {
+    expect(PerformanceTelemetry.frameBudgetMicrosForRefreshRate(120), 8334);
+    expect(PerformanceTelemetry.frameBudgetMicrosForRefreshRate(60), 16667);
+    expect(PerformanceTelemetry.frameBudgetMicrosForRefreshRate(null), 16667);
+  });
 }

--- a/test/common/logging/performance_telemetry_test.dart
+++ b/test/common/logging/performance_telemetry_test.dart
@@ -24,5 +24,7 @@ void main() {
     expect(PerformanceTelemetry.frameBudgetMicrosForRefreshRate(120), 8334);
     expect(PerformanceTelemetry.frameBudgetMicrosForRefreshRate(60), 16667);
     expect(PerformanceTelemetry.frameBudgetMicrosForRefreshRate(null), 16667);
+    expect(PerformanceTelemetry.frameBudgetMicrosForRefreshRate(0), 16667);
+    expect(PerformanceTelemetry.frameBudgetMicrosForRefreshRate(-1), 16667);
   });
 }

--- a/test/schedule/ui/viewmodels/weekly_schedule_view_model_pager_test.dart
+++ b/test/schedule/ui/viewmodels/weekly_schedule_view_model_pager_test.dart
@@ -12,6 +12,114 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test(
+    'equivalent visible schedule results keep the same snapshot version',
+    () async {
+      final provider = _EquivalentScheduleProvider(<ScheduleEntry>[
+        _entry(DateTime(2026, 2, 9), 'CURRENT_WEEK'),
+      ]);
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        _FakeScheduleSourceProvider(),
+        nowProvider: () => DateTime(2026, 2, 10, 10),
+      );
+      addTearDown(viewModel.dispose);
+
+      final weekStart = DateTime(2026, 2, 9);
+      final weekEnd = DateTime(2026, 2, 16);
+      await viewModel.updateSchedule(weekStart, weekEnd, force: true);
+
+      final initialSnapshot = viewModel.visibleScheduleSnapshot!;
+      var notifications = 0;
+      viewModel.addListener((_) => notifications += 1, const ['weekSchedule']);
+
+      await viewModel.updateSchedule(
+        weekStart,
+        weekEnd,
+        force: true,
+        awaitRefresh: true,
+      );
+
+      expect(notifications, 0);
+      expect(
+        viewModel.visibleScheduleSnapshot!.version,
+        initialSnapshot.version,
+      );
+      expect(
+        viewModel.visibleScheduleSnapshot!.entries.single.title,
+        'CURRENT_WEEK',
+      );
+    },
+  );
+
+  test(
+    'latest valid cache and refresh result wins after paging settles',
+    () async {
+      final provider = _CacheThenUpdatedScheduleProvider();
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        _FakeScheduleSourceProvider(),
+        nowProvider: () => DateTime(2026, 2, 10, 10),
+      );
+      addTearDown(viewModel.dispose);
+
+      final weekStart = DateTime(2026, 2, 9);
+      final weekEnd = DateTime(2026, 2, 16);
+      await viewModel.updateSchedule(
+        weekStart,
+        weekEnd,
+        force: true,
+        awaitRefresh: true,
+      );
+      expect(viewModel.weekSchedule!.entries.single.title, 'CACHED_WEEK');
+
+      viewModel.beginVisiblePaging();
+      await viewModel.updateSchedule(
+        weekStart,
+        weekEnd,
+        force: true,
+        awaitRefresh: true,
+      );
+
+      expect(viewModel.weekSchedule!.entries.single.title, 'CACHED_WEEK');
+
+      viewModel.endVisiblePaging(weekStart, weekEnd);
+
+      expect(viewModel.weekSchedule!.entries.single.title, 'REFRESHED_WEEK');
+    },
+  );
+
+  test(
+    'queued result for a week that is no longer settled is discarded',
+    () async {
+      final provider = _CacheThenUpdatedScheduleProvider();
+      final viewModel = WeeklyScheduleViewModel(
+        provider,
+        _FakeScheduleSourceProvider(),
+        nowProvider: () => DateTime(2026, 2, 10, 10),
+      );
+      addTearDown(viewModel.dispose);
+
+      final weekStart = DateTime(2026, 2, 9);
+      final weekEnd = DateTime(2026, 2, 16);
+      final otherWeekStart = DateTime(2026, 2, 16);
+      final otherWeekEnd = DateTime(2026, 2, 23);
+      await viewModel.updateSchedule(weekStart, weekEnd, force: true);
+
+      viewModel.beginVisiblePaging();
+      await viewModel.updateSchedule(
+        weekStart,
+        weekEnd,
+        force: true,
+        awaitRefresh: true,
+      );
+      viewModel.endVisiblePaging(otherWeekStart, otherWeekEnd);
+
+      expect(viewModel.currentDateStart, weekStart);
+      expect(viewModel.weekSchedule!.entries.single.title, 'CACHED_WEEK');
+    },
+  );
+
   test('cached week commit updates weekSchedule after pager settles', () async {
     final viewModel = WeeklyScheduleViewModel(
       _FakeScheduleProvider(<ScheduleEntry>[
@@ -385,6 +493,53 @@ class _FakeScheduleProvider implements ScheduleProvider {
   @override
   dynamic noSuchMethod(Invocation invocation) {
     throw UnsupportedError('Unexpected ScheduleProvider call: $invocation');
+  }
+}
+
+class _EquivalentScheduleProvider extends _FakeScheduleProvider {
+  _EquivalentScheduleProvider(super.entries);
+
+  @override
+  Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
+    final schedule = await super.getCachedSchedule(start, end);
+    return Schedule.fromList(
+      schedule.entries.map((entry) => entry.copyWith()).toList(),
+    );
+  }
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken, {
+    ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
+  }) async {
+    return ScheduleQueryResult(await getCachedSchedule(start, end), const []);
+  }
+}
+
+class _CacheThenUpdatedScheduleProvider extends _FakeScheduleProvider {
+  var _updateCount = 0;
+
+  _CacheThenUpdatedScheduleProvider() : super(const <ScheduleEntry>[]);
+
+  @override
+  Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
+    return Schedule.fromList([_entry(start, 'CACHED_WEEK')]);
+  }
+
+  @override
+  Future<ScheduleQueryResult> getUpdatedSchedule(
+    DateTime start,
+    DateTime end,
+    CancellationToken cancellationToken, {
+    ScheduleRefreshOrigin origin = ScheduleRefreshOrigin.userBrowsing,
+  }) async {
+    final title = _updateCount++ == 0 ? 'CACHED_WEEK' : 'REFRESHED_WEEK';
+    return ScheduleQueryResult(
+      Schedule.fromList([_entry(start, title)]),
+      const [],
+    );
   }
 }
 

--- a/test/schedule/ui/weeklyschedule/schedule_widget_layout_profile_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_widget_layout_profile_test.dart
@@ -9,15 +9,88 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('uses compact mobile grid dimensions on narrow layouts', (
+  test('grid painters isolate static columns from changing hour lines', () {
+    final staticColumns = ScheduleGridVerticalLinesPainter(46, 5, Colors.grey);
+    expect(
+      staticColumns.shouldRepaint(
+        ScheduleGridVerticalLinesPainter(46, 5, Colors.grey),
+      ),
+      isFalse,
+    );
+    expect(
+      staticColumns.shouldRepaint(
+        ScheduleGridVerticalLinesPainter(54, 5, Colors.grey),
+      ),
+      isTrue,
+    );
+
+    final hourLines = ScheduleGridHorizontalLinesPainter(
+      7,
+      19,
+      52,
+      Colors.grey,
+    );
+    expect(
+      hourLines.shouldRepaint(
+        ScheduleGridHorizontalLinesPainter(7, 19, 52, Colors.grey),
+      ),
+      isFalse,
+    );
+    expect(
+      hourLines.shouldRepaint(
+        ScheduleGridHorizontalLinesPainter(7, 20, 52, Colors.grey),
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('weekly layers have independent repaint boundaries', (
     tester,
   ) async {
     await tester.pumpWidget(
-      _buildApp(
-        width: 360,
-        height: 680,
-      ),
+      _buildApp(width: 360, height: 680, now: DateTime(2026, 2, 11, 12)),
     );
+
+    final gridLayer = find.byKey(const ValueKey<String>('schedule-grid-layer'));
+    expect(gridLayer, findsOneWidget);
+    expect(
+      find.descendant(of: gridLayer, matching: find.byType(RepaintBoundary)),
+      findsNWidgets(2),
+    );
+    expect(
+      find.byKey(const ValueKey<String>('schedule-entry-layer')),
+      findsOneWidget,
+    );
+    expect(
+      tester.widget<RepaintBoundary>(
+        find.byKey(const ValueKey<String>('schedule-entry-layer')),
+      ),
+      isA<RepaintBoundary>(),
+    );
+    expect(
+      find.byKey(const ValueKey<String>('schedule-past-overlay-layer')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(
+        const ValueKey<String>('schedule-current-time-indicator-layer'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('schedule-grid-static-columns')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('schedule-grid-hour-lines')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('uses compact mobile grid dimensions on narrow layouts', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildApp(width: 360, height: 680));
 
     final grid = tester.widget<ScheduleGrid>(find.byType(ScheduleGrid));
     expect(grid.timeLabelsWidth, 46);
@@ -25,20 +98,16 @@ void main() {
   });
 
   testWidgets('keeps default grid dimensions on wide layouts', (tester) async {
-    await tester.pumpWidget(
-      _buildApp(
-        width: 800,
-        height: 680,
-      ),
-    );
+    await tester.pumpWidget(_buildApp(width: 800, height: 680));
 
     final grid = tester.widget<ScheduleGrid>(find.byType(ScheduleGrid));
     expect(grid.timeLabelsWidth, 54);
     expect(grid.dateLabelsHeight, 72);
   });
 
-  testWidgets('compact layout keeps adjacent day event cards nearly touching',
-      (tester) async {
+  testWidgets('compact layout keeps adjacent day event cards nearly touching', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       _buildApp(
         width: 360,
@@ -65,8 +134,9 @@ void main() {
     expect(gap, lessThanOrEqualTo(0.3));
   });
 
-  testWidgets('compact layout keeps overlap cards visually separated',
-      (tester) async {
+  testWidgets('compact layout keeps overlap cards visually separated', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       _buildApp(
         width: 360,
@@ -74,7 +144,10 @@ void main() {
         schedule: Schedule.fromList([
           _entry(DateTime(2026, 2, 9, 9), DateTime(2026, 2, 9, 11), 'C1'),
           _entry(
-              DateTime(2026, 2, 9, 9, 30), DateTime(2026, 2, 9, 10, 30), 'C2'),
+            DateTime(2026, 2, 9, 9, 30),
+            DateTime(2026, 2, 9, 10, 30),
+            'C2',
+          ),
         ]),
       ),
     );
@@ -100,6 +173,7 @@ void main() {
 Widget _buildApp({
   required double width,
   required double height,
+  DateTime? now,
   Schedule? schedule,
 }) {
   return MaterialApp(
@@ -120,7 +194,7 @@ Widget _buildApp({
             displayStart: DateTime(2026, 2, 9),
             displayEnd: DateTime(2026, 2, 13),
             onScheduleEntryTap: (_) {},
-            now: DateTime(2026, 2, 11, 12),
+            now: now ?? DateTime(2026, 2, 11, 12),
             displayStartHour: 7.0,
             displayEndHour: 19.0,
           ),


### PR DESCRIPTION
## Summary

- suppress equivalent visible Schedule state notifications with immutable render snapshots
- reject stale source/page results and queue only the latest valid visible result while paging
- split static grid columns from viewport-dependent hour lines
- isolate stable entries, labels, overlays, and current-time rendering into targeted layers
- make production frame diagnostics use the active display refresh budget with sub-millisecond logging precision

## Stack

This PR is intentionally based on **PR #101**, which is based on **PR #97**. Merge #97, retarget and merge #101, then retarget this PR to `v2` before merging.

## Pixel 8 Pro results

Three current-`v2` control runs and three final branch runs at 120 Hz / 1.0x animations:

- first populated swipe missed frames: **20.45% → 14.89%**
- first populated swipe p99: **32.33 → 25.85 ms**
- settled populated swipe missed frames: **22.92% → 12.24%**
- database-cached navigation missed frames: **17.95% → 7.20%**
- rapid four-swipe burst missed frames: **16.45% → 7.45%**
- rapid burst p95: **16.00 → 9.89 ms**
- short→tall frames over 16.67 ms: **3 → 1**

## Validation

- full `flutter analyze`
- 163 stacked Schedule/telemetry tests passed
- three-run current-`v2` Pixel control
- three-run final branch Pixel diagnostic
- all Schedule final-state and animation-progression checks passed

Documentation: `docs/solutions/performance/weekly-schedule-state-raster-refresh-20260712.md`
