### PR TITLE
Fix release notification initialization and settings loading

### DIFF
--- a/android/app/src/main/res/raw/keep.xml
+++ b/android/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/outline_event_note_24" />

--- a/lib/common/appstart/app_initializer.dart
+++ b/lib/common/appstart/app_initializer.dart
@@ -9,14 +9,19 @@ import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/appstart/localization_initialize.dart';
 import 'package:dualmate/common/appstart/notification_schedule_changed_initialize.dart';
 import 'package:dualmate/common/appstart/notifications_initialize.dart';
+import 'package:dualmate/common/appstart/notification_settings_state.dart';
 import 'package:dualmate/common/appstart/service_injector.dart';
+import 'package:dualmate/common/background/task_callback.dart';
+import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/features/local_calendar_feature.dart';
+import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/common/util/rapla_tls_override.dart';
 import 'package:dualmate/native/widget/widget_update_callback.dart';
 import 'package:dualmate/schedule/background/calendar_synchronizer.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
 import 'package:kiwi/kiwi.dart';
 import 'package:timezone/data/latest.dart' as tz;
 
@@ -50,6 +55,40 @@ Future<void> _reportNonFatalInitException(
     print(reportError);
     print(reportTrace);
   }
+}
+
+void _updateNotificationSettingsState(
+  NotificationSettingsState state, {
+  required Object? notificationInitializationError,
+  required Object? backgroundInitializationError,
+}) {
+  if (notificationInitializationError != null) {
+    state.markFailed(notificationInitializationError);
+    return;
+  }
+
+  final container = KiwiContainer();
+  final hasNotificationApi = container.isRegistered<NotificationApi>();
+  final hasScheduler = container.isRegistered<WorkSchedulerService>();
+  final hasNextDayTask = container.isRegistered<TaskCallback>(
+    name: NextDayInformationNotification.name,
+  );
+
+  if (!hasNotificationApi || !hasScheduler || !hasNextDayTask) {
+    state.markFailed(
+      backgroundInitializationError ??
+          StateError('Notification settings dependencies were not registered.'),
+    );
+    return;
+  }
+
+  final scheduler = container.resolve<WorkSchedulerService>();
+  if (!scheduler.isSchedulingAvailable()) {
+    state.markUnavailable();
+    return;
+  }
+
+  state.markReady();
 }
 
 Future<void> initializeAppBase(bool isBackground) async {
@@ -118,30 +157,41 @@ Future<void> initializeAppBackground(bool isBackground) async {
   widgetUpdateCallback.registerCanteenCallback(KiwiContainer().resolve());
   print("Background init: widgets ${stopwatch.elapsedMilliseconds}ms");
 
+  final notificationSettingsState = KiwiContainer()
+      .resolve<NotificationSettingsState>();
+  notificationSettingsState.markLoading();
+
+  Object? notificationInitializationError;
   final shouldRequestNotificationPermission =
       shouldAutoRequestNotificationPermissionAtStartup();
-  await NotificationsInitialize().setupNotifications(
-    requestRuntimePermission: shouldRequestNotificationPermission,
-  );
-  print("Background init: notifications ${stopwatch.elapsedMilliseconds}ms");
+  try {
+    await NotificationsInitialize().setupNotifications(
+      requestRuntimePermission: shouldRequestNotificationPermission,
+    );
+    print("Background init: notifications ${stopwatch.elapsedMilliseconds}ms");
+  } catch (error, trace) {
+    notificationInitializationError = error;
+    print("Background init: notifications failed (${error.runtimeType})");
+    print(error);
+    print(trace);
+    await _reportNonFatalInitException(
+      error,
+      trace,
+      message: 'Background init: notifications failed',
+      tags: {'feature': 'notifications'},
+      contexts: {
+        'notifications': {'phase': 'plugin.initialize'},
+      },
+    );
+  }
+
+  Object? backgroundInitializationError;
   try {
     await BackgroundInitialize().setupBackgroundScheduling();
     print("Background init: workmanager ${stopwatch.elapsedMilliseconds}ms");
-  } on Exception catch (exception, trace) {
-    print("Background init: workmanager failed (${exception.runtimeType})");
-    print(exception);
-    print(trace);
-    await _reportNonFatalInitException(
-      exception,
-      trace,
-      message: 'Background init: workmanager failed',
-      tags: {'feature': 'background'},
-      contexts: {
-        'background': {'phase': 'workmanager.setup'},
-      },
-    );
   } catch (error, trace) {
-    print("Background init: workmanager failed");
+    backgroundInitializationError = error;
+    print("Background init: workmanager failed (${error.runtimeType})");
     print(error);
     print(trace);
     await _reportNonFatalInitException(
@@ -155,37 +205,34 @@ Future<void> initializeAppBackground(bool isBackground) async {
     );
   }
 
-  try {
-    NotificationScheduleChangedInitialize().setupNotification();
-    print(
-      "Background init: schedule notify ${stopwatch.elapsedMilliseconds}ms",
-    );
-  } on Exception catch (exception, trace) {
-    print("Background init: schedule notify failed (${exception.runtimeType})");
-    print(exception);
-    print(trace);
-    await _reportNonFatalInitException(
-      exception,
-      trace,
-      message: 'Background init: schedule notify failed',
-      tags: {'feature': 'notifications'},
-      contexts: {
-        'notifications': {'phase': 'schedule_changed.setup'},
-      },
-    );
-  } catch (error, trace) {
-    print("Background init: schedule notify failed");
-    print(error);
-    print(trace);
-    await _reportNonFatalInitException(
-      error,
-      trace,
-      message: 'Background init: schedule notify failed',
-      tags: {'feature': 'notifications'},
-      contexts: {
-        'notifications': {'phase': 'schedule_changed.setup'},
-      },
-    );
+  _updateNotificationSettingsState(
+    notificationSettingsState,
+    notificationInitializationError: notificationInitializationError,
+    backgroundInitializationError: backgroundInitializationError,
+  );
+
+  if (notificationInitializationError == null) {
+    try {
+      NotificationScheduleChangedInitialize().setupNotification();
+      print(
+        "Background init: schedule notify ${stopwatch.elapsedMilliseconds}ms",
+      );
+    } catch (error, trace) {
+      print("Background init: schedule notify failed (${error.runtimeType})");
+      print(error);
+      print(trace);
+      await _reportNonFatalInitException(
+        error,
+        trace,
+        message: 'Background init: schedule notify failed',
+        tags: {'feature': 'notifications'},
+        contexts: {
+          'notifications': {'phase': 'schedule_changed.setup'},
+        },
+      );
+    }
+  } else {
+    print("Background init: schedule notify skipped");
   }
 
   tz.initializeTimeZones();

--- a/lib/common/appstart/app_initializer.dart
+++ b/lib/common/appstart/app_initializer.dart
@@ -67,6 +67,11 @@ void _updateNotificationSettingsState(
     return;
   }
 
+  if (backgroundInitializationError != null) {
+    state.markFailed(backgroundInitializationError);
+    return;
+  }
+
   final container = KiwiContainer();
   final hasNotificationApi = container.isRegistered<NotificationApi>();
   final hasScheduler = container.isRegistered<WorkSchedulerService>();
@@ -76,8 +81,7 @@ void _updateNotificationSettingsState(
 
   if (!hasNotificationApi || !hasScheduler || !hasNextDayTask) {
     state.markFailed(
-      backgroundInitializationError ??
-          StateError('Notification settings dependencies were not registered.'),
+      StateError('Notification settings dependencies were not registered.'),
     );
     return;
   }

--- a/lib/common/appstart/notification_settings_state.dart
+++ b/lib/common/appstart/notification_settings_state.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/foundation.dart';
+
+enum NotificationSettingsStatus { loading, ready, unavailable, failed }
+
+class NotificationSettingsState extends ChangeNotifier {
+  NotificationSettingsStatus _status;
+  Object? _error;
+
+  NotificationSettingsState({
+    NotificationSettingsStatus initialStatus =
+        NotificationSettingsStatus.loading,
+  }) : _status = initialStatus;
+
+  NotificationSettingsStatus get status => _status;
+  Object? get error => _error;
+  bool get isReady => _status == NotificationSettingsStatus.ready;
+
+  void markLoading() {
+    _setStatus(NotificationSettingsStatus.loading);
+  }
+
+  void markReady() {
+    _setStatus(NotificationSettingsStatus.ready);
+  }
+
+  void markUnavailable() {
+    _setStatus(NotificationSettingsStatus.unavailable);
+  }
+
+  void markFailed(Object error) {
+    _setStatus(NotificationSettingsStatus.failed, error: error);
+  }
+
+  void _setStatus(NotificationSettingsStatus status, {Object? error}) {
+    if (_status == status && identical(_error, error)) {
+      return;
+    }
+    _status = status;
+    _error = error;
+    notifyListeners();
+  }
+}

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -3,6 +3,7 @@ import 'package:dualmate/canteen/business/canteen_provider.dart';
 import 'package:dualmate/canteen/data/canteen_meal_repository.dart';
 import 'package:dualmate/canteen/service/canteen_scraper.dart';
 import 'package:dualmate/canteen/service/dhbw_app_canteen_source.dart';
+import 'package:dualmate/common/appstart/notification_settings_state.dart';
 import 'package:dualmate/common/data/database_access.dart';
 import 'package:dualmate/common/data/preferences/preferences_access.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
@@ -35,6 +36,7 @@ void injectServices(bool isBackground) {
   if (_isInjected) return;
 
   KiwiContainer c = KiwiContainer();
+  c.registerInstance(NotificationSettingsState());
   c.registerInstance(
     PreferencesProvider(PreferencesAccess(), SecureStorageAccess()),
   );

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -40,6 +40,10 @@ final de = {
   "notificationScheduleChangedClass": "%0 (%1) hat sich geändert.",
   "notificationScheduleChangedClassTitle": "Vorlesung geändert",
   "settingsNotificationsTitle": "Benachrichtigungen",
+  "settingsNotificationsLoading":
+      "Benachrichtigungseinstellungen werden geladen",
+  "settingsNotificationsUnavailable":
+      "Benachrichtigungseinstellungen sind nicht verfügbar",
   "settingsNotificationsNextDay": "Benachrichtigung am Abend",
   "settingsNotificationsScheduleChange":
       "Benachrichtigung bei einer Planänderung",

--- a/lib/common/i18n/localization_strings_en.dart
+++ b/lib/common/i18n/localization_strings_en.dart
@@ -34,6 +34,8 @@ final en = {
   "notificationScheduleChangedClass": "%0 (%1) changed",
   "notificationScheduleChangedClassTitle": "Class changed",
   "settingsNotificationsTitle": "Notifications",
+  "settingsNotificationsLoading": "Loading notification settings",
+  "settingsNotificationsUnavailable": "Notification settings are unavailable",
   "settingsNotificationsNextDay": "Notify in the evening",
   "settingsNotificationsScheduleChange": "Notify when the schedule changed",
   "screenScheduleTitle": "Schedule",

--- a/lib/common/i18n/localizations.dart
+++ b/lib/common/i18n/localizations.dart
@@ -109,6 +109,12 @@ class L {
   String get settingsNotificationsTitle =>
       _getValue("settingsNotificationsTitle");
 
+  String get settingsNotificationsLoading =>
+      _getValue("settingsNotificationsLoading");
+
+  String get settingsNotificationsUnavailable =>
+      _getValue("settingsNotificationsUnavailable");
+
   String get settingsNotificationsNextDay =>
       _getValue("settingsNotificationsNextDay");
 

--- a/lib/common/ui/widgets/title_list_tile.dart
+++ b/lib/common/ui/widgets/title_list_tile.dart
@@ -2,21 +2,26 @@ import 'package:flutter/material.dart';
 
 class TitleListTile extends StatelessWidget {
   final String title;
+  final Widget? trailing;
 
-  const TitleListTile({Key? key, required this.title}) : super(key: key);
+  const TitleListTile({Key? key, required this.title, this.trailing})
+    : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 24, 16, 4),
-          child: Text(
-            title,
-            style: Theme.of(context).textTheme.bodySmall ?? const TextStyle(),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 4),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              title,
+              style: Theme.of(context).textTheme.bodySmall ?? const TextStyle(),
+            ),
           ),
-        ),
-      ],
+          if (trailing != null) trailing!,
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:dualmate/canteen/business/canteen_location_service.dart';
 import 'package:dualmate/canteen/ui/widgets/select_canteen_location_dialog.dart';
 import 'package:dualmate/common/application_constants.dart';
+import 'package:dualmate/common/appstart/notification_settings_state.dart';
 import 'package:dualmate/common/background/task_callback.dart';
 import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/app_theme_enum.dart';
@@ -32,10 +33,44 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  late final _SettingsPageDependencies _dependencies =
-      _resolveSettingsPageDependencies();
+  late final NotificationSettingsState _notificationSettingsState;
+  late final SettingsViewModel settingsViewModel;
 
-  SettingsViewModel get settingsViewModel => _dependencies.settingsViewModel;
+  @override
+  void initState() {
+    super.initState();
+    _notificationSettingsState = _resolveNotificationSettingsState();
+    settingsViewModel = SettingsViewModel(
+      KiwiContainer().resolve(),
+      KiwiContainer().resolve(),
+      _resolveNextDayInformationNotificationOrNull(),
+      _resolveNotificationApiOrNull(),
+    );
+    _syncNotificationDependencies();
+    _notificationSettingsState.addListener(
+      _handleNotificationSettingsStateChanged,
+    );
+  }
+
+  void _handleNotificationSettingsStateChanged() {
+    _syncNotificationDependencies();
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void _syncNotificationDependencies() {
+    if (!_notificationSettingsState.isReady) return;
+
+    final nextDayTask = _resolveNextDayInformationNotificationOrNull();
+    final notificationApi = _resolveNotificationApiOrNull();
+    if (nextDayTask == null || notificationApi == null) return;
+
+    settingsViewModel.attachNotificationDependencies(
+      nextDayInformationNotification: nextDayTask,
+      notificationApi: notificationApi,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -256,54 +291,76 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   List<Widget> buildNotificationSettings(BuildContext context) {
-    final service = _dependencies.workSchedulerService;
-    if (service == null) {
-      return [];
+    final service = _resolveWorkSchedulerServiceOrNull();
+    final controlsReady =
+        _notificationSettingsState.isReady &&
+        settingsViewModel.notificationControlsReady &&
+        service?.isSchedulingAvailable() == true;
+
+    Widget? statusIndicator;
+    switch (_notificationSettingsState.status) {
+      case NotificationSettingsStatus.loading:
+        statusIndicator = Semantics(
+          label: L.of(context).settingsNotificationsLoading,
+          child: const SizedBox.square(
+            dimension: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        );
+      case NotificationSettingsStatus.failed:
+      case NotificationSettingsStatus.unavailable:
+        statusIndicator = Tooltip(
+          message: L.of(context).settingsNotificationsUnavailable,
+          child: const Icon(Icons.error_outline, size: 18),
+        );
+      case NotificationSettingsStatus.ready:
+        statusIndicator = null;
     }
 
-    if (_dependencies.canShowNotificationSettings &&
-        service.isSchedulingAvailable()) {
-      return [
-        TitleListTile(title: L.of(context).settingsNotificationsTitle),
-        PropertyChangeConsumer<SettingsViewModel, String>(
-          properties: const ["notifyAboutNextDay"],
-          builder:
-              (
-                BuildContext context,
-                SettingsViewModel? model,
-                Set<String>? properties,
-              ) {
-                if (model == null) return Container();
-                return SwitchListTile(
-                  title: Text(L.of(context).settingsNotificationsNextDay),
-                  onChanged: model.setNotifyAboutNextDay,
-                  value: model.notifyAboutNextDay,
-                );
-              },
-        ),
-        PropertyChangeConsumer<SettingsViewModel, String>(
-          properties: const ["notifyAboutScheduleChanges"],
-          builder:
-              (
-                BuildContext context,
-                SettingsViewModel? model,
-                Set<String>? properties,
-              ) {
-                if (model == null) return Container();
-                return SwitchListTile(
-                  title: Text(
-                    L.of(context).settingsNotificationsScheduleChange,
-                  ),
-                  onChanged: model.setNotifyAboutScheduleChanges,
-                  value: model.notifyAboutScheduleChanges,
-                );
-              },
-        ),
-        const Divider(),
-      ];
-    } else {
-      return [];
-    }
+    return [
+      TitleListTile(
+        title: L.of(context).settingsNotificationsTitle,
+        trailing: statusIndicator,
+      ),
+      PropertyChangeConsumer<SettingsViewModel, String>(
+        properties: const ["notifyAboutNextDay", "notificationControlsReady"],
+        builder:
+            (
+              BuildContext context,
+              SettingsViewModel? model,
+              Set<String>? properties,
+            ) {
+              if (model == null) return Container();
+              return SwitchListTile(
+                title: Text(L.of(context).settingsNotificationsNextDay),
+                onChanged: controlsReady ? model.setNotifyAboutNextDay : null,
+                value: model.notifyAboutNextDay,
+              );
+            },
+      ),
+      PropertyChangeConsumer<SettingsViewModel, String>(
+        properties: const [
+          "notifyAboutScheduleChanges",
+          "notificationControlsReady",
+        ],
+        builder:
+            (
+              BuildContext context,
+              SettingsViewModel? model,
+              Set<String>? properties,
+            ) {
+              if (model == null) return Container();
+              return SwitchListTile(
+                title: Text(L.of(context).settingsNotificationsScheduleChange),
+                onChanged: controlsReady
+                    ? model.setNotifyAboutScheduleChanges
+                    : null,
+                value: model.notifyAboutScheduleChanges,
+              );
+            },
+      ),
+      const Divider(),
+    ];
   }
 
   List<Widget> buildDesignSettings(BuildContext context) {
@@ -367,7 +424,9 @@ class _SettingsPageState extends State<SettingsPage> {
                     value: model.showPerformanceOverlay,
                   ),
                   ListTile(
-                    title: Text(L.of(context).settingsDeveloperReplayOnboarding),
+                    title: Text(
+                      L.of(context).settingsDeveloperReplayOnboarding,
+                    ),
                     onTap: () async {
                       final scheduleSourceProvider =
                           _resolveOptional<ScheduleSourceProvider>();
@@ -380,14 +439,13 @@ class _SettingsPageState extends State<SettingsPage> {
                       _resolveOptional<ScheduleProvider>()
                           ?.invalidateScheduleCache();
                       SchedulePage.resetSharedState();
-                      final preferencesProvider =
-                          KiwiContainer().resolve<PreferencesProvider>();
+                      final preferencesProvider = KiwiContainer()
+                          .resolve<PreferencesProvider>();
                       await preferencesProvider.setIsFirstStart(true);
                       if (!mounted) return;
-                      Navigator.of(context).pushNamedAndRemoveUntil(
-                        "onboarding",
-                        (route) => false,
-                      );
+                      Navigator.of(
+                        context,
+                      ).pushNamedAndRemoveUntil("onboarding", (route) => false);
                     },
                   ),
                 ],
@@ -400,29 +458,21 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   void dispose() {
+    _notificationSettingsState.removeListener(
+      _handleNotificationSettingsStateChanged,
+    );
     settingsViewModel.dispose();
     super.dispose();
   }
 }
 
-_SettingsPageDependencies _resolveSettingsPageDependencies() {
-  final notificationApi = _resolveNotificationApiOrNull();
-  final nextDayTask = _resolveNextDayInformationNotificationOrNull();
-  final workSchedulerService = _resolveWorkSchedulerServiceOrNull();
+NotificationSettingsState _resolveNotificationSettingsState() {
+  final existing = _resolveOptional<NotificationSettingsState>();
+  if (existing != null) return existing;
 
-  return _SettingsPageDependencies(
-    settingsViewModel: SettingsViewModel(
-      KiwiContainer().resolve(),
-      KiwiContainer().resolve(),
-      nextDayTask ?? _NoopTaskCallback(NextDayInformationNotification.name),
-      notificationApi ?? VoidNotificationApi(),
-    ),
-    workSchedulerService: workSchedulerService,
-    canShowNotificationSettings:
-        notificationApi != null &&
-        nextDayTask != null &&
-        workSchedulerService != null,
-  );
+  final state = NotificationSettingsState();
+  KiwiContainer().registerInstance(state);
+  return state;
 }
 
 TaskCallback? _resolveNextDayInformationNotificationOrNull() {
@@ -447,34 +497,4 @@ T? _resolveOptional<T>([String? name]) {
   } on NotRegisteredKiwiError {
     return null;
   }
-}
-
-class _SettingsPageDependencies {
-  final SettingsViewModel settingsViewModel;
-  final WorkSchedulerService? workSchedulerService;
-  final bool canShowNotificationSettings;
-
-  const _SettingsPageDependencies({
-    required this.settingsViewModel,
-    required this.workSchedulerService,
-    required this.canShowNotificationSettings,
-  });
-}
-
-class _NoopTaskCallback implements TaskCallback {
-  final String _name;
-
-  const _NoopTaskCallback(this._name);
-
-  @override
-  Future<void> cancel() async {}
-
-  @override
-  String getName() => _name;
-
-  @override
-  Future<void> run() async {}
-
-  @override
-  Future<void> schedule() async {}
 }

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -470,7 +470,18 @@ NotificationSettingsState _resolveNotificationSettingsState() {
   final existing = _resolveOptional<NotificationSettingsState>();
   if (existing != null) return existing;
 
-  final state = NotificationSettingsState();
+  final notificationApi = _resolveNotificationApiOrNull();
+  final nextDayTask = _resolveNextDayInformationNotificationOrNull();
+  final scheduler = _resolveWorkSchedulerServiceOrNull();
+
+  var initialStatus = NotificationSettingsStatus.loading;
+  if (notificationApi != null && nextDayTask != null && scheduler != null) {
+    initialStatus = scheduler.isSchedulingAvailable()
+        ? NotificationSettingsStatus.ready
+        : NotificationSettingsStatus.unavailable;
+  }
+
+  final state = NotificationSettingsState(initialStatus: initialStatus);
   KiwiContainer().registerInstance(state);
   return state;
 }

--- a/lib/ui/settings/viewmodels/settings_view_model.dart
+++ b/lib/ui/settings/viewmodels/settings_view_model.dart
@@ -16,8 +16,8 @@ class SettingsViewModel extends BaseViewModel {
 
   final PreferencesProvider _preferencesProvider;
   final CanteenLocationService _canteenLocationService;
-  final TaskCallback _nextDayInformationNotification;
-  final NotificationApi _notificationApi;
+  TaskCallback? _nextDayInformationNotification;
+  NotificationApi? _notificationApi;
 
   bool _notifyAboutNextDay = false;
 
@@ -26,6 +26,9 @@ class SettingsViewModel extends BaseViewModel {
   bool _notifyAboutScheduleChanges = false;
 
   bool get notifyAboutScheduleChanges => _notifyAboutScheduleChanges;
+
+  bool get notificationControlsReady =>
+      _nextDayInformationNotification != null && _notificationApi != null;
 
   bool _prettifySchedule = false;
 
@@ -55,6 +58,23 @@ class SettingsViewModel extends BaseViewModel {
     _loadPreferences();
   }
 
+  void attachNotificationDependencies({
+    required TaskCallback nextDayInformationNotification,
+    required NotificationApi notificationApi,
+  }) {
+    if (identical(
+          _nextDayInformationNotification,
+          nextDayInformationNotification,
+        ) &&
+        identical(_notificationApi, notificationApi)) {
+      return;
+    }
+
+    _nextDayInformationNotification = nextDayInformationNotification;
+    _notificationApi = notificationApi;
+    notifyIfMounted("notificationControlsReady");
+  }
+
   void incrementDeveloperTapCount() {
     if (_isDeveloperOptionsEnabled) return;
     _developerTapCount += 1;
@@ -65,8 +85,11 @@ class SettingsViewModel extends BaseViewModel {
   }
 
   Future<void> setNotifyAboutScheduleChanges(bool value) async {
+    final notificationApi = _notificationApi;
+    if (notificationApi == null) return;
+
     if (value) {
-      final granted = await _notificationApi.requestRuntimePermission();
+      final granted = await notificationApi.requestRuntimePermission();
       if (granted != true) {
         _notifyAboutScheduleChanges = false;
         notifyIfMounted("notifyAboutScheduleChanges");
@@ -91,13 +114,19 @@ class SettingsViewModel extends BaseViewModel {
   }
 
   Future<void> setNotifyAboutNextDay(bool value) async {
+    final notificationApi = _notificationApi;
+    final nextDayInformationNotification = _nextDayInformationNotification;
+    if (notificationApi == null || nextDayInformationNotification == null) {
+      return;
+    }
+
     if (value) {
-      final granted = await _notificationApi.requestRuntimePermission();
+      final granted = await notificationApi.requestRuntimePermission();
       if (granted != true) {
         _notifyAboutNextDay = false;
         notifyIfMounted("notifyAboutNextDay");
         await _preferencesProvider.setNotifyAboutNextDay(false);
-        await _nextDayInformationNotification.cancel();
+        await nextDayInformationNotification.cancel();
         return;
       }
     }
@@ -109,9 +138,9 @@ class SettingsViewModel extends BaseViewModel {
     await _preferencesProvider.setNotifyAboutNextDay(value);
 
     if (value)
-      await _nextDayInformationNotification.schedule();
+      await nextDayInformationNotification.schedule();
     else
-      await _nextDayInformationNotification.cancel();
+      await nextDayInformationNotification.cancel();
   }
 
   Future<void> setUseDhMineForDates(bool value) async {

--- a/test/common/appstart/notification_resource_keep_test.dart
+++ b/test/common/appstart/notification_resource_keep_test.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('release resource shrinking keeps the notification icon', () {
+    final keepFile = File('android/app/src/main/res/raw/keep.xml');
+
+    expect(keepFile.existsSync(), isTrue);
+    expect(
+      keepFile.readAsStringSync(),
+      contains('tools:keep="@drawable/outline_event_note_24"'),
+    );
+  });
+}

--- a/test/ui/settings/settings_page_lifecycle_test.dart
+++ b/test/ui/settings/settings_page_lifecycle_test.dart
@@ -1,7 +1,7 @@
 import 'package:dualmate/canteen/business/canteen_location_service.dart';
 import 'package:dualmate/common/application_constants.dart';
+import 'package:dualmate/common/appstart/notification_settings_state.dart';
 import 'package:dualmate/common/background/task_callback.dart';
-import 'package:dualmate/common/background/void_background_work_scheduler.dart';
 import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/app_theme_enum.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
@@ -27,13 +27,18 @@ void main() {
       CanteenLocationService(preferencesProvider),
     );
     KiwiContainer().registerInstance<WorkSchedulerService>(
-      VoidBackgroundWorkScheduler(),
+      _AvailableWorkScheduler(),
     );
     KiwiContainer().registerInstance<TaskCallback>(
       _FakeTaskCallback(),
       name: NextDayInformationNotification.name,
     );
     KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
+    KiwiContainer().registerInstance(
+      NotificationSettingsState(
+        initialStatus: NotificationSettingsStatus.ready,
+      ),
+    );
   });
 
   tearDown(() {
@@ -59,78 +64,138 @@ void main() {
     },
   );
 
-  testWidgets('settings page opens when next-day task is not registered', (
+  testWidgets(
+    'notification controls stay visible while next-day task is unavailable',
+    (tester) async {
+      KiwiContainer().clear();
+      final preferencesProvider = _FakePreferencesProvider();
+      KiwiContainer().registerInstance<PreferencesProvider>(
+        preferencesProvider,
+      );
+      KiwiContainer().registerInstance<CanteenLocationService>(
+        CanteenLocationService(preferencesProvider),
+      );
+      KiwiContainer().registerInstance<WorkSchedulerService>(
+        _AvailableWorkScheduler(),
+      );
+      KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
+      KiwiContainer().registerInstance(NotificationSettingsState());
+
+      final rootViewModel = RootViewModel(KiwiContainer().resolve());
+      await rootViewModel.loadFromPreferences();
+
+      await tester.pumpWidget(_wrapWithApp(rootViewModel, SettingsPage()));
+      await tester.pump();
+      await tester.scrollUntilVisible(
+        find.text('Notifications'),
+        300,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pump();
+
+      expect(find.text('Notifications'), findsOneWidget);
+      expect(find.text('Notify in the evening'), findsOneWidget);
+      expect(
+        tester
+            .widget<SwitchListTile>(
+              find.widgetWithText(SwitchListTile, 'Notify in the evening'),
+            )
+            .onChanged,
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'notification controls enable when deferred services become ready',
+    (tester) async {
+      KiwiContainer().clear();
+      final preferencesProvider = _FakePreferencesProvider();
+      final notificationState = NotificationSettingsState();
+      KiwiContainer().registerInstance<PreferencesProvider>(
+        preferencesProvider,
+      );
+      KiwiContainer().registerInstance<CanteenLocationService>(
+        CanteenLocationService(preferencesProvider),
+      );
+      KiwiContainer().registerInstance(notificationState);
+
+      final rootViewModel = RootViewModel(KiwiContainer().resolve());
+      await rootViewModel.loadFromPreferences();
+
+      await tester.pumpWidget(_wrapWithApp(rootViewModel, SettingsPage()));
+      await tester.pump();
+      await tester.scrollUntilVisible(
+        find.text('Notifications'),
+        300,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pump();
+
+      final loadingSwitch = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Notify in the evening'),
+      );
+      expect(loadingSwitch.onChanged, isNull);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      KiwiContainer().registerInstance<WorkSchedulerService>(
+        _AvailableWorkScheduler(),
+      );
+      KiwiContainer().registerInstance<TaskCallback>(
+        _FakeTaskCallback(),
+        name: NextDayInformationNotification.name,
+      );
+      KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
+      notificationState.markReady();
+      await tester.pump();
+
+      final readySwitch = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Notify in the evening'),
+      );
+      expect(readySwitch.onChanged, isNotNull);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('notification controls stay disabled when initialization fails', (
     tester,
   ) async {
     KiwiContainer().clear();
     final preferencesProvider = _FakePreferencesProvider();
+    final notificationState = NotificationSettingsState();
     KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
     KiwiContainer().registerInstance<CanteenLocationService>(
       CanteenLocationService(preferencesProvider),
     );
-    KiwiContainer().registerInstance<WorkSchedulerService>(
-      VoidBackgroundWorkScheduler(),
-    );
-    KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
+    KiwiContainer().registerInstance(notificationState);
 
     final rootViewModel = RootViewModel(KiwiContainer().resolve());
     await rootViewModel.loadFromPreferences();
 
     await tester.pumpWidget(_wrapWithApp(rootViewModel, SettingsPage()));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Settings'), findsOneWidget);
-    expect(find.text('Next day schedule'), findsNothing);
-    expect(tester.takeException(), isNull);
-  });
-
-  testWidgets('settings page opens before notification services are registered', (
-    tester,
-  ) async {
-    KiwiContainer().clear();
-    final preferencesProvider = _FakePreferencesProvider();
-    KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
-    KiwiContainer().registerInstance<CanteenLocationService>(
-      CanteenLocationService(preferencesProvider),
+    await tester.pump();
+    await tester.scrollUntilVisible(
+      find.text('Notifications'),
+      300,
+      scrollable: find.byType(Scrollable).first,
     );
+    await tester.pump();
 
-    final rootViewModel = RootViewModel(KiwiContainer().resolve());
-    await rootViewModel.loadFromPreferences();
+    notificationState.markFailed(StateError('notification init failed'));
+    await tester.pump();
 
-    await tester.pumpWidget(_wrapWithApp(rootViewModel, SettingsPage()));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Settings'), findsOneWidget);
-    expect(find.text('Next day schedule'), findsNothing);
-    expect(tester.takeException(), isNull);
-  });
-
-  testWidgets('settings page opens when next-day task resolve races startup', (
-    tester,
-  ) async {
-    KiwiContainer().clear();
-    final preferencesProvider = _FakePreferencesProvider();
-    KiwiContainer().registerInstance<PreferencesProvider>(preferencesProvider);
-    KiwiContainer().registerInstance<CanteenLocationService>(
-      CanteenLocationService(preferencesProvider),
+    expect(find.text('Notifications'), findsOneWidget);
+    expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    expect(
+      tester
+          .widget<SwitchListTile>(
+            find.widgetWithText(SwitchListTile, 'Notify in the evening'),
+          )
+          .onChanged,
+      isNull,
     );
-    KiwiContainer().registerInstance<WorkSchedulerService>(
-      VoidBackgroundWorkScheduler(),
-    );
-    KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
-    KiwiContainer().registerFactory<TaskCallback>(
-      (_) => throw NotRegisteredKiwiError('startup race'),
-      name: NextDayInformationNotification.name,
-    );
-
-    final rootViewModel = RootViewModel(KiwiContainer().resolve());
-    await rootViewModel.loadFromPreferences();
-
-    await tester.pumpWidget(_wrapWithApp(rootViewModel, SettingsPage()));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Settings'), findsOneWidget);
-    expect(find.text('Next day schedule'), findsNothing);
     expect(tester.takeException(), isNull);
   });
 
@@ -195,6 +260,41 @@ class _FakeTaskCallback implements TaskCallback {
 
   @override
   Future<void> schedule() async {}
+}
+
+class _AvailableWorkScheduler implements WorkSchedulerService {
+  @override
+  Future<void> cancelTask(String id) async {}
+
+  @override
+  Future<void> executeTask(String id) async {}
+
+  @override
+  bool isSchedulingAvailable() => true;
+
+  @override
+  void registerTask(TaskCallback task) {}
+
+  @override
+  Future<void> scheduleOneShotTaskAt(
+    DateTime date,
+    String id,
+    String name,
+  ) async {}
+
+  @override
+  Future<void> scheduleOneShotTaskIn(
+    Duration delay,
+    String id,
+    String name,
+  ) async {}
+
+  @override
+  Future<void> schedulePeriodic(
+    Duration delay,
+    String id, [
+    bool needsNetwork = false,
+  ]) async {}
 }
 
 class _FakePreferencesProvider implements PreferencesProvider {

--- a/test/ui/settings/settings_page_lifecycle_test.dart
+++ b/test/ui/settings/settings_page_lifecycle_test.dart
@@ -2,6 +2,7 @@ import 'package:dualmate/canteen/business/canteen_location_service.dart';
 import 'package:dualmate/common/application_constants.dart';
 import 'package:dualmate/common/appstart/notification_settings_state.dart';
 import 'package:dualmate/common/background/task_callback.dart';
+import 'package:dualmate/common/background/void_background_work_scheduler.dart';
 import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/common/data/preferences/app_theme_enum.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
@@ -76,10 +77,12 @@ void main() {
         CanteenLocationService(preferencesProvider),
       );
       KiwiContainer().registerInstance<WorkSchedulerService>(
-        _AvailableWorkScheduler(),
+        VoidBackgroundWorkScheduler(),
       );
       KiwiContainer().registerInstance<NotificationApi>(VoidNotificationApi());
-      KiwiContainer().registerInstance(NotificationSettingsState());
+      final notificationState = NotificationSettingsState();
+      notificationState.markUnavailable();
+      KiwiContainer().registerInstance(notificationState);
 
       final rootViewModel = RootViewModel(KiwiContainer().resolve());
       await rootViewModel.loadFromPreferences();


### PR DESCRIPTION
## Summary
- preserve the Android notification icon through release resource shrinking
- isolate notification startup failures so unrelated background workers still initialize
- keep notification controls visible while deferred initialization runs, then enable them live
- show a persistent unavailable state instead of silently removing the settings

## Verification
- `flutter analyze`
- `flutter test` — 470 tests passed
- `:app:testDebugUnitTest` — passed
- built and inspected a release APK; R8 reports `outline_event_note_24` retained by `keep.xml`
- installed the release APK side-by-side on a connected SM-G996B
- verified notification, WorkManager, and schedule-notification initialization complete without `invalid_icon`
- verified both notification switches are visible, enabled, and can be toggled off and on

Closes #106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification settings status feedback, including loading and unavailable states.
  * Notification controls remain disabled until required services are ready.
  * Notification preferences now become available automatically when background services finish initializing.
  * Added support for optional trailing content in settings list items.

* **Bug Fixes**
  * Improved startup resilience when notification services fail or are unavailable.
  * Preserved the notification icon during Android resource processing.
  * Added English and German translations for notification status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->