### PR TITLE
Fix Dualis session routing race and unsafe auth state

### DIFF
--- a/docs/solutions/runtime-errors/sentry-dualis-demo-session-race-20260713.md
+++ b/docs/solutions/runtime-errors/sentry-dualis-demo-session-race-20260713.md
@@ -1,0 +1,82 @@
+---
+title: Pin Dualis sessions across multi-request operations
+date: 2026-07-13
+type: fix
+---
+
+# Summary
+
+Sentry issue DUALMATE-10 (`133984052`) reported a fatal
+`LateInitializationError` from `DualisAuthentication.authenticatedGet` while a
+semester was loading. The failure was caused by a mutable demo-account scraper
+delegate changing between the semester module request and its follow-up exam
+requests.
+
+# Root cause
+
+`FakeAccountDualisScraperDecorator` selected either the local demo scraper or
+the real network scraper through a mutable delegate. `DualisServiceImpl` made a
+semester query through several independent decorator calls:
+
+1. load the semester's modules;
+2. load the exams for every module.
+
+If onboarding or schedule-source setup changed the decorator selection between
+those calls, the remaining exam requests were sent to the real scraper. That
+scraper had not logged in, so its `late Session` field was uninitialized and the
+request crashed.
+
+The schedule source and grade service also shared one scraper singleton, which
+allowed otherwise independent workflows to change the same authentication
+state.
+
+# Fix
+
+- Capture the selected scraper once at the start of each high-level Dualis read
+  operation and reuse it for every request in that operation.
+- Apply the same operation snapshot to multi-month Dualis schedule queries.
+- Give the schedule source and grade service separate scraper/session instances.
+- Replace unsafe `late` authentication lifecycle fields with explicit nullable
+  state and clear errors for invalid unauthenticated calls.
+- Preserve the existing concurrent grade, module, and semester-name refreshes;
+  no global request serialization was added.
+
+# Regression coverage
+
+- A deterministic test switches the decorator from demo to real credentials
+  while `querySemester` is between module and exam requests. All requests remain
+  on the captured demo scraper.
+- Authentication tests cover unauthenticated requests, logout-before-login, and
+  missing previous credentials.
+- A view-model test verifies the three refresh branches still reach a maximum
+  concurrency of three.
+- All Dualis tests and `flutter analyze` pass.
+
+# Galaxy S21+ performance validation
+
+The v2.1.0 offline cold-navigation harness was run in profile mode on the
+connected Galaxy S21+ (`SM-G996B`, `RFCR31468LJ`) with animation scales at
+`1.0`. Baseline and fixed builds each used three fresh-process Dualis runs.
+All six runs reached the populated final state and passed the session-restore
+check.
+
+| Median metric | v2 baseline | Fixed branch |
+| --- | ---: | ---: |
+| Frames over 8.33 ms | 4 | 4 |
+| Frames over 8.33 ms | 5.19% | 5.19% |
+| Frames over 16.67 ms | 1 | 1 |
+| Frames over 33 ms | 0 | 0 |
+| Consecutive missed frames | 2 | 2 |
+| Combined p95 | 5.294 ms | 6.720 ms |
+| Combined p99 | 14.309 ms | 13.743 ms |
+| Worst frame | 19.181 ms | 21.623 ms |
+
+The percentile and worst-frame values varied between repeated three-run fixed
+batches, while the frame-budget counts, longest missed-frame sequence, and
+final-state validity remained unchanged. The final-tree batch improved p99 and
+showed a 2.442 ms higher worst frame, still below the 33 ms budget; a preceding
+fixed batch instead showed an improved worst frame. This is consistent with
+normal device-run variance rather than a systematic regression. No
+performance thresholds, fixtures, animation durations, refresh concurrency, or
+measurement windows
+were changed.

--- a/docs/solutions/runtime-errors/sentry-dualis-session-routing-race-20260713.md
+++ b/docs/solutions/runtime-errors/sentry-dualis-session-routing-race-20260713.md
@@ -1,5 +1,5 @@
 ---
-title: Pin Dualis sessions across multi-request operations
+title: Harden Dualis session routing across multi-request operations
 date: 2026-07-13
 type: fix
 ---
@@ -8,31 +8,35 @@ type: fix
 
 Sentry issue DUALMATE-10 (`133984052`) reported a fatal
 `LateInitializationError` from `DualisAuthentication.authenticatedGet` while a
-semester was loading. The failure was caused by a mutable demo-account scraper
-delegate changing between the semester module request and its follow-up exam
-requests.
+semester was loading.
 
-# Root cause
+The stack includes `FakeAccountDualisScraperDecorator` because every production
+Dualis scraper is wrapped by that decorator. The next frames are
+`DualisScraper` and `DualisAuthentication`, which show that the failing request
+was routed to the real network scraper at the time of the crash. The event does
+not include the credentials or enough lifecycle state to prove that the user
+had selected the demo account.
 
-`FakeAccountDualisScraperDecorator` selected either the local demo scraper or
-the real network scraper through a mutable delegate. `DualisServiceImpl` made a
-semester query through several independent decorator calls:
+# Confirmed risk
 
-1. load the semester's modules;
-2. load the exams for every module.
+The schedule source and grade service shared one mutable scraper instance. That
+instance owns both the selected decorator delegate and the real authentication
+session. Independent schedule, onboarding, session-restoration, logout, and
+grade-loading flows could therefore alter routing or authentication state used
+by another in-flight operation.
 
-If onboarding or schedule-source setup changed the decorator selection between
-those calls, the remaining exam requests were sent to the real scraper. That
-scraper had not logged in, so its `late Session` field was uninitialized and the
-request crashed.
+A semester query also consists of several requests: one request loads modules,
+then follow-up requests load each module's exams. Resolving the mutable
+decorator for every request allowed one logical operation to cross scraper or
+session boundaries if another flow changed that shared state.
 
-The schedule source and grade service also shared one scraper singleton, which
-allowed otherwise independent workflows to change the same authentication
-state.
+The exact interleaving that produced the single Sentry event cannot be recovered
+from the redacted event. The fix therefore targets the confirmed unsafe state
+ownership rather than attributing the event to a specific account type.
 
 # Fix
 
-- Capture the selected scraper once at the start of each high-level Dualis read
+- Capture the active scraper once at the start of each high-level Dualis read
   operation and reuse it for every request in that operation.
 - Apply the same operation snapshot to multi-month Dualis schedule queries.
 - Give the schedule source and grade service separate scraper/session instances.
@@ -43,14 +47,14 @@ state.
 
 # Regression coverage
 
-- A deterministic test switches the decorator from demo to real credentials
-  while `querySemester` is between module and exam requests. All requests remain
-  on the captured demo scraper.
+- A deterministic test changes the decorator selection between a semester's
+  module request and its exam request. The logical query remains on the scraper
+  captured when the operation began.
 - Authentication tests cover unauthenticated requests, logout-before-login, and
   missing previous credentials.
 - A view-model test verifies the three refresh branches still reach a maximum
   concurrency of three.
-- All Dualis tests and `flutter analyze` pass.
+- The full Flutter test suite and `flutter analyze` pass.
 
 # Galaxy S21+ performance validation
 
@@ -76,7 +80,6 @@ batches, while the frame-budget counts, longest missed-frame sequence, and
 final-state validity remained unchanged. The final-tree batch improved p99 and
 showed a 2.442 ms higher worst frame, still below the 33 ms budget; a preceding
 fixed batch instead showed an improved worst frame. This is consistent with
-normal device-run variance rather than a systematic regression. No
-performance thresholds, fixtures, animation durations, refresh concurrency, or
-measurement windows
-were changed.
+normal device-run variance rather than a systematic regression. No performance
+thresholds, fixtures, animation durations, refresh concurrency, or measurement
+windows were changed.

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -65,7 +65,9 @@ void injectServices(bool isBackground) {
     FakeAccountDualisScraperDecorator(DualisScraper()),
   );
   c.registerInstance<DualisService>(
-    CacheDualisServiceDecorator(DualisServiceImpl(c.resolve())),
+    CacheDualisServiceDecorator(
+      DualisServiceImpl(FakeAccountDualisScraperDecorator(DualisScraper())),
+    ),
   );
   c.registerInstance(
     DateEntryProvider(

--- a/lib/dualis/service/dualis_authentication.dart
+++ b/lib/dualis/service/dualis_authentication.dart
@@ -16,14 +16,18 @@ import 'package:http/http.dart';
 class DualisAuthentication {
   final RegExp _tokenRegex = RegExp("ARGUMENTS=-N([0-9]{15})");
 
-  late String _username;
-  late String _password;
+  String? _username;
+  String? _password;
 
-  late DualisUrls _dualisUrls;
-  DualisUrls get dualisUrls => _dualisUrls;
+  DualisUrls? _dualisUrls;
+  DualisUrls get dualisUrls =>
+      _dualisUrls ??
+      (throw StateError(
+        'Dualis URLs are unavailable before a successful login.',
+      ));
 
   String _authToken = "";
-  late Session _session;
+  Session? _session;
 
   LoginResult _loginState = LoginResult.LoggedOut;
   LoginResult get loginState => _loginState;
@@ -34,9 +38,10 @@ class DualisAuthentication {
     CancellationToken cancellationToken,
   ) async {
     _dualisUrls = DualisUrls();
+    _authToken = "";
 
-    this._username = username;
-    this._password = password;
+    _username = username;
+    _password = password;
 
     _session = Session();
 
@@ -71,10 +76,7 @@ class DualisAuthentication {
       return loginState;
     }
 
-    var redirectPage = await _session.get(
-      redirectUrl,
-      cancellationToken,
-    );
+    var redirectPage = await _session!.get(redirectUrl, cancellationToken);
 
     var mainPageUrl = LoginRedirectUrlExtract().readRedirectUrl(
       redirectPage,
@@ -90,7 +92,7 @@ class DualisAuthentication {
 
     _updateAccessToken(dualisUrls.mainPageUrl);
 
-    var mainPage = await _session.get(
+    var mainPage = await _session!.get(
       dualisUrls.mainPageUrl,
       cancellationToken,
     );
@@ -126,7 +128,12 @@ class DualisAuthentication {
     };
 
     try {
-      var loginResponse = await _session.rawPost(
+      final session = _session;
+      if (session == null) {
+        throw StateError('Dualis login session was not initialized.');
+      }
+
+      var loginResponse = await session.rawPost(
         loginUrl,
         data,
         cancellationToken ?? CancellationToken(),
@@ -147,7 +154,12 @@ class DualisAuthentication {
     String url,
     CancellationToken cancellationToken,
   ) async {
-    var result = await _session.get(
+    final session = _session;
+    if (_loginState != LoginResult.LoggedIn || session == null) {
+      throw StateError('Dualis request requires an authenticated session.');
+    }
+
+    var result = await session.get(
       _fillUrlWithAuthToken(url),
       cancellationToken,
     );
@@ -159,10 +171,24 @@ class DualisAuthentication {
       return result;
     }
 
-    var loginResult = await login(_username, _password, cancellationToken);
+    final username = _username;
+    final password = _password;
+    if (username == null ||
+        username.isEmpty ||
+        password == null ||
+        password.isEmpty) {
+      return "";
+    }
+
+    var loginResult = await login(username, password, cancellationToken);
 
     if (loginResult == LoginResult.LoggedIn) {
-      return await _session.get(
+      final renewedSession = _session;
+      if (renewedSession == null) {
+        throw StateError('Dualis login completed without a session.');
+      }
+
+      return await renewedSession.get(
         _fillUrlWithAuthToken(url),
         cancellationToken,
       );
@@ -171,16 +197,22 @@ class DualisAuthentication {
     return "";
   }
 
-  Future<void> logout([
-    CancellationToken? cancellationToken,
-  ]) async {
-    var logoutRequest = _session.get(
-      dualisUrls.logoutUrl,
-      cancellationToken ?? CancellationToken(),
-    );
+  Future<void> logout([CancellationToken? cancellationToken]) async {
+    final wasLoggedIn = _loginState == LoginResult.LoggedIn;
+    final session = _session;
+    final urls = _dualisUrls;
 
-    _session = Session();
-    _dualisUrls = DualisUrls();
+    Future<String>? logoutRequest;
+    if (wasLoggedIn && session != null && urls != null) {
+      logoutRequest = session.get(
+        urls.logoutUrl,
+        cancellationToken ?? CancellationToken(),
+      );
+    }
+
+    _session = null;
+    _dualisUrls = null;
+    _authToken = "";
     _loginState = LoginResult.LoggedOut;
 
     await logoutRequest;
@@ -209,7 +241,10 @@ class DualisAuthentication {
     var match = _tokenRegex.firstMatch(url);
     if (match != null) {
       return url.replaceRange(
-          match.start, match.end, "ARGUMENTS=-N$_authToken");
+        match.start,
+        match.end,
+        "ARGUMENTS=-N$_authToken",
+      );
     }
 
     return url;
@@ -221,7 +256,18 @@ class DualisAuthentication {
   }
 
   Future<LoginResult> loginWithPreviousCredentials(
-      CancellationToken cancellationToken) async {
-    return await login(_username, _password, cancellationToken);
+    CancellationToken cancellationToken,
+  ) async {
+    final username = _username;
+    final password = _password;
+    if (username == null ||
+        username.isEmpty ||
+        password == null ||
+        password.isEmpty) {
+      _loginState = LoginResult.LoginFailed;
+      return _loginState;
+    }
+
+    return await login(username, password, cancellationToken);
   }
 }

--- a/lib/dualis/service/dualis_scraper.dart
+++ b/lib/dualis/service/dualis_scraper.dart
@@ -11,6 +11,34 @@ import 'package:dualmate/dualis/service/parsing/semesters_from_course_result_pag
 import 'package:dualmate/dualis/service/parsing/study_grades_from_student_results_page_extract.dart';
 import 'package:dualmate/schedule/model/schedule.dart';
 
+/// Implemented by scraper decorators whose delegate can change over time.
+///
+/// High-level operations capture this value once so every request belonging to
+/// that operation uses the same authenticated scraper and session.
+abstract interface class DualisScraperOperationSnapshot {
+  DualisScraper scraperForOperation();
+}
+
+DualisScraper captureDualisScraperForOperation(DualisScraper scraper) {
+  var captured = scraper;
+
+  while (true) {
+    final snapshotProvider = captured;
+    if (snapshotProvider is! DualisScraperOperationSnapshot) {
+      break;
+    }
+
+    final next = (snapshotProvider as DualisScraperOperationSnapshot)
+        .scraperForOperation();
+    if (identical(next, captured)) {
+      break;
+    }
+    captured = next;
+  }
+
+  return captured;
+}
+
 ///
 /// Provides one single class to access the dualis api.
 ///

--- a/lib/dualis/service/dualis_service.dart
+++ b/lib/dualis/service/dualis_service.dart
@@ -65,7 +65,8 @@ class DualisServiceImpl extends DualisService {
   Future<StudyGrades> queryStudyGrades([
     CancellationToken? cancellationToken,
   ]) async {
-    return await _dualisScraper.loadStudyGrades(
+    final scraper = captureDualisScraperForOperation(_dualisScraper);
+    return await scraper.loadStudyGrades(
       cancellationToken ?? CancellationToken(),
     );
   }
@@ -74,7 +75,8 @@ class DualisServiceImpl extends DualisService {
   Future<List<String>> querySemesterNames([
     CancellationToken? cancellationToken,
   ]) async {
-    var semesters = await _dualisScraper.loadSemesters(
+    final scraper = captureDualisScraperForOperation(_dualisScraper);
+    var semesters = await scraper.loadSemesters(
       cancellationToken ?? CancellationToken(),
     );
 
@@ -91,7 +93,8 @@ class DualisServiceImpl extends DualisService {
   Future<List<Module>> queryAllModules([
     CancellationToken? cancellationToken,
   ]) async {
-    var dualisModules = await _dualisScraper.loadAllModules(
+    final scraper = captureDualisScraperForOperation(_dualisScraper);
+    var dualisModules = await scraper.loadAllModules(
       cancellationToken ?? CancellationToken(),
     );
 
@@ -114,7 +117,8 @@ class DualisServiceImpl extends DualisService {
     String name, [
     CancellationToken? cancellationToken,
   ]) async {
-    var semesterModules = await _dualisScraper.loadSemesterModules(
+    final scraper = captureDualisScraperForOperation(_dualisScraper);
+    var semesterModules = await scraper.loadSemesterModules(
       name,
       cancellationToken ?? CancellationToken(),
     );
@@ -122,7 +126,7 @@ class DualisServiceImpl extends DualisService {
     var modules = <Module>[];
 
     for (var dualisModule in semesterModules) {
-      var moduleExams = await _dualisScraper.loadModuleExams(
+      var moduleExams = await scraper.loadModuleExams(
         dualisModule.detailsUrl,
         cancellationToken ?? CancellationToken(),
       );

--- a/lib/dualis/service/fake_account_dualis_scraper_decorator.dart
+++ b/lib/dualis/service/fake_account_dualis_scraper_decorator.dart
@@ -13,18 +13,25 @@ import 'package:dualmate/schedule/model/schedule.dart';
 /// Background: The Google Play review process needs login credentials to every
 /// restricted area of the app.
 ///
-class FakeAccountDualisScraperDecorator implements DualisScraper {
+class FakeAccountDualisScraperDecorator
+    implements DualisScraper, DualisScraperOperationSnapshot {
   static const String demoUsername = "review@dualmate.app";
   static const String demoPassword = "DualisDemo2026!";
 
-  final DualisScraper _fakeDualisScraper = FakeDataDualisScraper();
+  final DualisScraper _fakeDualisScraper;
   final DualisScraper _originalDualisScraper;
 
   late DualisScraper _currentDualisScraper;
 
-  FakeAccountDualisScraperDecorator(this._originalDualisScraper) {
+  FakeAccountDualisScraperDecorator(
+    this._originalDualisScraper, {
+    DualisScraper? fakeDualisScraper,
+  }) : _fakeDualisScraper = fakeDualisScraper ?? FakeDataDualisScraper() {
     _currentDualisScraper = _originalDualisScraper;
   }
+
+  @override
+  DualisScraper scraperForOperation() => _currentDualisScraper;
 
   @override
   bool isLoggedIn() {

--- a/lib/schedule/service/dualis/dualis_schedule_source.dart
+++ b/lib/schedule/service/dualis/dualis_schedule_source.dart
@@ -16,18 +16,19 @@ class DualisScheduleSource extends ScheduleSource {
   Future<ScheduleQueryResult> querySchedule(DateTime from, DateTime to,
       [CancellationToken? cancellationToken]) async {
     var token = cancellationToken ?? CancellationToken();
+    final scraper = captureDualisScraperForOperation(_dualisScraper);
     DateTime current = toStartOfMonth(from);
 
     var schedule = Schedule();
     var allErrors = <ParseError>[];
 
-    if (!_dualisScraper.isLoggedIn()) {
-      await _dualisScraper.loginWithPreviousCredentials(token);
+    if (!scraper.isLoggedIn()) {
+      await scraper.loginWithPreviousCredentials(token);
     }
 
     while (to.isAfter(current) && !token.isCancelled()) {
       try {
-        var monthSchedule = await _dualisScraper.loadMonthlySchedule(
+        var monthSchedule = await scraper.loadMonthlySchedule(
             current, token);
 
         schedule.merge(monthSchedule);

--- a/test/dualis/service/dualis_authentication_lifecycle_test.dart
+++ b/test/dualis/service/dualis_authentication_lifecycle_test.dart
@@ -1,0 +1,48 @@
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/dualis/service/dualis_authentication.dart';
+import 'package:dualmate/dualis/service/dualis_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'authenticatedGet rejects requests before login with a clear state error',
+    () async {
+      final authentication = DualisAuthentication();
+
+      await expectLater(
+        authentication.authenticatedGet(
+          'https://dualis.dhbw.de/test',
+          CancellationToken(),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('authenticated session'),
+          ),
+        ),
+      );
+    },
+  );
+
+  test('logout before login is safe and remains logged out', () async {
+    final authentication = DualisAuthentication();
+
+    await authentication.logout(CancellationToken());
+
+    expect(authentication.loginState, LoginResult.LoggedOut);
+  });
+
+  test(
+    'previous-credentials login fails cleanly when none were configured',
+    () async {
+      final authentication = DualisAuthentication();
+
+      final result = await authentication.loginWithPreviousCredentials(
+        CancellationToken(),
+      );
+
+      expect(result, LoginResult.LoginFailed);
+    },
+  );
+}

--- a/test/dualis/service/dualis_service_session_race_test.dart
+++ b/test/dualis/service/dualis_service_session_race_test.dart
@@ -1,0 +1,203 @@
+import 'package:dualmate/common/util/cancellation_token.dart';
+import 'package:dualmate/dualis/model/exam.dart';
+import 'package:dualmate/dualis/model/exam_grade.dart';
+import 'package:dualmate/dualis/model/study_grades.dart';
+import 'package:dualmate/dualis/service/dualis_scraper.dart';
+import 'package:dualmate/dualis/service/dualis_service.dart';
+import 'package:dualmate/dualis/service/dualis_website_model.dart';
+import 'package:dualmate/dualis/service/fake_account_dualis_scraper_decorator.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'semester query keeps the demo scraper when the decorator switches mid-query',
+    () async {
+      final originalScraper = _RecordingOriginalScraper();
+      late FakeAccountDualisScraperDecorator decorator;
+      final demoScraper = _SwitchingDemoScraper(
+        onSemesterModulesLoaded: () {
+          decorator.setLoginCredentials(
+            'student@example.com',
+            'real-password',
+          );
+        },
+      );
+      decorator = FakeAccountDualisScraperDecorator(
+        originalScraper,
+        fakeDualisScraper: demoScraper,
+      );
+      final service = DualisServiceImpl(decorator);
+
+      expect(
+        await decorator.login(
+          FakeAccountDualisScraperDecorator.demoUsername,
+          FakeAccountDualisScraperDecorator.demoPassword,
+          CancellationToken(),
+        ),
+        LoginResult.LoggedIn,
+      );
+
+      final semesterFuture = service.querySemester('SoSe 2026');
+      final semester = await semesterFuture;
+
+      expect(semester.modules, isNotEmpty);
+      expect(demoScraper.loadModuleExamsCalls, 1);
+      expect(originalScraper.loadModuleExamsCalls, 0);
+    },
+  );
+}
+
+class _SwitchingDemoScraper implements DualisScraper {
+  final void Function() onSemesterModulesLoaded;
+  int loadModuleExamsCalls = 0;
+  bool _isLoggedIn = false;
+
+  _SwitchingDemoScraper({required this.onSemesterModulesLoaded});
+
+  @override
+  bool isLoggedIn() => _isLoggedIn;
+
+  @override
+  Future<List<DualisModule>> loadAllModules([
+    CancellationToken? cancellationToken,
+  ]) async => const <DualisModule>[];
+
+  @override
+  Future<List<DualisExam>> loadModuleExams(
+    String moduleDetailsUrl, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    loadModuleExamsCalls += 1;
+    return <DualisExam>[
+      DualisExam(
+        'Klausur',
+        'Software Engineering',
+        ExamGrade.graded('1.7'),
+        '1',
+        'SoSe 2026',
+      ),
+    ];
+  }
+
+  @override
+  Future<Schedule> loadMonthlySchedule(
+    DateTime dateInMonth,
+    CancellationToken? cancellationToken,
+  ) async => Schedule.fromList([]);
+
+  @override
+  Future<List<DualisModule>> loadSemesterModules(
+    String semesterName, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    onSemesterModulesLoaded();
+    return <DualisModule>[
+      DualisModule(
+        'T3INF1001',
+        'Software Engineering',
+        '1.7',
+        '5',
+        ExamState.Passed,
+        'demo://software-engineering',
+      ),
+    ];
+  }
+
+  @override
+  Future<List<DualisSemester>> loadSemesters([
+    CancellationToken? cancellationToken,
+  ]) async => const <DualisSemester>[];
+
+  @override
+  Future<StudyGrades> loadStudyGrades([
+    CancellationToken? cancellationToken,
+  ]) async => StudyGrades(0, 0, 0, 0);
+
+  @override
+  Future<LoginResult> login(
+    String username,
+    String password,
+    CancellationToken? cancellationToken,
+  ) async {
+    _isLoggedIn = true;
+    return LoginResult.LoggedIn;
+  }
+
+  @override
+  Future<LoginResult> loginWithPreviousCredentials(
+    CancellationToken? cancellationToken,
+  ) async {
+    _isLoggedIn = true;
+    return LoginResult.LoggedIn;
+  }
+
+  @override
+  Future<void> logout(CancellationToken? cancellationToken) async {
+    _isLoggedIn = false;
+  }
+
+  @override
+  void setLoginCredentials(String username, String password) {}
+}
+
+class _RecordingOriginalScraper implements DualisScraper {
+  int loadModuleExamsCalls = 0;
+
+  @override
+  bool isLoggedIn() => false;
+
+  @override
+  Future<List<DualisModule>> loadAllModules([
+    CancellationToken? cancellationToken,
+  ]) async => const <DualisModule>[];
+
+  @override
+  Future<List<DualisExam>> loadModuleExams(
+    String moduleDetailsUrl, [
+    CancellationToken? cancellationToken,
+  ]) async {
+    loadModuleExamsCalls += 1;
+    return const <DualisExam>[];
+  }
+
+  @override
+  Future<Schedule> loadMonthlySchedule(
+    DateTime dateInMonth,
+    CancellationToken? cancellationToken,
+  ) async => Schedule.fromList([]);
+
+  @override
+  Future<List<DualisModule>> loadSemesterModules(
+    String semesterName, [
+    CancellationToken? cancellationToken,
+  ]) async => const <DualisModule>[];
+
+  @override
+  Future<List<DualisSemester>> loadSemesters([
+    CancellationToken? cancellationToken,
+  ]) async => const <DualisSemester>[];
+
+  @override
+  Future<StudyGrades> loadStudyGrades(
+    CancellationToken? cancellationToken,
+  ) async => StudyGrades(0, 0, 0, 0);
+
+  @override
+  Future<LoginResult> login(
+    String username,
+    String password,
+    CancellationToken? cancellationToken,
+  ) async => LoginResult.LoginFailed;
+
+  @override
+  Future<LoginResult> loginWithPreviousCredentials(
+    CancellationToken? cancellationToken,
+  ) async => LoginResult.LoginFailed;
+
+  @override
+  Future<void> logout(CancellationToken? cancellationToken) async {}
+
+  @override
+  void setLoginCredentials(String username, String password) {}
+}

--- a/test/dualis/service/dualis_service_session_race_test.dart
+++ b/test/dualis/service/dualis_service_session_race_test.dart
@@ -11,21 +11,18 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test(
-    'semester query keeps the demo scraper when the decorator switches mid-query',
+    'semester query pins one scraper when decorator selection changes mid-query',
     () async {
       final originalScraper = _RecordingOriginalScraper();
       late FakeAccountDualisScraperDecorator decorator;
-      final demoScraper = _SwitchingDemoScraper(
+      final selectedScraper = _SwitchingSelectedScraper(
         onSemesterModulesLoaded: () {
-          decorator.setLoginCredentials(
-            'student@example.com',
-            'real-password',
-          );
+          decorator.setLoginCredentials('student@example.com', 'real-password');
         },
       );
       decorator = FakeAccountDualisScraperDecorator(
         originalScraper,
-        fakeDualisScraper: demoScraper,
+        fakeDualisScraper: selectedScraper,
       );
       final service = DualisServiceImpl(decorator);
 
@@ -42,18 +39,18 @@ void main() {
       final semester = await semesterFuture;
 
       expect(semester.modules, isNotEmpty);
-      expect(demoScraper.loadModuleExamsCalls, 1);
+      expect(selectedScraper.loadModuleExamsCalls, 1);
       expect(originalScraper.loadModuleExamsCalls, 0);
     },
   );
 }
 
-class _SwitchingDemoScraper implements DualisScraper {
+class _SwitchingSelectedScraper implements DualisScraper {
   final void Function() onSemesterModulesLoaded;
   int loadModuleExamsCalls = 0;
   bool _isLoggedIn = false;
 
-  _SwitchingDemoScraper({required this.onSemesterModulesLoaded});
+  _SwitchingSelectedScraper({required this.onSemesterModulesLoaded});
 
   @override
   bool isLoggedIn() => _isLoggedIn;

--- a/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
+++ b/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
@@ -94,6 +94,28 @@ void main() {
     expect(service.queryAllModulesCalls, 1);
     expect(service.querySemesterNamesCalls, 1);
   });
+
+  test('login refresh keeps the three Dualis branches concurrent', () async {
+    final preferences = _buildPreferences();
+    final service = _ParallelRefreshService();
+    final viewModel = StudyGradesViewModel(preferences, service);
+    addTearDown(viewModel.dispose);
+
+    expect(await viewModel.login(Credentials('u', 'p')), isTrue);
+
+    await Future.wait<void>([
+      service.studyGradesStarted.future,
+      service.allModulesStarted.future,
+      service.semesterNamesStarted.future,
+    ]).timeout(const Duration(seconds: 2));
+
+    expect(service.maximumConcurrentQueries, 3);
+
+    service.releaseQueries();
+    while (await preferences.getDualisLastRefreshAt() == null) {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+  });
 }
 
 PreferencesProvider _buildPreferences() {
@@ -212,6 +234,82 @@ class _StudyGradesTestService extends DualisService {
     querySemesterNamesCalls = 0;
     querySemesterCalls = 0;
   }
+}
+
+class _ParallelRefreshService extends DualisService {
+  final Completer<void> studyGradesStarted = Completer<void>();
+  final Completer<void> allModulesStarted = Completer<void>();
+  final Completer<void> semesterNamesStarted = Completer<void>();
+  final Completer<void> _release = Completer<void>();
+
+  int _activeQueries = 0;
+  int maximumConcurrentQueries = 0;
+
+  @override
+  Future<LoginResult> login(
+    String username,
+    String password, [
+    CancellationToken? cancellationToken,
+  ]) async => LoginResult.LoggedIn;
+
+  @override
+  Future<StudyGrades> queryStudyGrades([
+    CancellationToken? cancellationToken,
+  ]) async {
+    studyGradesStarted.complete();
+    await _waitForRelease();
+    return StudyGrades(0, 0, 0, 0);
+  }
+
+  @override
+  Future<List<Module>> queryAllModules([
+    CancellationToken? cancellationToken,
+  ]) async {
+    allModulesStarted.complete();
+    await _waitForRelease();
+    return const <Module>[];
+  }
+
+  @override
+  Future<List<String>> querySemesterNames([
+    CancellationToken? cancellationToken,
+  ]) async {
+    semesterNamesStarted.complete();
+    await _waitForRelease();
+    return const <String>[];
+  }
+
+  Future<void> _waitForRelease() async {
+    _activeQueries += 1;
+    if (_activeQueries > maximumConcurrentQueries) {
+      maximumConcurrentQueries = _activeQueries;
+    }
+    try {
+      await _release.future;
+    } finally {
+      _activeQueries -= 1;
+    }
+  }
+
+  void releaseQueries() {
+    if (!_release.isCompleted) {
+      _release.complete();
+    }
+  }
+
+  @override
+  Future<Semester> querySemester(
+    String name, [
+    CancellationToken? cancellationToken,
+  ]) async => Semester(name, const <Module>[]);
+
+  @override
+  Future<void> logout([
+    CancellationToken? cancellationToken,
+  ]) async {}
+
+  @override
+  void clearCache() {}
 }
 
 class _FakePreferencesAccess extends PreferencesAccess {


### PR DESCRIPTION
## Summary

Fixes the fatal Dualis authentication-state failure reported as **DUALMATE-10 / Sentry issue 133984052**.

The Sentry stack reaches `FakeAccountDualisScraperDecorator` because every production Dualis scraper is wrapped by it. The following frames are `DualisScraper` and `DualisAuthentication`, showing that the failing request was routed to the real network scraper when `authenticatedGet()` accessed an uninitialized session. The event does not expose credentials or enough lifecycle state to prove that the user selected the demo account.

The confirmed structural problem was that schedule and grade workflows shared one mutable scraper, delegate, and authentication session, while semester and schedule loads span multiple requests. Another workflow could therefore alter routing or session state during an in-flight logical operation.

Sentry: https://fariszr.sentry.io/issues/133984052/

## Changes

- capture the active scraper once per high-level Dualis operation;
- keep all module/exam requests in a semester query on that captured session;
- apply the same protection to multi-month Dualis schedule queries;
- isolate schedule and grades behind separate scraper/session instances;
- replace unsafe `late` authentication lifecycle state with explicit validation;
- preserve the existing parallel grades/modules/semester refresh behavior;
- add deterministic coverage for a decorator-selection change during a multi-request query.

No global request serialization was added, and the v2.1.0 lazy rendering/deferred navigation paths are unchanged.

## Validation

- `flutter test` — **445 tests passed**
- `flutter analyze` — **no issues**
- focused session-routing and authentication lifecycle tests pass
- refresh concurrency test confirms all **3** Dualis branches still run concurrently

## Galaxy S21+ performance

Tested on the connected Galaxy S21+ (`SM-G996B`, `RFCR31468LJ`) using the v2.1.0 offline cold-navigation harness in profile mode. Baseline and final branch each used three fresh-process Dualis runs; all runs reached the populated final state and passed session restoration.

| Median metric | `v2` baseline | Fixed branch |
| --- | ---: | ---: |
| Frames over 8.33 ms | 4 | 4 |
| Frames over 8.33 ms | 5.19% | 5.19% |
| Frames over 16.67 ms | 1 | 1 |
| Frames over 33 ms | 0 | 0 |
| Consecutive missed frames | 2 | 2 |
| Combined p95 | 5.294 ms | 6.720 ms |
| Combined p99 | 14.309 ms | 13.743 ms |
| Worst frame | 19.181 ms | 21.623 ms |

The stable frame-budget indicators are unchanged. Percentile and worst-frame differences varied between repeated fixed batches and are consistent with device-run variance rather than a systematic regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session and authentication-state handling before login, during logout, and when restoring previous credentials.
  * Ensured multi-step data requests consistently use the same active account session, preventing mixed-account results during account switching.
  * Improved schedule and academic data retrieval reliability.

* **Tests**
  * Added coverage for unauthenticated requests, safe logout, credential restoration failures, session switching, and concurrent data refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->