### PR TITLE
Add reliable class reminders

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".ExtApplication"
@@ -23,6 +24,19 @@
         android:enableOnBackInvokedCallback="true"
         android:localeConfig="@xml/locales_config"
         tools:replace="android:label">
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"
+            android:exported="false" />
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
         <receiver
 			android:name=".widget.now.ScheduleNowWidget"
             android:label="@string/widget_schedule_title"

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/MainActivity.kt
@@ -6,12 +6,16 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
 import android.util.Log
 
 class MainActivity : FlutterActivity() {
     private var pendingRoute: String? = null
     private var pendingPayload: Map<String, Any?>? = null
     private var navigationChannel: MethodChannel? = null
+    private var notificationSettingsChannel: MethodChannel? = null
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         GeneratedPluginRegistrant.registerWith(flutterEngine)
@@ -32,6 +36,20 @@ class MainActivity : FlutterActivity() {
                 "clearLaunchPayload" -> {
                     pendingPayload = null
                     result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        notificationSettingsChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.fariszr.dualmate/notification_settings"
+        )
+        notificationSettingsChannel?.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "openClassReminderNotificationSettings" -> {
+                    val channelId = call.argument<String>("channelId")
+                    result.success(openNotificationSettings(channelId))
                 }
                 else -> result.notImplemented()
             }
@@ -119,6 +137,28 @@ class MainActivity : FlutterActivity() {
             navigationChannel?.invokeMethod("openRoute", arguments)
         } else {
             navigationChannel?.invokeMethod("openRoute", route)
+        }
+    }
+
+    private fun openNotificationSettings(channelId: String?): Boolean {
+        return try {
+            val settingsIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                !channelId.isNullOrBlank()
+            ) {
+                Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+                    putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
+                }
+            } else {
+                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+                }
+            }
+            startActivity(settingsIntent)
+            true
+        } catch (error: Exception) {
+            Log.w("MainActivity", "Could not open notification settings", error)
+            false
         }
     }
 }

--- a/docs/plans/2026-07-18-feat-class-reminders-plan.md
+++ b/docs/plans/2026-07-18-feat-class-reminders-plan.md
@@ -1,0 +1,26 @@
+---
+title: Class reminder feature
+date: 2026-07-18
+status: implemented
+---
+
+# Class reminder feature
+
+## Architecture
+
+- Extract stable canonical class-name normalization from visual schedule prettification.
+- Persist recurring and one-time rules plus a scheduled-notification manifest in sqflite.
+- Reconcile only refreshed windows through one serialized, coalescing queue.
+- Schedule exact Android notifications with deterministic persisted identifiers.
+- Keep foreground refreshes non-blocking and drain reminder work in background refreshes.
+- Bulk-delete past occurrence data while retaining recurring class-name rules.
+- Preserve configuration and expose a paused state when notification or exact-alarm permission is unavailable.
+- Clear and cancel source-scoped reminders before an actual schedule-source change.
+
+## Delivery slices
+
+1. Canonical identity and deterministic IDs.
+2. Persistent rules, manifest, and bulk cleanup.
+3. Incremental coordinator, queue, exact scheduling, lifecycle, reboot, and telemetry integration.
+4. Material 3 configuration sheet, schedule indicators, permission banner, and source-change confirmation.
+5. Automated regression coverage plus Galaxy S21+ deployment and interaction verification.

--- a/docs/solutions/features/class-reminders-20260718.md
+++ b/docs/solutions/features/class-reminders-20260718.md
@@ -1,0 +1,20 @@
+---
+title: Reliable class reminders with incremental reconciliation
+date: 2026-07-18
+category: features
+tags:
+  - schedule
+  - reminders
+  - notifications
+  - android
+---
+
+# Reliable class reminders with incremental reconciliation
+
+Class reminders are stored separately from schedule rows so recurring rules survive cache replacement and one-time rules can reconnect to moved occurrences. Recurring identity uses `CanonicalClassName`, which applies the title-cleaning rules even when visual prettification is disabled.
+
+`ClassReminderController` enqueues refreshed in-memory windows after schedule persistence. `ReminderSyncQueue` serializes work, coalesces overlapping requests, and drops requests from an old source generation. `ClassReminderCoordinator` compares desired alarms with the local manifest and performs only changed schedules, cancellations, and batched manifest writes. Foreground refreshes only enqueue; background refreshes drain the queue before returning.
+
+Android alarms use `exactAllowWhileIdle`, deterministic IDs, a dedicated notification channel, and the plugin boot receiver. Notification taps reuse the schedule widget payload path to open the relevant week and class details.
+
+Permission loss cancels manifest-backed alarms without deleting rules. Permission restoration reconciles the upcoming 14-day window. Past one-time rules and manifest rows are bulk-deleted by class start time, while recurring rules remain until explicit removal or a confirmed source change.

--- a/docs/solutions/notifications/class-reminder-delivery-isolation-20260718.md
+++ b/docs/solutions/notifications/class-reminder-delivery-isolation-20260718.md
@@ -1,0 +1,32 @@
+---
+title: Isolating exact class reminders from schedule-change notifications
+date: 2026-07-18
+category: notifications
+tags:
+  - schedule
+  - reminders
+  - exact-alarms
+  - android
+  - regression-testing
+---
+
+# Isolating exact class reminders from schedule-change notifications
+
+An immediate notification headed "Weitere Vorlesung" is emitted by the existing
+background schedule-change flow when a refresh discovers an added class. It is
+not a timed class reminder and is intentionally independent of the class start
+time. A class reminder instead uses reminder-specific copy such as "Recht
+beginnt in 30 Minuten" and is scheduled for `classStart - offset`.
+
+Class reminders now reserve negative deterministic notification identifiers.
+The existing immediate-notification API uses non-negative random identifiers,
+so the two notification families cannot replace or cancel one another through
+an Android identifier collision. Reminder copy uses DualMate's saved language
+rather than the device locale, including singular German and English wording.
+
+Regression coverage verifies exact Android scheduling, the requested local
+trigger time, elapsed-trigger suppression, stable identity, queue serialization,
+canonical recurring matching, schedule-change notifications, and the evening
+next-day notification. A Galaxy S21+ profile build also delivered a dedicated
+`class_reminders` notification from an `RTC_WAKEUP` alarm with a zero window at
+the expected offset.

--- a/docs/solutions/notifications/class-reminder-reliability-hardening-20260718.md
+++ b/docs/solutions/notifications/class-reminder-reliability-hardening-20260718.md
@@ -1,0 +1,72 @@
+---
+title: Hardening class-reminder lifecycle, filtering, and Android permissions
+date: 2026-07-18
+category: notifications
+tags:
+  - schedule
+  - reminders
+  - permissions
+  - filters
+  - performance
+  - android
+---
+
+# Hardening class-reminder lifecycle, filtering, and Android permissions
+
+The first class-reminder implementation had several cross-layer reliability
+risks that were not visible in the core scheduling tests. A lifecycle callback
+could query reminder permissions before `NotificationApi` had been registered,
+temporarily treating an unavailable dependency as a permission denial. The
+schedule page then mounted and removed the paused banner during startup, which
+also changed the weekly schedule's widget structure while its initial refresh
+animation was running.
+
+Reminder permission state now remains unknown until the notification service is
+ready and all three required checks complete: application notification access,
+the dedicated `class_reminders` channel, and exact-alarm access. Unknown state
+never pauses reminders, cancels alarms, or renders muted reminder indicators.
+The schedule subtree remains mounted under a stable layout while only the notice
+height and opacity animate. Reminder actions remain disabled until controller
+initialization completes, and permission repair opens one Android settings
+surface at a time.
+
+Schedule filtering is treated as a presentation decision rather than evidence
+that Rapla removed an occurrence. Reminder reconciliation consumes the
+unfiltered schedule immediately after persistence, while the normal UI callback
+continues to receive the filtered schedule. When a user hides a class that has
+reminders, the filter page explicitly offers to keep the reminders or hide the
+class and remove them. Reminder-bearing rows show a bell so hidden reminder
+state is discoverable.
+
+One-time reminders now preserve ambiguous same-title moves instead of silently
+deleting the user's rule. Exact matches are preferred, followed by a unique
+same-time rename and then a unique nearest occurrence within a guarded window.
+An authoritative refresh with no plausible occurrence still removes the rule.
+Moved rules are persisted even when their notification time has already passed.
+
+Rapla source identity now excludes transient date and navigation parameters,
+normalizes scheme and host casing, and orders stable query parameters. Copying
+the same calendar URL while viewing another week therefore does not clear
+reminders. Notification navigation uses the actual schedule title rather than
+the canonical matching title, so detail resolution also works when visual
+prettification is disabled.
+
+For rendering performance, schedule cards no longer resolve the reminder
+controller or attach one listener per entry. The weekly entry layer owns one
+listener, uses indexed rule lookup, and passes the resolved reminder state into
+each card. Rule reloads notify only when effective reminder state changes, and
+foreground schedule refreshes only enqueue reminder reconciliation after the
+unfiltered schedule is persisted.
+
+# Verification
+
+- Full Flutter suite: 548 tests passed.
+- Android JVM/unit build: `:app:testDebugUnitTest` passed.
+- `flutter analyze` passed without issues.
+- Regression coverage includes startup dependency readiness, confirmed
+  permission denial, channel disablement, settings routing, unfiltered reminder
+  reconciliation, filter keep/remove/cancel behavior, ambiguous one-time moves,
+  stable Rapla source identity, notification title resolution, and one reminder
+  listener for a multi-entry weekly schedule.
+- Galaxy S21+ profile-mode verification covers cold launch, schedule refresh
+  animation, filter interaction, permission notice behavior, and frame timing.

--- a/docs/solutions/ui/class-reminder-permission-startup-flicker-20260718.md
+++ b/docs/solutions/ui/class-reminder-permission-startup-flicker-20260718.md
@@ -1,0 +1,30 @@
+---
+title: Preventing the class-reminder permission banner from flashing at startup
+date: 2026-07-18
+category: ui
+tags:
+  - schedule
+  - reminders
+  - permissions
+  - startup
+---
+
+# Preventing the class-reminder permission banner from flashing at startup
+
+The reminder controller previously represented both an unchecked permission
+state and a verified denial with `_permissionsGranted == false`. During startup,
+persisted reminder rules were loaded and listeners were notified before Android
+finished the notification and exact-alarm permission queries. The schedule page
+therefore rendered the paused banner briefly even when both permissions were
+already granted.
+
+The controller now tracks whether the permission result is known separately
+from whether it is granted. `remindersPaused` remains false while the two
+platform checks are pending and becomes true only after a verified denial or a
+permission-query failure. This preserves the persistent warning for genuinely
+missing permissions without exposing provisional startup state to the UI.
+
+The regression test holds both Android permission futures open after reminder
+rules load. It verifies that the warning never renders for eventually granted
+permissions and that either a notification-permission denial or an exact-alarm
+denial renders the warning once verification completes.

--- a/docs/solutions/ui/reminder-paused-notice-copy-20260718.md
+++ b/docs/solutions/ui/reminder-paused-notice-copy-20260718.md
@@ -1,0 +1,28 @@
+---
+title: Align the paused-reminder notice with the schedule banner
+date: 2026-07-18
+type: ui-fix
+---
+
+# Problem
+
+The paused-reminder notice used a custom horizontal warning layout. Its German
+title, explanation, and action competed for width and made the notice unusually
+tall and visually inconsistent with the existing missing-schedule-source
+notice. The recurring-reminder explanation was also unnecessarily long in
+German.
+
+# Solution
+
+- Reused `BannerWidget` for the paused-reminder state.
+- Added an optional semibold banner heading while preserving the existing
+  banner structure and styling.
+- Shortened the German permission and recurring-name-matching copy without
+  changing their meaning.
+- Added German widget coverage for both notices.
+
+# Verification
+
+- Focused reminder and schedule-page widget tests.
+- `flutter analyze`.
+- Galaxy S21+ profile-mode cold-start comparison.

--- a/lib/common/appstart/app_initializer.dart
+++ b/lib/common/appstart/app_initializer.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:dualmate/canteen/business/canteen_provider.dart';
 import 'package:dualmate/common/appstart/background_initialize.dart';
 import 'package:dualmate/common/appstart/performance_fixture_mode.dart';
+import 'package:dualmate/common/appstart/debug_startup_overrides.dart';
 import 'package:dualmate/common/appstart/performance_fixture_schedule_source.dart';
 import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/appstart/localization_initialize.dart';
@@ -111,6 +112,15 @@ Future<void> initializeAppBase(bool isBackground) async {
   print("Base init: services ${stopwatch.elapsedMilliseconds}ms");
 
   if (isPerformanceFixtureMode) {
+    // A fresh fixture installation has no persisted schedule source yet. Apply
+    // debug launch overrides before validating and replacing that source so
+    // device/profile runs can start deterministically on their first launch.
+    if (!isBackground) {
+      final overrides = DebugStartupOverrides.fromEnvironment();
+      if (overrides.isActive) {
+        await overrides.apply(KiwiContainer().resolve<PreferencesProvider>());
+      }
+    }
     final scheduleSourceProvider = KiwiContainer()
         .resolve<ScheduleSourceProvider>();
     final didConfigureScheduleSource = await scheduleSourceProvider

--- a/lib/common/appstart/app_initializer.dart
+++ b/lib/common/appstart/app_initializer.dart
@@ -22,6 +22,7 @@ import 'package:dualmate/schedule/background/calendar_synchronizer.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:kiwi/kiwi.dart';
 import 'package:timezone/data/latest.dart' as tz;
 
@@ -242,9 +243,21 @@ Future<void> initializeAppBackground(bool isBackground) async {
   tz.initializeTimeZones();
   print("Background init: time zones ${stopwatch.elapsedMilliseconds}ms");
 
+  try {
+    await KiwiContainer().resolve<ClassReminderController>().initialize();
+    print("Background init: reminders ${stopwatch.elapsedMilliseconds}ms");
+  } catch (error, trace) {
+    await _reportNonFatalInitException(
+      error,
+      trace,
+      message: 'Background init: class reminders failed',
+      tags: {'feature': 'class_reminders'},
+    );
+  }
+
   if (isBackground) {
     var setup = KiwiContainer().resolve<ScheduleSourceProvider>();
-    setup.setupScheduleSource();
+    await setup.setupScheduleSource();
     print(
       "Background init: schedule source ${stopwatch.elapsedMilliseconds}ms",
     );

--- a/lib/common/appstart/app_initializer.dart
+++ b/lib/common/appstart/app_initializer.dart
@@ -253,6 +253,14 @@ Future<void> initializeAppBackground(bool isBackground) async {
   tz.initializeTimeZones();
   print("Background init: time zones ${stopwatch.elapsedMilliseconds}ms");
 
+  if (isBackground) {
+    var setup = KiwiContainer().resolve<ScheduleSourceProvider>();
+    await setup.setupScheduleSource();
+    print(
+      "Background init: schedule source ${stopwatch.elapsedMilliseconds}ms",
+    );
+  }
+
   try {
     await KiwiContainer().resolve<ClassReminderController>().initialize();
     print("Background init: reminders ${stopwatch.elapsedMilliseconds}ms");
@@ -262,14 +270,6 @@ Future<void> initializeAppBackground(bool isBackground) async {
       trace,
       message: 'Background init: class reminders failed',
       tags: {'feature': 'class_reminders'},
-    );
-  }
-
-  if (isBackground) {
-    var setup = KiwiContainer().resolve<ScheduleSourceProvider>();
-    await setup.setupScheduleSource();
-    print(
-      "Background init: schedule source ${stopwatch.elapsedMilliseconds}ms",
     );
   }
 

--- a/lib/common/appstart/background_initialize.dart
+++ b/lib/common/appstart/background_initialize.dart
@@ -7,6 +7,7 @@ import 'package:dualmate/common/background/void_background_work_scheduler.dart';
 import 'package:dualmate/common/background/work_scheduler_service.dart';
 import 'package:dualmate/schedule/background/background_schedule_update.dart';
 import 'package:dualmate/schedule/ui/notification/next_day_information_notification.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:kiwi/kiwi.dart';
 
 ///
@@ -41,6 +42,7 @@ class BackgroundInitialize {
         KiwiContainer().resolve(),
         KiwiContainer().resolve(),
         KiwiContainer().resolve(),
+        reminderController: KiwiContainer().resolve<ClassReminderController>(),
       ),
       NextDayInformationNotification(
         KiwiContainer().resolve(),

--- a/lib/common/appstart/background_initialize.dart
+++ b/lib/common/appstart/background_initialize.dart
@@ -30,31 +30,32 @@ class BackgroundInitialize {
       scheduler = VoidBackgroundWorkScheduler();
     }
 
-    KiwiContainer().registerInstance<WorkSchedulerService>(scheduler);
+    final container = KiwiContainer();
+    container.registerInstance<WorkSchedulerService>(scheduler);
+    final reminderController = container.isRegistered<ClassReminderController>()
+        ? container.resolve<ClassReminderController>()
+        : null;
 
     var tasks = [
-      BackgroundCanteenUpdate(
-        KiwiContainer().resolve(),
-        KiwiContainer().resolve(),
-      ),
+      BackgroundCanteenUpdate(container.resolve(), container.resolve()),
       BackgroundScheduleUpdate(
-        KiwiContainer().resolve(),
-        KiwiContainer().resolve(),
-        KiwiContainer().resolve(),
-        KiwiContainer().resolve(),
-        reminderController: KiwiContainer().resolve<ClassReminderController>(),
+        container.resolve(),
+        container.resolve(),
+        container.resolve(),
+        container.resolve(),
+        reminderController: reminderController,
       ),
       NextDayInformationNotification(
-        KiwiContainer().resolve(),
-        KiwiContainer().resolve(),
-        KiwiContainer().resolve(),
-        KiwiContainer().resolve(),
+        container.resolve(),
+        container.resolve(),
+        container.resolve(),
+        container.resolve(),
       ),
     ];
 
     for (var task in tasks) {
       scheduler.registerTask(task);
-      KiwiContainer().registerInstance(task, name: task.getName());
+      container.registerInstance(task, name: task.getName());
     }
 
     for (var task in tasks) {

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -70,7 +70,11 @@ void injectServices(bool isBackground) {
   );
   c.registerInstance(ClassReminderRepository(c.resolve()));
   c.registerInstance<ClassReminderScheduler>(
-    PlatformClassReminderScheduler(() => c.resolve<NotificationApi>()),
+    PlatformClassReminderScheduler(
+      () => c.resolve<NotificationApi>(),
+      languageCode: () =>
+          c.resolve<PreferencesProvider>().getLastUsedLanguageCode(),
+    ),
   );
   c.registerInstance(
     ClassReminderController(

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -82,7 +82,9 @@ void injectServices(bool isBackground) {
       scheduleProvider: c.resolve(),
       sourceProvider: c.resolve(),
       scheduler: c.resolve<ClassReminderScheduler>(),
-      notificationApi: () => c.resolve<NotificationApi>(),
+      notificationApi: () => c.isRegistered<NotificationApi>()
+          ? c.resolve<NotificationApi>()
+          : null,
     ),
   );
   c.registerInstance<DualisScraper>(

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -24,6 +24,11 @@ import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
 import 'package:dualmate/schedule/data/schedule_query_information_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+import 'package:dualmate/schedule/reminders/platform_class_reminder_scheduler.dart';
+import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:kiwi/kiwi.dart';
 
 bool _isInjected = false;
@@ -61,6 +66,19 @@ void injectServices(bool isBackground) {
       c.resolve(),
       c.resolve(),
       c.resolve(),
+    ),
+  );
+  c.registerInstance(ClassReminderRepository(c.resolve()));
+  c.registerInstance<ClassReminderScheduler>(
+    PlatformClassReminderScheduler(() => c.resolve<NotificationApi>()),
+  );
+  c.registerInstance(
+    ClassReminderController(
+      repository: c.resolve(),
+      scheduleProvider: c.resolve(),
+      sourceProvider: c.resolve(),
+      scheduler: c.resolve<ClassReminderScheduler>(),
+      notificationApi: () => c.resolve<NotificationApi>(),
     ),
   );
   c.registerInstance<DualisScraper>(

--- a/lib/common/data/database_access.dart
+++ b/lib/common/data/database_access.dart
@@ -171,4 +171,11 @@ class DatabaseAccess {
     Database db = await _database;
     return await db.delete(table, where: where, whereArgs: whereArgs);
   }
+
+  Future<T> transaction<T>(
+    Future<T> Function(DatabaseExecutor executor) action,
+  ) async {
+    final db = await _database;
+    return db.transaction(action);
+  }
 }

--- a/lib/common/data/database_access.dart
+++ b/lib/common/data/database_access.dart
@@ -73,6 +73,20 @@ class DatabaseAccess {
     await batch.commit(noResult: true);
   }
 
+  Future<void> insertOrReplaceBatch(
+    String table,
+    List<Map<String, dynamic>> rows,
+  ) async {
+    if (rows.isEmpty) return;
+
+    final db = await _database;
+    final batch = db.batch();
+    for (final row in rows) {
+      batch.insert(table, row, conflictAlgorithm: ConflictAlgorithm.replace);
+    }
+    await batch.commit(noResult: true);
+  }
+
   Future<List<Map<String, dynamic>>> queryAllRows(String table) async {
     Database db = await _database;
     return await db.query(table);

--- a/lib/common/data/sql_scripts.dart
+++ b/lib/common/data/sql_scripts.dart
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS ScheduleQueryInformation
   queryTime INTEGER,
   PRIMARY KEY (start, end)
 );
-'''
+''',
     ],
 
     // Version 2 - Add DateEntries table
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS DateEntries
   year TEXT,
   databaseName TEXT
 );
-'''
+''',
     ],
 
     // Version 3 - Add Schedule Entry filter table
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS ScheduleEntryFilters
 (
   title TEXT
 );
-'''
+''',
     ],
 
     // Version 4 - Add Canteen meals table
@@ -66,7 +66,44 @@ CREATE TABLE IF NOT EXISTS canteen_meals
   notes TEXT,
   meal_types TEXT
 );
-'''
+''',
+    ],
+
+    // Version 5 - Class reminder rules and scheduled-notification manifest
+    [
+      '''
+CREATE TABLE IF NOT EXISTS ClassReminderRules
+(
+  id TEXT PRIMARY KEY,
+  scope INTEGER NOT NULL,
+  canonicalTitle TEXT NOT NULL,
+  offsetMinutes INTEGER NOT NULL,
+  sourceIdentity TEXT NOT NULL,
+  occurrenceStart INTEGER,
+  occurrenceEnd INTEGER
+);
+''',
+      '''
+CREATE INDEX IF NOT EXISTS idx_class_reminder_rules_source_occurrence
+ON ClassReminderRules(sourceIdentity, scope, occurrenceStart);
+''',
+      '''
+CREATE TABLE IF NOT EXISTS ScheduledClassNotifications
+(
+  ruleId TEXT NOT NULL,
+  occurrenceIdentity TEXT NOT NULL,
+  sourceIdentity TEXT NOT NULL,
+  notificationId INTEGER NOT NULL,
+  scheduledTime INTEGER NOT NULL,
+  classStart INTEGER NOT NULL,
+  contentFingerprint TEXT NOT NULL,
+  PRIMARY KEY (ruleId, occurrenceIdentity)
+);
+''',
+      '''
+CREATE INDEX IF NOT EXISTS idx_scheduled_class_notifications_window
+ON ScheduledClassNotifications(sourceIdentity, classStart);
+''',
     ],
   ];
 }

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -238,6 +238,11 @@ final de = {
   "filterTitle": "Filter",
   "filterSaveError": "Filter konnten nicht gespeichert werden",
   "filterLoadError": "Filter konnten nicht geladen werden",
+  "filterReminderHideTitle": "{className} ausblenden?",
+  "filterReminderHideMessage":
+      "Für diese Vorlesung sind Erinnerungen aktiv. Sollen sie erhalten oder beim Ausblenden entfernt werden?",
+  "filterReminderKeep": "Erinnerungen behalten",
+  "filterReminderRemove": "Ausblenden und Erinnerungen entfernen",
   "canteenFilterAll": "Alle Gerichte",
   "canteenFilterNoPork": "Ohne Schwein",
   "canteenFilterVegetarian": "Vegetarisch",

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -178,11 +178,41 @@ final de = {
   "widgetHelpDialogMessage":
       "Platziere ein Widget auf deinen Startbildschirm um einen schnellen Blick auf deinen täglichen Vorlesungsplan zu bekommen.",
   "widgetHelpDialogTitle": "Schon gewusst?",
-  "exactAlarmPermissionTitle": "Genaue Alarme erlauben",
+  "exactAlarmPermissionTitle": "Zuverlässige Erinnerungen und Widgets erlauben",
   "exactAlarmPermissionMessage":
-      "Damit die Vorlesungs-Widgets aktuell bleiben, erlaube bitte genaue Alarme für diese App.",
+      "Damit Klassenerinnerungen und Stundenplan-Widgets pünktlich funktionieren, erlaube genaue Alarme für DualMate.",
   "exactAlarmPermissionAllow": "Erlauben",
   "exactAlarmPermissionLater": "Später",
+  "classReminderTooltipAdd": "Erinnerung hinzufügen",
+  "classReminderTooltipEdit": "Erinnerung bearbeiten",
+  "classReminderSheetTitle": "Klassenerinnerung",
+  "classReminderFiveMinutes": "5 Minuten vorher",
+  "classReminderFifteenMinutes": "15 Minuten vorher",
+  "classReminderThirtyMinutes": "30 Minuten vorher",
+  "classReminderOneHour": "1 Stunde vorher",
+  "classReminderCustom": "Benutzerdefiniert",
+  "classReminderCustomMinutes": "Minuten vorher",
+  "classReminderThisOccurrence": "Dieser Termin",
+  "classReminderEveryOccurrence": "Jeder Termin",
+  "classReminderMatchingTitle": "Abgleich nach Klassenname",
+  "classReminderMatchingDescription":
+      "DualMate wendet diese Erinnerung auf zukünftige Klassen mit demselben angezeigten Klassennamen an. Wenn sich der Klassenname ändert, gilt die Erinnerung nicht mehr.",
+  "classReminderSave": "Erinnerung speichern",
+  "classReminderRemove": "Erinnerung entfernen",
+  "classReminderPermissionTitle": "Zuverlässige Erinnerungen aktivieren",
+  "classReminderPermissionMessage":
+      "DualMate benötigt die Benachrichtigungs- und die Berechtigung für genaue Alarme, um Klassenerinnerungen pünktlich zuzustellen.",
+  "classReminderPermissionCancel": "Abbrechen",
+  "classReminderPermissionOpenSettings": "Einstellungen öffnen",
+  "classReminderPausedTitle": "Klassenerinnerungen sind pausiert",
+  "classReminderPausedMessage":
+      "DualMate kann Erinnerungen nicht zuverlässig zustellen, weil eine erforderliche Berechtigung deaktiviert ist.",
+  "classReminderFixPermissions": "Berechtigungen korrigieren",
+  "classReminderSourceChangeTitle": "Stundenplanquelle ändern?",
+  "classReminderSourceChangeMessage":
+      "Wenn du deinen Stundenplan änderst, werden alle mit dem aktuellen Stundenplan verknüpften Klassenerinnerungen entfernt.",
+  "classReminderSourceChangeCancel": "Abbrechen",
+  "classReminderSourceChangeConfirm": "Ändern und Erinnerungen entfernen",
   "donateButtonTitle": "Spendiere dem Entwickler einen Kaffee",
   "donateButtonSubtitle": "Hier kannst du die Entwicklung der App unterstützen",
   "donateDialogMessage":

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -194,9 +194,9 @@ final de = {
   "classReminderCustomMinutes": "Minuten vorher",
   "classReminderThisOccurrence": "Dieser Termin",
   "classReminderEveryOccurrence": "Jeder Termin",
-  "classReminderMatchingTitle": "Abgleich nach Klassenname",
+  "classReminderMatchingTitle": "Abgleich nach Kursname",
   "classReminderMatchingDescription":
-      "DualMate wendet diese Erinnerung auf zukünftige Klassen mit demselben angezeigten Klassennamen an. Wenn sich der Klassenname ändert, gilt die Erinnerung nicht mehr.",
+      "Gilt für künftige Termine mit demselben Kursnamen. Wird er geändert, greift die Erinnerung nicht mehr.",
   "classReminderSave": "Erinnerung speichern",
   "classReminderRemove": "Erinnerung entfernen",
   "classReminderPermissionTitle": "Zuverlässige Erinnerungen aktivieren",
@@ -204,10 +204,10 @@ final de = {
       "DualMate benötigt die Benachrichtigungsberechtigung und die Berechtigung für genaue Alarme, um Klassenerinnerungen pünktlich zuzustellen.",
   "classReminderPermissionCancel": "Abbrechen",
   "classReminderPermissionOpenSettings": "Einstellungen öffnen",
-  "classReminderPausedTitle": "Klassenerinnerungen sind pausiert",
+  "classReminderPausedTitle": "Klassenerinnerungen pausiert",
   "classReminderPausedMessage":
-      "DualMate kann Erinnerungen nicht zuverlässig zustellen, weil eine erforderliche Berechtigung deaktiviert ist.",
-  "classReminderFixPermissions": "Berechtigungen korrigieren",
+      "Aktiviere Benachrichtigungen und genaue Alarme, damit sie wieder funktionieren.",
+  "classReminderFixPermissions": "Berechtigungen prüfen",
   "classReminderSourceChangeTitle": "Stundenplanquelle ändern?",
   "classReminderSourceChangeMessage":
       "Wenn du deinen Stundenplan änderst, werden alle mit dem aktuellen Stundenplan verknüpften Klassenerinnerungen entfernt.",

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -201,7 +201,7 @@ final de = {
   "classReminderRemove": "Erinnerung entfernen",
   "classReminderPermissionTitle": "Zuverlässige Erinnerungen aktivieren",
   "classReminderPermissionMessage":
-      "DualMate benötigt die Benachrichtigungs- und die Berechtigung für genaue Alarme, um Klassenerinnerungen pünktlich zuzustellen.",
+      "DualMate benötigt die Benachrichtigungsberechtigung und die Berechtigung für genaue Alarme, um Klassenerinnerungen pünktlich zuzustellen.",
   "classReminderPermissionCancel": "Abbrechen",
   "classReminderPermissionOpenSettings": "Einstellungen öffnen",
   "classReminderPausedTitle": "Klassenerinnerungen sind pausiert",

--- a/lib/common/i18n/localization_strings_en.dart
+++ b/lib/common/i18n/localization_strings_en.dart
@@ -227,6 +227,11 @@ final en = {
   "filterTitle": "Filter",
   "filterSaveError": "Could not save filters",
   "filterLoadError": "Could not load filters",
+  "filterReminderHideTitle": "Hide {className}?",
+  "filterReminderHideMessage":
+      "This class has active reminders. Keep them, or remove them when hiding the class?",
+  "filterReminderKeep": "Keep reminders",
+  "filterReminderRemove": "Hide and remove reminders",
   "canteenFilterAll": "All meals",
   "canteenFilterNoPork": "Without pork",
   "canteenFilterVegetarian": "Vegetarian",

--- a/lib/common/i18n/localization_strings_en.dart
+++ b/lib/common/i18n/localization_strings_en.dart
@@ -167,11 +167,41 @@ final en = {
   "widgetHelpDialogMessage":
       "Place a widget on your home screen to get a quick view on your daily schedule.",
   "widgetHelpDialogTitle": "Did you know?",
-  "exactAlarmPermissionTitle": "Allow exact alarms",
+  "exactAlarmPermissionTitle": "Allow reliable reminders and widgets",
   "exactAlarmPermissionMessage":
-      "To keep the schedule widgets up to date, please allow exact alarms for this app.",
+      "To keep class reminders and schedule widgets working on time, allow exact alarms for DualMate.",
   "exactAlarmPermissionAllow": "Allow",
   "exactAlarmPermissionLater": "Later",
+  "classReminderTooltipAdd": "Add reminder",
+  "classReminderTooltipEdit": "Edit reminder",
+  "classReminderSheetTitle": "Class reminder",
+  "classReminderFiveMinutes": "5 minutes before",
+  "classReminderFifteenMinutes": "15 minutes before",
+  "classReminderThirtyMinutes": "30 minutes before",
+  "classReminderOneHour": "1 hour before",
+  "classReminderCustom": "Custom",
+  "classReminderCustomMinutes": "Minutes before",
+  "classReminderThisOccurrence": "This occurrence",
+  "classReminderEveryOccurrence": "Every occurrence",
+  "classReminderMatchingTitle": "Matches by class name",
+  "classReminderMatchingDescription":
+      "DualMate applies this reminder to future classes with the same displayed class name. If the class name changes, the reminder will no longer apply.",
+  "classReminderSave": "Save reminder",
+  "classReminderRemove": "Remove reminder",
+  "classReminderPermissionTitle": "Enable reliable reminders",
+  "classReminderPermissionMessage":
+      "DualMate needs notification and exact-alarm permission to deliver class reminders on time.",
+  "classReminderPermissionCancel": "Cancel",
+  "classReminderPermissionOpenSettings": "Open settings",
+  "classReminderPausedTitle": "Class reminders are paused",
+  "classReminderPausedMessage":
+      "DualMate cannot deliver reminders reliably because a required permission is disabled.",
+  "classReminderFixPermissions": "Fix permissions",
+  "classReminderSourceChangeTitle": "Change schedule source?",
+  "classReminderSourceChangeMessage":
+      "Changing your schedule will remove all class reminders linked to the current schedule.",
+  "classReminderSourceChangeCancel": "Cancel",
+  "classReminderSourceChangeConfirm": "Change and remove reminders",
   "donateButtonTitle": "Give the developer a cup of coffee",
   "donateButtonSubtitle": "Here you can support the development of the app",
   "donateDialogMessage":

--- a/lib/common/i18n/localizations.dart
+++ b/lib/common/i18n/localizations.dart
@@ -495,6 +495,11 @@ class L {
   String get filterSaveError => _getValue("filterSaveError");
 
   String get filterLoadError => _getValue("filterLoadError");
+  String get filterReminderHideTitle => _getValue("filterReminderHideTitle");
+  String get filterReminderHideMessage =>
+      _getValue("filterReminderHideMessage");
+  String get filterReminderKeep => _getValue("filterReminderKeep");
+  String get filterReminderRemove => _getValue("filterReminderRemove");
 
   String get canteenFilterAll => _getValue("canteenFilterAll");
   String get canteenFilterNoPork => _getValue("canteenFilterNoPork");

--- a/lib/common/i18n/localizations.dart
+++ b/lib/common/i18n/localizations.dart
@@ -406,6 +406,50 @@ class L {
   String get exactAlarmPermissionLater =>
       _getValue("exactAlarmPermissionLater");
 
+  String get classReminderTooltipAdd => _getValue("classReminderTooltipAdd");
+  String get classReminderTooltipEdit => _getValue("classReminderTooltipEdit");
+  String get classReminderSheetTitle => _getValue("classReminderSheetTitle");
+  String get classReminderFiveMinutes => _getValue("classReminderFiveMinutes");
+  String get classReminderFifteenMinutes =>
+      _getValue("classReminderFifteenMinutes");
+  String get classReminderThirtyMinutes =>
+      _getValue("classReminderThirtyMinutes");
+  String get classReminderOneHour => _getValue("classReminderOneHour");
+  String get classReminderCustom => _getValue("classReminderCustom");
+  String get classReminderCustomMinutes =>
+      _getValue("classReminderCustomMinutes");
+  String get classReminderThisOccurrence =>
+      _getValue("classReminderThisOccurrence");
+  String get classReminderEveryOccurrence =>
+      _getValue("classReminderEveryOccurrence");
+  String get classReminderMatchingTitle =>
+      _getValue("classReminderMatchingTitle");
+  String get classReminderMatchingDescription =>
+      _getValue("classReminderMatchingDescription");
+  String get classReminderSave => _getValue("classReminderSave");
+  String get classReminderRemove => _getValue("classReminderRemove");
+  String get classReminderPermissionTitle =>
+      _getValue("classReminderPermissionTitle");
+  String get classReminderPermissionMessage =>
+      _getValue("classReminderPermissionMessage");
+  String get classReminderPermissionCancel =>
+      _getValue("classReminderPermissionCancel");
+  String get classReminderPermissionOpenSettings =>
+      _getValue("classReminderPermissionOpenSettings");
+  String get classReminderPausedTitle => _getValue("classReminderPausedTitle");
+  String get classReminderPausedMessage =>
+      _getValue("classReminderPausedMessage");
+  String get classReminderFixPermissions =>
+      _getValue("classReminderFixPermissions");
+  String get classReminderSourceChangeTitle =>
+      _getValue("classReminderSourceChangeTitle");
+  String get classReminderSourceChangeMessage =>
+      _getValue("classReminderSourceChangeMessage");
+  String get classReminderSourceChangeCancel =>
+      _getValue("classReminderSourceChangeCancel");
+  String get classReminderSourceChangeConfirm =>
+      _getValue("classReminderSourceChangeConfirm");
+
   String get donateButtonTitle => _getValue("donateButtonTitle");
 
   String get donateButtonSubtitle => _getValue("donateButtonSubtitle");

--- a/lib/common/ui/notification_api.dart
+++ b/lib/common/ui/notification_api.dart
@@ -8,6 +8,7 @@ import 'package:dualmate/common/util/widget_navigation_payload.dart';
 import 'package:dualmate/ui/navigation/main_section_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter/services.dart';
 import 'package:timezone/timezone.dart' as tz;
 
 ///
@@ -23,20 +24,38 @@ typedef NotificationPluginInitializer =
 typedef NotificationRuntimePermissionRequester =
     Future<bool?> Function(FlutterLocalNotificationsPlugin plugin);
 
+typedef NotificationChannelEnabledChecker =
+    Future<bool> Function(FlutterLocalNotificationsPlugin plugin);
+
+typedef NotificationChannelSettingsOpener = Future<bool> Function();
+
 class NotificationApi {
+  static const String classReminderChannelId = 'class_reminders';
+  static const MethodChannel _settingsChannel = MethodChannel(
+    'com.fariszr.dualmate/notification_settings',
+  );
+
   final FlutterLocalNotificationsPlugin _localNotificationsPlugin;
   final NotificationPluginInitializer _pluginInitializer;
   final NotificationRuntimePermissionRequester _runtimePermissionRequester;
+  final NotificationChannelEnabledChecker _classReminderChannelChecker;
+  final NotificationChannelSettingsOpener _classReminderSettingsOpener;
 
   NotificationApi({
     FlutterLocalNotificationsPlugin? localNotificationsPlugin,
     NotificationPluginInitializer? pluginInitializer,
     NotificationRuntimePermissionRequester? runtimePermissionRequester,
+    NotificationChannelEnabledChecker? classReminderChannelChecker,
+    NotificationChannelSettingsOpener? classReminderSettingsOpener,
   }) : _localNotificationsPlugin =
            localNotificationsPlugin ?? FlutterLocalNotificationsPlugin(),
        _pluginInitializer = pluginInitializer ?? _defaultPluginInitializer,
        _runtimePermissionRequester =
-           runtimePermissionRequester ?? _defaultRuntimePermissionRequester;
+           runtimePermissionRequester ?? _defaultRuntimePermissionRequester,
+       _classReminderChannelChecker =
+           classReminderChannelChecker ?? _defaultClassReminderChannelChecker,
+       _classReminderSettingsOpener =
+           classReminderSettingsOpener ?? _defaultClassReminderSettingsOpener;
 
   ///
   /// Initialize the notifications. You can't show any notifications before you
@@ -122,6 +141,30 @@ class NotificationApi {
     return androidPlugin?.requestNotificationsPermission();
   }
 
+  static Future<bool> _defaultClassReminderChannelChecker(
+    FlutterLocalNotificationsPlugin plugin,
+  ) async {
+    final androidPlugin = plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    final channels = await androidPlugin?.getNotificationChannels();
+    if (channels == null) return false;
+    final matching = channels.where(
+      (channel) => channel.id == classReminderChannelId,
+    );
+    if (matching.isEmpty) return true;
+    return matching.first.importance != Importance.none;
+  }
+
+  static Future<bool> _defaultClassReminderSettingsOpener() async {
+    return await _settingsChannel.invokeMethod<bool>(
+          'openClassReminderNotificationSettings',
+          {'channelId': classReminderChannelId},
+        ) ??
+        false;
+  }
+
   ///
   /// Show a notification with the given title and message
   ///
@@ -167,6 +210,20 @@ class NotificationApi {
     return await androidPlugin?.areNotificationsEnabled() ?? false;
   }
 
+  Future<bool> areClassRemindersEnabled() {
+    return _classReminderChannelChecker(_localNotificationsPlugin);
+  }
+
+  Future<bool> openClassReminderSettings() async {
+    try {
+      return await _classReminderSettingsOpener();
+    } on PlatformException {
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
   Future<bool> canScheduleExactNotifications() async {
     final androidPlugin = _localNotificationsPlugin
         .resolvePlatformSpecificImplementation<
@@ -191,7 +248,7 @@ class NotificationApi {
     required String payload,
   }) async {
     const androidDetails = AndroidNotificationDetails(
-      'class_reminders',
+      classReminderChannelId,
       'Class reminders',
       channelDescription: 'Reliable reminders before scheduled classes',
       icon: 'outline_event_note_24',
@@ -247,6 +304,12 @@ class VoidNotificationApi extends NotificationApi {
 
   @override
   Future<bool> areNotificationsEnabled() => Future.value(false);
+
+  @override
+  Future<bool> areClassRemindersEnabled() => Future.value(false);
+
+  @override
+  Future<bool> openClassReminderSettings() => Future.value(false);
 
   @override
   Future<bool> canScheduleExactNotifications() => Future.value(false);

--- a/lib/common/ui/notification_api.dart
+++ b/lib/common/ui/notification_api.dart
@@ -1,23 +1,27 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:math';
 
 import 'package:dualmate/common/logging/crash_reporting.dart';
+import 'package:dualmate/common/util/widget_navigation_payload.dart';
+import 'package:dualmate/ui/navigation/main_section_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/timezone.dart' as tz;
 
 ///
 /// Provides methods to display native notifications
 ///
-typedef NotificationPluginInitializer = Future<bool?> Function(
-  FlutterLocalNotificationsPlugin plugin,
-  InitializationSettings settings,
-  DidReceiveNotificationResponseCallback onDidReceiveNotificationResponse,
-);
+typedef NotificationPluginInitializer =
+    Future<bool?> Function(
+      FlutterLocalNotificationsPlugin plugin,
+      InitializationSettings settings,
+      DidReceiveNotificationResponseCallback onDidReceiveNotificationResponse,
+    );
 
-typedef NotificationRuntimePermissionRequester = Future<bool?> Function(
-  FlutterLocalNotificationsPlugin plugin,
-);
+typedef NotificationRuntimePermissionRequester =
+    Future<bool?> Function(FlutterLocalNotificationsPlugin plugin);
 
 class NotificationApi {
   final FlutterLocalNotificationsPlugin _localNotificationsPlugin;
@@ -28,11 +32,11 @@ class NotificationApi {
     FlutterLocalNotificationsPlugin? localNotificationsPlugin,
     NotificationPluginInitializer? pluginInitializer,
     NotificationRuntimePermissionRequester? runtimePermissionRequester,
-  })  : _localNotificationsPlugin =
-            localNotificationsPlugin ?? FlutterLocalNotificationsPlugin(),
-        _pluginInitializer = pluginInitializer ?? _defaultPluginInitializer,
-        _runtimePermissionRequester =
-            runtimePermissionRequester ?? _defaultRuntimePermissionRequester;
+  }) : _localNotificationsPlugin =
+           localNotificationsPlugin ?? FlutterLocalNotificationsPlugin(),
+       _pluginInitializer = pluginInitializer ?? _defaultPluginInitializer,
+       _runtimePermissionRequester =
+           runtimePermissionRequester ?? _defaultRuntimePermissionRequester;
 
   ///
   /// Initialize the notifications. You can't show any notifications before you
@@ -55,6 +59,17 @@ class NotificationApi {
       initializationSettings,
       selectNotification,
     );
+    try {
+      final launchDetails = await _localNotificationsPlugin
+          .getNotificationAppLaunchDetails();
+      final launchResponse = launchDetails?.notificationResponse;
+      if (launchDetails?.didNotificationLaunchApp == true &&
+          launchResponse != null) {
+        selectNotification(launchResponse);
+      }
+    } catch (_) {
+      // Some test and unsupported platform implementations omit launch details.
+    }
     if (requestRuntimePermission) {
       unawaited(this.requestRuntimePermission());
     }
@@ -66,8 +81,9 @@ class NotificationApi {
 
   Future<bool?> _requestRuntimePermissionsBestEffort() async {
     try {
-      final granted =
-          await _runtimePermissionRequester(_localNotificationsPlugin);
+      final granted = await _runtimePermissionRequester(
+        _localNotificationsPlugin,
+      );
       developer.log(
         'Notification runtime permission requested: $granted',
         name: 'notification_api',
@@ -99,8 +115,10 @@ class NotificationApi {
   static Future<bool?> _defaultRuntimePermissionRequester(
     FlutterLocalNotificationsPlugin plugin,
   ) async {
-    final androidPlugin = plugin.resolvePlatformSpecificImplementation<
-        AndroidFlutterLocalNotificationsPlugin>();
+    final androidPlugin = plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
     return androidPlugin?.requestNotificationsPermission();
   }
 
@@ -141,7 +159,79 @@ class NotificationApi {
     );
   }
 
-  void selectNotification(NotificationResponse notificationResponse) {}
+  Future<bool> areNotificationsEnabled() async {
+    final androidPlugin = _localNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    return await androidPlugin?.areNotificationsEnabled() ?? false;
+  }
+
+  Future<bool> canScheduleExactNotifications() async {
+    final androidPlugin = _localNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    return await androidPlugin?.canScheduleExactNotifications() ?? false;
+  }
+
+  Future<bool> requestExactAlarmPermission() async {
+    final androidPlugin = _localNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    return await androidPlugin?.requestExactAlarmsPermission() ?? false;
+  }
+
+  Future<void> scheduleExactNotification({
+    required int id,
+    required String title,
+    required String body,
+    required DateTime scheduledTime,
+    required String payload,
+  }) async {
+    const androidDetails = AndroidNotificationDetails(
+      'class_reminders',
+      'Class reminders',
+      channelDescription: 'Reliable reminders before scheduled classes',
+      icon: 'outline_event_note_24',
+      channelAction: AndroidNotificationChannelAction.createIfNotExists,
+      importance: Importance.high,
+      priority: Priority.high,
+      category: AndroidNotificationCategory.reminder,
+    );
+    const details = NotificationDetails(android: androidDetails);
+    await _localNotificationsPlugin.zonedSchedule(
+      id,
+      title,
+      body,
+      tz.TZDateTime.from(scheduledTime, tz.getLocation('Europe/Berlin')),
+      details,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      payload: payload,
+    );
+  }
+
+  Future<void> cancelNotification(int id) {
+    return _localNotificationsPlugin.cancel(id);
+  }
+
+  void selectNotification(NotificationResponse notificationResponse) {
+    final payload = notificationResponse.payload;
+    if (payload == null || payload.isEmpty) return;
+    try {
+      final decoded = jsonDecode(payload);
+      if (decoded is! Map<String, dynamic>) return;
+      final schedulePayload = WidgetScheduleEntryPayload.fromMap(decoded);
+      if (schedulePayload.isEmpty) return;
+      WidgetNavigationPayloadStore.instance.setSchedulePayload(schedulePayload);
+      MainSectionController.instance.openRoute('schedule');
+    } on FormatException {
+      return;
+    }
+  }
 }
 
 ///
@@ -154,6 +244,27 @@ class VoidNotificationApi extends NotificationApi {
 
   @override
   Future<bool?> requestRuntimePermission() => Future.value(null);
+
+  @override
+  Future<bool> areNotificationsEnabled() => Future.value(false);
+
+  @override
+  Future<bool> canScheduleExactNotifications() => Future.value(false);
+
+  @override
+  Future<bool> requestExactAlarmPermission() => Future.value(false);
+
+  @override
+  Future<void> scheduleExactNotification({
+    required int id,
+    required String title,
+    required String body,
+    required DateTime scheduledTime,
+    required String payload,
+  }) => Future.value();
+
+  @override
+  Future<void> cancelNotification(int id) => Future.value();
 
   @override
   void selectNotification(NotificationResponse notificationResponse) {}

--- a/lib/schedule/background/background_schedule_update.dart
+++ b/lib/schedule/background/background_schedule_update.dart
@@ -7,6 +7,8 @@ import 'package:dualmate/native/widget/widget_helper.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:kiwi/kiwi.dart';
 
 class BackgroundScheduleUpdate extends TaskCallback {
   static const String name = 'BackgroundScheduleUpdate';
@@ -15,13 +17,15 @@ class BackgroundScheduleUpdate extends TaskCallback {
   final ScheduleSourceProvider scheduleSource;
   final WorkSchedulerService scheduler;
   final WidgetHelper widgetHelper;
+  final ClassReminderController? reminderController;
 
   BackgroundScheduleUpdate(
     this.scheduleProvider,
     this.scheduleSource,
     this.scheduler,
-    this.widgetHelper,
-  );
+    this.widgetHelper, {
+    this.reminderController,
+  });
 
   Future updateSchedule() async {
     if (!scheduleSource.currentScheduleSource.canQuery()) {
@@ -41,6 +45,12 @@ class BackgroundScheduleUpdate extends TaskCallback {
         cancellationToken,
         origin: ScheduleRefreshOrigin.backgroundPeriodic,
       );
+      final controller =
+          reminderController ??
+          (KiwiContainer().isRegistered<ClassReminderController>()
+              ? KiwiContainer().resolve<ClassReminderController>()
+              : null);
+      await controller?.queue.drain();
     } on ScheduleQueryFailedException catch (e, trace) {
       print("Background schedule update failed");
       print(e.innerException.toString());
@@ -59,7 +69,8 @@ class BackgroundScheduleUpdate extends TaskCallback {
       );
       print("Background schedule update status: failure");
       print(
-          "Background schedule update next: retry in ${_updateInterval.inHours}h");
+        "Background schedule update next: retry in ${_updateInterval.inHours}h",
+      );
       return;
     } catch (e, trace) {
       print("Background schedule update unexpected failure");
@@ -79,7 +90,8 @@ class BackgroundScheduleUpdate extends TaskCallback {
       );
       print("Background schedule update status: failure");
       print(
-          "Background schedule update next: retry in ${_updateInterval.inHours}h");
+        "Background schedule update next: retry in ${_updateInterval.inHours}h",
+      );
       return;
     }
 
@@ -129,11 +141,7 @@ class BackgroundScheduleUpdate extends TaskCallback {
 
   @override
   Future<void> schedule() async {
-    await scheduler.schedulePeriodic(
-      _updateInterval,
-      getName(),
-      true,
-    );
+    await scheduler.schedulePeriodic(_updateInterval, getName(), true);
   }
 
   @override

--- a/lib/schedule/business/schedule_provider.dart
+++ b/lib/schedule/business/schedule_provider.dart
@@ -25,6 +25,9 @@ import 'package:intl/intl.dart';
 typedef ScheduleUpdatedCallback =
     Future<void> Function(Schedule schedule, DateTime start, DateTime end);
 
+typedef SchedulePersistedCallback =
+    void Function(Schedule schedule, DateTime start, DateTime end);
+
 typedef ScheduleEntryChangedCallback =
     Future<void> Function(
       ScheduleDiff scheduleDiff,
@@ -52,6 +55,8 @@ class ScheduleProvider {
   final ScheduleQueryInformationRepository _scheduleQueryInformationRepository;
   final List<ScheduleUpdatedCallback> _scheduleUpdatedCallbacks =
       <ScheduleUpdatedCallback>[];
+  final List<SchedulePersistedCallback> _schedulePersistedCallbacks =
+      <SchedulePersistedCallback>[];
 
   late ScheduleFilter _scheduleFilter;
 
@@ -117,6 +122,10 @@ class ScheduleProvider {
 
     _cacheWindow(start, end, cachedSchedule);
     return cachedSchedule;
+  }
+
+  Future<Schedule> getUnfilteredCachedSchedule(DateTime start, DateTime end) {
+    return _scheduleEntryRepository.queryScheduleBetweenDates(start, end);
   }
 
   Future<DateTime?> getLastQueryTimeForWindow(
@@ -205,6 +214,11 @@ class ScheduleProvider {
         },
       );
 
+      final persistedSchedule = schedule;
+      for (final callback in _schedulePersistedCallbacks) {
+        callback(persistedSchedule, start, end);
+      }
+
       schedule = await PerformanceTelemetry.instance.measureTask(
         'schedule.entries.filter',
         args: {
@@ -278,6 +292,14 @@ class ScheduleProvider {
   void removeScheduleUpdatedCallback(ScheduleUpdatedCallback callback) {
     if (_scheduleUpdatedCallbacks.contains(callback))
       _scheduleUpdatedCallbacks.remove(callback);
+  }
+
+  void addSchedulePersistedCallback(SchedulePersistedCallback callback) {
+    _schedulePersistedCallbacks.add(callback);
+  }
+
+  void removeSchedulePersistedCallback(SchedulePersistedCallback callback) {
+    _schedulePersistedCallbacks.remove(callback);
   }
 
   void addScheduleEntryChangedCallback(ScheduleEntryChangedCallback callback) {

--- a/lib/schedule/business/schedule_source_identity.dart
+++ b/lib/schedule/business/schedule_source_identity.dart
@@ -1,0 +1,65 @@
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+
+abstract final class ScheduleSourceIdentity {
+  static const Set<String> _transientRaplaParameters = {
+    'day',
+    'month',
+    'year',
+    'next',
+    'prev',
+    'goto',
+  };
+
+  static String create(ScheduleSourceType type, String configuredValue) {
+    final normalized = switch (type) {
+      ScheduleSourceType.Rapla => normalizeRaplaUrl(configuredValue),
+      ScheduleSourceType.Dualis => configuredValue.trim().toLowerCase(),
+      ScheduleSourceType.Ical ||
+      ScheduleSourceType.Mannheim => configuredValue.trim(),
+      ScheduleSourceType.None => '',
+    };
+    return '${type.name.toLowerCase()}:${_stableHash(normalized)}';
+  }
+
+  static String normalizeRaplaUrl(String value) {
+    var raw = value.trim();
+    if (raw.isEmpty) return raw;
+    if (!raw.startsWith('http://') && !raw.startsWith('https://')) {
+      raw = 'https://$raw';
+    }
+
+    final uri = Uri.tryParse(raw);
+    if (uri == null) return raw;
+
+    final entries = <MapEntry<String, String>>[];
+    final keys = uri.queryParametersAll.keys.toList()..sort();
+    for (final key in keys) {
+      if (_transientRaplaParameters.contains(key.toLowerCase())) continue;
+      final values = List<String>.from(uri.queryParametersAll[key] ?? const [])
+        ..sort();
+      for (final item in values) {
+        entries.add(MapEntry(key, item));
+      }
+    }
+
+    return uri
+        .replace(
+          scheme: uri.scheme.toLowerCase(),
+          host: uri.host.toLowerCase(),
+          fragment: '',
+          queryParameters: entries.isEmpty
+              ? const <String, String>{}
+              : Map<String, String>.fromEntries(entries),
+        )
+        .toString();
+  }
+
+  static String _stableHash(String value) {
+    var hash = 0x811c9dc5;
+    for (final byte in value.codeUnits) {
+      hash ^= byte;
+      hash = (hash * 0x01000193) & 0xffffffff;
+    }
+    return hash.toRadixString(16).padLeft(8, '0');
+  }
+}

--- a/lib/schedule/business/schedule_source_identity.dart
+++ b/lib/schedule/business/schedule_source_identity.dart
@@ -42,14 +42,28 @@ abstract final class ScheduleSourceIdentity {
       }
     }
 
+    if (entries.isEmpty) {
+      return uri
+          .replace(
+            scheme: uri.scheme.toLowerCase(),
+            host: uri.host.toLowerCase(),
+            fragment: '',
+            queryParameters: const <String, String>{},
+          )
+          .toString();
+    }
+
+    final encodedPairs = entries.map(
+      (e) =>
+          '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}',
+    );
+    final query = encodedPairs.join('&');
     return uri
         .replace(
           scheme: uri.scheme.toLowerCase(),
           host: uri.host.toLowerCase(),
           fragment: '',
-          queryParameters: entries.isEmpty
-              ? const <String, String>{}
-              : Map<String, String>.fromEntries(entries),
+          query: query,
         )
         .toString();
   }

--- a/lib/schedule/business/schedule_source_provider.dart
+++ b/lib/schedule/business/schedule_source_provider.dart
@@ -173,7 +173,12 @@ class ScheduleSourceProvider {
   }
 
   bool wouldChangeTo(ScheduleSourceType type, String configuredValue) {
-    final nextIdentity = ScheduleSourceIdentity.create(type, configuredValue);
+    final String nextIdentity;
+    if (type == ScheduleSourceType.None || configuredValue.trim().isEmpty) {
+      nextIdentity = 'none';
+    } else {
+      nextIdentity = ScheduleSourceIdentity.create(type, configuredValue);
+    }
     return nextIdentity != _currentSourceIdentity;
   }
 

--- a/lib/schedule/business/schedule_source_provider.dart
+++ b/lib/schedule/business/schedule_source_provider.dart
@@ -180,6 +180,12 @@ class ScheduleSourceProvider {
     return hash.toRadixString(16).padLeft(8, '0');
   }
 
+  bool wouldChangeTo(ScheduleSourceType type, String configuredValue) {
+    final nextIdentity =
+        '${type.name.toLowerCase()}:${_stableHash(configuredValue)}';
+    return nextIdentity != _currentSourceIdentity;
+  }
+
   /// Onboarding stores the Rapla URL first and defers full source setup plus
   /// cache clearing to post-onboarding initialization. Other setup flows run
   /// after onboarding and therefore keep the default immediate setup behavior.

--- a/lib/schedule/business/schedule_source_provider.dart
+++ b/lib/schedule/business/schedule_source_provider.dart
@@ -3,6 +3,7 @@ import 'package:dualmate/common/logging/analytics.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_query_information_repository.dart';
 import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:dualmate/schedule/business/schedule_source_identity.dart';
 import 'package:dualmate/schedule/service/dualis/dualis_schedule_source.dart';
 import 'package:dualmate/schedule/service/error_report_schedule_source_decorator.dart';
 import 'package:dualmate/schedule/service/ical/ical_schedule_source.dart';
@@ -168,21 +169,11 @@ class ScheduleSourceProvider {
         (await _preferencesProvider.loadDualisCredentials()).username,
       ScheduleSourceType.None => '',
     };
-    return '${type.name.toLowerCase()}:${_stableHash(configuredValue)}';
-  }
-
-  String _stableHash(String value) {
-    var hash = 0x811c9dc5;
-    for (final byte in value.codeUnits) {
-      hash ^= byte;
-      hash = (hash * 0x01000193) & 0xffffffff;
-    }
-    return hash.toRadixString(16).padLeft(8, '0');
+    return ScheduleSourceIdentity.create(type, configuredValue);
   }
 
   bool wouldChangeTo(ScheduleSourceType type, String configuredValue) {
-    final nextIdentity =
-        '${type.name.toLowerCase()}:${_stableHash(configuredValue)}';
+    final nextIdentity = ScheduleSourceIdentity.create(type, configuredValue);
     return nextIdentity != _currentSourceIdentity;
   }
 

--- a/lib/schedule/business/schedule_source_provider.dart
+++ b/lib/schedule/business/schedule_source_provider.dart
@@ -30,10 +30,14 @@ class ScheduleSourceProvider {
 
   ScheduleSource _currentScheduleSource = InvalidScheduleSource();
   ScheduleSourceType _currentScheduleSourceType = ScheduleSourceType.None;
+  String _currentSourceIdentity = 'none';
+  int _sourceGeneration = 0;
 
   ScheduleSource get currentScheduleSource => _currentScheduleSource;
   ScheduleSourceType get currentScheduleSourceType =>
       _currentScheduleSourceType;
+  String get currentSourceIdentity => _currentSourceIdentity;
+  int get sourceGeneration => _sourceGeneration;
 
   List<OnDidChangeScheduleSource> _onDidChangeScheduleSourceCallbacks = [];
 
@@ -65,6 +69,13 @@ class ScheduleSourceProvider {
     _currentScheduleSourceType = didSetupCorrectly()
         ? scheduleSourceType
         : ScheduleSourceType.None;
+    final nextIdentity = didSetupCorrectly()
+        ? await _configuredSourceIdentity(scheduleSourceType)
+        : 'none';
+    if (_currentSourceIdentity != nextIdentity) {
+      _currentSourceIdentity = nextIdentity;
+      _sourceGeneration += 1;
+    }
 
     var success = didSetupCorrectly();
 
@@ -145,6 +156,28 @@ class ScheduleSourceProvider {
     }
 
     return InvalidScheduleSource();
+  }
+
+  Future<String> _configuredSourceIdentity(ScheduleSourceType type) async {
+    final configuredValue = switch (type) {
+      ScheduleSourceType.Rapla => await _preferencesProvider.getRaplaUrl(),
+      ScheduleSourceType.Ical => await _preferencesProvider.getIcalUrl(),
+      ScheduleSourceType.Mannheim =>
+        await _preferencesProvider.getMannheimScheduleId(),
+      ScheduleSourceType.Dualis =>
+        (await _preferencesProvider.loadDualisCredentials()).username,
+      ScheduleSourceType.None => '',
+    };
+    return '${type.name.toLowerCase()}:${_stableHash(configuredValue)}';
+  }
+
+  String _stableHash(String value) {
+    var hash = 0x811c9dc5;
+    for (final byte in value.codeUnits) {
+      hash ^= byte;
+      hash = (hash * 0x01000193) & 0xffffffff;
+    }
+    return hash.toRadixString(16).padLeft(8, '0');
   }
 
   /// Onboarding stores the Rapla URL first and defers full source setup plus

--- a/lib/schedule/reminders/canonical_class_name.dart
+++ b/lib/schedule/reminders/canonical_class_name.dart
@@ -39,7 +39,9 @@ abstract final class CanonicalClassName {
     final isUppercaseCode = first.length >= 3 && first == first.toUpperCase();
     final hasAtLeastTwoDigits = RegExp(r'\d').allMatches(first).length >= 2;
     if (isUppercaseCode && hasAtLeastTwoDigits) {
-      return trimmed.substring(first.length).trimLeft();
+      return trimmed
+          .substring(first.length)
+          .replaceFirst(RegExp(r'^\s*-\s*'), '');
     }
     return title;
   }

--- a/lib/schedule/reminders/canonical_class_name.dart
+++ b/lib/schedule/reminders/canonical_class_name.dart
@@ -1,0 +1,62 @@
+/// Stable class-name normalization used as recurring reminder identity.
+///
+/// Keep changes to this algorithm backwards-compatible or migrate persisted
+/// reminder rules alongside them.
+abstract final class CanonicalClassName {
+  static final RegExp _onlinePrefix = RegExp(
+    r'^\s*\(?online\)?(?:\s*-\s*|\s+)',
+    caseSensitive: false,
+  );
+  static final RegExp _onlineSuffix = RegExp(
+    r'(?:\s*-\s*|\s+)\(?online\)?\s*$',
+    caseSensitive: false,
+  );
+  static final RegExp _courseCodePrefix = RegExp(
+    r'^[A-Z]{3,}-?[A-Z]+[0-9]*[A-Z]*[0-9]*/?[A-Z]*[0-9]*\s*-?\s*',
+  );
+  static final RegExp _whitespace = RegExp(r'\s+');
+
+  static String fromTitle(String title) {
+    var result = removeCourseCodePrefix(title);
+    result = removeOnlineMarker(result);
+    return result.trim().replaceAll(_whitespace, ' ');
+  }
+
+  static String removeOnlineMarker(String title) {
+    return title
+        .replaceFirst(_onlinePrefix, '')
+        .replaceFirst(_onlineSuffix, '');
+  }
+
+  static String removeCourseCodePrefix(String title) {
+    final match = _courseCodePrefix.firstMatch(title);
+    if (match != null) {
+      return title.substring(match.end);
+    }
+
+    final trimmed = title.trimLeft();
+    final first = trimmed.split(RegExp(r'\s+')).first;
+    final isUppercaseCode = first.length >= 3 && first == first.toUpperCase();
+    final hasAtLeastTwoDigits = RegExp(r'\d').allMatches(first).length >= 2;
+    if (isUppercaseCode && hasAtLeastTwoDigits) {
+      return trimmed.substring(first.length).trimLeft();
+    }
+    return title;
+  }
+
+  static String? courseCodePrefix(String title) {
+    final match = _courseCodePrefix.firstMatch(title);
+    if (match != null) {
+      return title.substring(0, match.end).trim();
+    }
+
+    final trimmed = title.trimLeft();
+    final first = trimmed.split(RegExp(r'\s+')).first;
+    if (first.length >= 3 &&
+        first == first.toUpperCase() &&
+        RegExp(r'\d').allMatches(first).length >= 2) {
+      return first;
+    }
+    return null;
+  }
+}

--- a/lib/schedule/reminders/class_reminder.dart
+++ b/lib/schedule/reminders/class_reminder.dart
@@ -69,7 +69,10 @@ abstract final class ClassReminderIdentity {
   }) {
     final input =
         '$sourceIdentity|$ruleId|${occurrenceStart.toUtc().millisecondsSinceEpoch}';
-    return _hash(input);
+    // Legacy immediate notifications use non-negative random identifiers.
+    // Keep class alarms in a disjoint namespace so neither family can replace
+    // or cancel a notification belonging to the other.
+    return -_hash(input);
   }
 
   static int _hash(String input) {

--- a/lib/schedule/reminders/class_reminder.dart
+++ b/lib/schedule/reminders/class_reminder.dart
@@ -43,6 +43,18 @@ class ScheduledClassNotification {
 }
 
 abstract final class ClassReminderIdentity {
+  static String ruleId({
+    required ClassReminderScope scope,
+    required String canonicalTitle,
+    required String sourceIdentity,
+    DateTime? occurrenceStart,
+  }) {
+    final identity = scope == ClassReminderScope.recurring
+        ? '$sourceIdentity|recurring|$canonicalTitle'
+        : '$sourceIdentity|one-time|$canonicalTitle|${occurrenceStart?.toUtc().millisecondsSinceEpoch}';
+    return 'class-reminder-${_hash(identity).toRadixString(16)}';
+  }
+
   static String occurrence({
     required String canonicalTitle,
     required DateTime occurrenceStart,
@@ -57,6 +69,10 @@ abstract final class ClassReminderIdentity {
   }) {
     final input =
         '$sourceIdentity|$ruleId|${occurrenceStart.toUtc().millisecondsSinceEpoch}';
+    return _hash(input);
+  }
+
+  static int _hash(String input) {
     var hash = 0x811c9dc5;
     for (final byte in input.codeUnits) {
       hash ^= byte;

--- a/lib/schedule/reminders/class_reminder.dart
+++ b/lib/schedule/reminders/class_reminder.dart
@@ -1,0 +1,67 @@
+enum ClassReminderScope { oneTime, recurring }
+
+class ClassReminderRule {
+  final String id;
+  final ClassReminderScope scope;
+  final String canonicalTitle;
+  final Duration offset;
+  final String sourceIdentity;
+  final DateTime? occurrenceStart;
+  final DateTime? occurrenceEnd;
+
+  const ClassReminderRule({
+    required this.id,
+    required this.scope,
+    required this.canonicalTitle,
+    required this.offset,
+    required this.sourceIdentity,
+    this.occurrenceStart,
+    this.occurrenceEnd,
+  });
+
+  bool get isOneTime => scope == ClassReminderScope.oneTime;
+}
+
+class ScheduledClassNotification {
+  final String ruleId;
+  final String occurrenceIdentity;
+  final String sourceIdentity;
+  final int notificationId;
+  final DateTime scheduledTime;
+  final DateTime classStart;
+  final String contentFingerprint;
+
+  const ScheduledClassNotification({
+    required this.ruleId,
+    required this.occurrenceIdentity,
+    required this.sourceIdentity,
+    required this.notificationId,
+    required this.scheduledTime,
+    required this.classStart,
+    required this.contentFingerprint,
+  });
+}
+
+abstract final class ClassReminderIdentity {
+  static String occurrence({
+    required String canonicalTitle,
+    required DateTime occurrenceStart,
+    required String sourceIdentity,
+  }) =>
+      '$sourceIdentity|$canonicalTitle|${occurrenceStart.toUtc().millisecondsSinceEpoch}';
+
+  static int notificationId({
+    required String ruleId,
+    required DateTime occurrenceStart,
+    required String sourceIdentity,
+  }) {
+    final input =
+        '$sourceIdentity|$ruleId|${occurrenceStart.toUtc().millisecondsSinceEpoch}';
+    var hash = 0x811c9dc5;
+    for (final byte in input.codeUnits) {
+      hash ^= byte;
+      hash = (hash * 0x01000193) & 0x7fffffff;
+    }
+    return hash == 0 ? 1 : hash;
+  }
+}

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -137,8 +137,9 @@ class ClassReminderController extends ChangeNotifier {
       ]);
       _permissionsGranted = results.every((granted) => granted);
     } catch (error, trace) {
+      _permissionsGranted = false;
+      _permissionStateKnown = true;
       await _reportQueueFailure(error, trace);
-      return;
     }
     _permissionStateKnown = true;
     if (!wasKnown || previous != _permissionsGranted) notifyListeners();

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -198,12 +198,14 @@ class ClassReminderController extends ChangeNotifier {
 
   Future<void> clearForSourceChange({String? sourceIdentity}) async {
     final identity = sourceIdentity ?? _activeSourceIdentity;
-    await _pauseSource(identity);
-    await _repository.clearSource(identity);
-    _reloadRevision += 1;
-    _rules = const [];
-    _activeSourceIdentity = 'none';
-    notifyListeners();
+    await _queue.runSerialized(() async {
+      await _pauseSource(identity);
+      await _repository.clearSource(identity);
+      _reloadRevision += 1;
+      _rules = const [];
+      _activeSourceIdentity = 'none';
+      notifyListeners();
+    });
   }
 
   Future<void> waitForSourceChange() => _sourceChangeFuture;
@@ -231,8 +233,10 @@ class ClassReminderController extends ChangeNotifier {
       final previousIdentity = _activeSourceIdentity;
       final currentIdentity = _sourceProvider.currentSourceIdentity;
       if (previousIdentity != 'none' && previousIdentity != currentIdentity) {
-        await _pauseSource(previousIdentity);
-        await _repository.clearSource(previousIdentity);
+        await _queue.runSerialized(() async {
+          await _pauseSource(previousIdentity);
+          await _repository.clearSource(previousIdentity);
+        });
       }
       await _reloadRules();
       if (hasReminders && permissionsGranted) {

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -27,14 +27,18 @@ class ClassReminderController extends ChangeNotifier {
   final ScheduleSourceProvider _sourceProvider;
   final ClassReminderCoordinator _coordinator;
   final ClassReminderScheduler _scheduler;
-  final NotificationApi Function() _notificationApi;
+  final NotificationApi? Function() _notificationApi;
   final DateTime Function() _now;
   late final ReminderSyncQueue _queue;
 
   List<ClassReminderRule> _rules = const [];
+  Map<String, ClassReminderRule> _recurringRulesByTitle = const {};
+  Map<String, ClassReminderRule> _oneTimeRulesByOccurrence = const {};
   bool _permissionsGranted = false;
   bool _permissionStateKnown = false;
   bool _initialized = false;
+  Future<void>? _initializationFuture;
+  Future<void>? _permissionRefreshFuture;
   int _reloadRevision = 0;
   Future<void> _sourceChangeFuture = Future<void>.value();
   DateTime? _lastCleanup;
@@ -45,7 +49,7 @@ class ClassReminderController extends ChangeNotifier {
     required ScheduleProvider scheduleProvider,
     required ScheduleSourceProvider sourceProvider,
     required ClassReminderScheduler scheduler,
-    required NotificationApi Function() notificationApi,
+    required NotificationApi? Function() notificationApi,
     DateTime Function()? now,
   }) : _repository = repository,
        _scheduleProvider = scheduleProvider,
@@ -63,53 +67,84 @@ class ClassReminderController extends ChangeNotifier {
       currentGeneration: () => _sourceProvider.sourceGeneration,
       onError: _reportQueueFailure,
     );
-    _scheduleProvider.addScheduleUpdatedCallback(_scheduleUpdated);
+    _scheduleProvider.addSchedulePersistedCallback(_scheduleUpdated);
     _sourceProvider.addDidChangeScheduleSourceCallback(_sourceChanged);
   }
 
   bool get hasReminders => _rules.isNotEmpty;
   bool get permissionsGranted => _permissionsGranted;
+  bool get permissionStateKnown => _permissionStateKnown;
+  bool get isInitialized => _initialized;
   bool get remindersPaused =>
       hasReminders && _permissionStateKnown && !_permissionsGranted;
   ReminderSyncQueue get queue => _queue;
 
-  Future<void> initialize() async {
-    if (_initialized) return;
+  Future<void> initialize() {
+    if (_initialized) return Future<void>.value();
+    return _initializationFuture ??= _initializeWithRetry();
+  }
+
+  Future<void> _initializeWithRetry() async {
+    try {
+      await _initialize();
+    } catch (_) {
+      _initializationFuture = null;
+      rethrow;
+    }
+  }
+
+  Future<void> _initialize() async {
     await _cleanupIfNeeded(force: true);
     await _reloadRules();
     await refreshPermissionState(scheduleWhenRestored: false);
     if (hasReminders && permissionsGranted) {
       await reconcileUpcoming(waitForCompletion: true);
-    } else if (hasReminders) {
+    } else if (remindersPaused) {
       await _pauseSource(_activeSourceIdentity);
     }
     _initialized = true;
+    notifyListeners();
   }
 
   Future<void> onAppResumed() async {
+    if (!_initialized) {
+      await initialize();
+      return;
+    }
     await _cleanupIfNeeded();
     await _reloadRules();
     await refreshPermissionState();
   }
 
-  Future<void> refreshPermissionState({
-    bool scheduleWhenRestored = true,
+  Future<void> refreshPermissionState({bool scheduleWhenRestored = true}) {
+    return _permissionRefreshFuture ??= _refreshPermissionState(
+      scheduleWhenRestored: scheduleWhenRestored,
+    ).whenComplete(() => _permissionRefreshFuture = null);
+  }
+
+  Future<void> _refreshPermissionState({
+    required bool scheduleWhenRestored,
   }) async {
     final previous = _permissionsGranted;
     final wasKnown = _permissionStateKnown;
+    final api = _notificationApi();
+    if (api == null) return;
     try {
-      final api = _notificationApi();
       final results = await Future.wait([
         api.areNotificationsEnabled(),
+        api.areClassRemindersEnabled(),
         api.canScheduleExactNotifications(),
       ]);
       _permissionsGranted = results.every((granted) => granted);
-    } catch (_) {
-      _permissionsGranted = false;
+    } catch (error, trace) {
+      await _reportQueueFailure(error, trace);
+      return;
     }
     _permissionStateKnown = true;
     if (!wasKnown || previous != _permissionsGranted) notifyListeners();
-    if (previous && !_permissionsGranted && hasReminders) {
+    if (_permissionsGranted == false &&
+        hasReminders &&
+        (!wasKnown || previous != _permissionsGranted)) {
       await _pauseSource(_activeSourceIdentity);
     }
     if (scheduleWhenRestored &&
@@ -121,10 +156,16 @@ class ClassReminderController extends ChangeNotifier {
   }
 
   Future<void> openReliablePermissionSettings() async {
+    final api = _notificationApi();
+    if (api == null) return;
     try {
-      final api = _notificationApi();
       if (!await api.areNotificationsEnabled()) {
         await api.requestRuntimePermission();
+        return;
+      }
+      if (!await api.areClassRemindersEnabled()) {
+        await api.openClassReminderSettings();
+        return;
       }
       if (!await api.canScheduleExactNotifications()) {
         await api.requestExactAlarmPermission();
@@ -136,19 +177,31 @@ class ClassReminderController extends ChangeNotifier {
 
   ClassReminderRule? ruleFor(ScheduleEntry entry) {
     final canonical = CanonicalClassName.fromTitle(entry.title);
-    final recurring = _rules.where(
-      (rule) =>
-          rule.scope == ClassReminderScope.recurring &&
-          rule.canonicalTitle == canonical,
+    return _oneTimeRulesByOccurrence[_occurrenceRuleKey(
+          canonical,
+          entry.start,
+        )] ??
+        _recurringRulesByTitle[canonical];
+  }
+
+  bool hasReminderForTitle(String title) {
+    final canonical = CanonicalClassName.fromTitle(title);
+    return _rules.any((rule) => rule.canonicalTitle == canonical);
+  }
+
+  Future<void> removeRemindersForTitle(String title) async {
+    final canonical = CanonicalClassName.fromTitle(title);
+    final ruleIds = _rules
+        .where((rule) => rule.canonicalTitle == canonical)
+        .map((rule) => rule.id)
+        .toList(growable: false);
+    if (ruleIds.isEmpty) return;
+    await _repository.applyRuleChanges(
+      upserts: const [],
+      removedRuleIds: ruleIds,
     );
-    if (recurring.isNotEmpty) return recurring.first;
-    final oneTime = _rules.where(
-      (rule) =>
-          rule.scope == ClassReminderScope.oneTime &&
-          rule.canonicalTitle == canonical &&
-          rule.occurrenceStart == entry.start,
-    );
-    return oneTime.isEmpty ? null : oneTime.first;
+    await _reloadRules();
+    await reconcileUpcoming(waitForCompletion: false);
   }
 
   Future<ReminderActivationResult> saveReminder({
@@ -207,6 +260,7 @@ class ClassReminderController extends ChangeNotifier {
       await _repository.clearSource(identity);
       _reloadRevision += 1;
       _rules = const [];
+      _rebuildRuleIndexes();
       _activeSourceIdentity = 'none';
       notifyListeners();
     });
@@ -217,16 +271,15 @@ class ClassReminderController extends ChangeNotifier {
   Future<void> reconcileUpcoming({required bool waitForCompletion}) async {
     final now = _now();
     final end = now.add(upcomingWindow);
-    final schedule = await _scheduleProvider.getCachedSchedule(now, end);
+    final schedule = await _scheduleProvider.getUnfilteredCachedSchedule(
+      now,
+      end,
+    );
     _enqueue(schedule, now, end);
     if (waitForCompletion) await _queue.drain();
   }
 
-  Future<void> _scheduleUpdated(
-    Schedule schedule,
-    DateTime start,
-    DateTime end,
-  ) async {
+  void _scheduleUpdated(Schedule schedule, DateTime start, DateTime end) {
     if (!hasReminders) return;
     _enqueue(schedule, start, end);
   }
@@ -268,6 +321,7 @@ class ClassReminderController extends ChangeNotifier {
 
   Future<void> _processRequest(ReminderSyncRequest request) async {
     await refreshPermissionState(scheduleWhenRestored: false);
+    if (!_permissionStateKnown) return;
     if (!_permissionsGranted) {
       await _coordinator.pauseWindow(
         start: request.start,
@@ -330,9 +384,53 @@ class ClassReminderController extends ChangeNotifier {
         sourceIdentity != _sourceProvider.currentSourceIdentity) {
       return;
     }
+    final sortedRules = List<ClassReminderRule>.from(rules)
+      ..sort((left, right) => left.id.compareTo(right.id));
+    final didChange =
+        _activeSourceIdentity != sourceIdentity ||
+        !_sameRules(_rules, sortedRules);
     _activeSourceIdentity = sourceIdentity;
-    _rules = rules;
-    notifyListeners();
+    _rules = sortedRules;
+    _rebuildRuleIndexes();
+    if (didChange) notifyListeners();
+  }
+
+  void _rebuildRuleIndexes() {
+    _recurringRulesByTitle = {
+      for (final rule in _rules)
+        if (rule.scope == ClassReminderScope.recurring)
+          rule.canonicalTitle: rule,
+    };
+    _oneTimeRulesByOccurrence = {
+      for (final rule in _rules)
+        if (rule.scope == ClassReminderScope.oneTime &&
+            rule.occurrenceStart != null)
+          _occurrenceRuleKey(rule.canonicalTitle, rule.occurrenceStart!): rule,
+    };
+  }
+
+  String _occurrenceRuleKey(String canonicalTitle, DateTime start) =>
+      '$canonicalTitle|${start.toUtc().millisecondsSinceEpoch}';
+
+  bool _sameRules(
+    List<ClassReminderRule> previous,
+    List<ClassReminderRule> next,
+  ) {
+    if (previous.length != next.length) return false;
+    for (var index = 0; index < previous.length; index++) {
+      final left = previous[index];
+      final right = next[index];
+      if (left.id != right.id ||
+          left.scope != right.scope ||
+          left.canonicalTitle != right.canonicalTitle ||
+          left.offset != right.offset ||
+          left.sourceIdentity != right.sourceIdentity ||
+          left.occurrenceStart != right.occurrenceStart ||
+          left.occurrenceEnd != right.occurrenceEnd) {
+        return false;
+      }
+    }
+    return true;
   }
 
   Future<void> _pauseSource(String sourceIdentity) async {
@@ -378,7 +476,7 @@ class ClassReminderController extends ChangeNotifier {
 
   @override
   void dispose() {
-    _scheduleProvider.removeScheduleUpdatedCallback(_scheduleUpdated);
+    _scheduleProvider.removeSchedulePersistedCallback(_scheduleUpdated);
     _sourceProvider.removeDidChangeScheduleSourceCallback(_sourceChanged);
     super.dispose();
   }

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -34,6 +34,8 @@ class ClassReminderController extends ChangeNotifier {
   List<ClassReminderRule> _rules = const [];
   bool _permissionsGranted = false;
   bool _initialized = false;
+  int _reloadRevision = 0;
+  Future<void> _sourceChangeFuture = Future<void>.value();
   DateTime? _lastCleanup;
   String _activeSourceIdentity = 'none';
 
@@ -71,7 +73,6 @@ class ClassReminderController extends ChangeNotifier {
 
   Future<void> initialize() async {
     if (_initialized) return;
-    _initialized = true;
     await _cleanupIfNeeded(force: true);
     await _reloadRules();
     await refreshPermissionState(scheduleWhenRestored: false);
@@ -80,6 +81,7 @@ class ClassReminderController extends ChangeNotifier {
     } else if (hasReminders) {
       await _pauseSource(_activeSourceIdentity);
     }
+    _initialized = true;
   }
 
   Future<void> onAppResumed() async {
@@ -155,7 +157,7 @@ class ClassReminderController extends ChangeNotifier {
       return ReminderActivationResult.permissionsRequired;
 
     final canonical = CanonicalClassName.fromTitle(entry.title);
-    await _removeApplicableRules(entry, canonical: canonical);
+    final obsoleteRuleIds = _applicableRuleIds(entry, canonical: canonical);
     final rule = ClassReminderRule(
       id: ClassReminderIdentity.ruleId(
         scope: scope,
@@ -172,29 +174,39 @@ class ClassReminderController extends ChangeNotifier {
       occurrenceStart: scope == ClassReminderScope.oneTime ? entry.start : null,
       occurrenceEnd: scope == ClassReminderScope.oneTime ? entry.end : null,
     );
-    await _repository.saveRule(rule);
+    await _repository.applyRuleChanges(
+      upserts: [rule],
+      removedRuleIds: obsoleteRuleIds.where((id) => id != rule.id).toList(),
+    );
     await _reloadRules();
     await reconcileUpcoming(waitForCompletion: false);
     return ReminderActivationResult.active;
   }
 
   Future<void> removeReminder(ScheduleEntry entry) async {
-    await _removeApplicableRules(
+    final ruleIds = _applicableRuleIds(
       entry,
       canonical: CanonicalClassName.fromTitle(entry.title),
+    );
+    await _repository.applyRuleChanges(
+      upserts: const [],
+      removedRuleIds: ruleIds,
     );
     await _reloadRules();
     await reconcileUpcoming(waitForCompletion: false);
   }
 
-  Future<void> clearForSourceChange() async {
-    final sourceIdentity = _sourceProvider.currentSourceIdentity;
-    await _pauseSource(sourceIdentity);
-    await _repository.clearSource(sourceIdentity);
+  Future<void> clearForSourceChange({String? sourceIdentity}) async {
+    final identity = sourceIdentity ?? _activeSourceIdentity;
+    await _pauseSource(identity);
+    await _repository.clearSource(identity);
+    _reloadRevision += 1;
     _rules = const [];
     _activeSourceIdentity = 'none';
     notifyListeners();
   }
+
+  Future<void> waitForSourceChange() => _sourceChangeFuture;
 
   Future<void> reconcileUpcoming({required bool waitForCompletion}) async {
     final now = _now();
@@ -209,12 +221,13 @@ class ClassReminderController extends ChangeNotifier {
     DateTime start,
     DateTime end,
   ) async {
+    if (!hasReminders) return;
     _enqueue(schedule, start, end);
   }
 
   void _sourceChanged(ScheduleSource _, bool setupSuccess) {
     if (!setupSuccess) return;
-    unawaited(() async {
+    _sourceChangeFuture = () async {
       final previousIdentity = _activeSourceIdentity;
       final currentIdentity = _sourceProvider.currentSourceIdentity;
       if (previousIdentity != 'none' && previousIdentity != currentIdentity) {
@@ -225,7 +238,12 @@ class ClassReminderController extends ChangeNotifier {
       if (hasReminders && permissionsGranted) {
         await reconcileUpcoming(waitForCompletion: false);
       }
-    }());
+    }();
+    unawaited(
+      _sourceChangeFuture.catchError((Object error, StackTrace trace) async {
+        await _reportQueueFailure(error, trace);
+      }),
+    );
   }
 
   void _enqueue(Schedule schedule, DateTime start, DateTime end) {
@@ -278,30 +296,34 @@ class ClassReminderController extends ChangeNotifier {
     await _reloadRules();
   }
 
-  Future<void> _removeApplicableRules(
+  List<String> _applicableRuleIds(
     ScheduleEntry entry, {
     required String canonical,
-  }) async {
+  }) {
     final applicable = _rules.where(
       (rule) =>
           rule.canonicalTitle == canonical &&
           (rule.scope == ClassReminderScope.recurring ||
               rule.occurrenceStart == entry.start),
     );
-    for (final rule in applicable.toList(growable: false)) {
-      await _repository.deleteRule(rule.id);
-    }
+    return applicable.map((rule) => rule.id).toList(growable: false);
   }
 
   Future<void> _reloadRules() async {
+    final revision = ++_reloadRevision;
     final sourceIdentity = _sourceProvider.currentSourceIdentity;
-    _activeSourceIdentity = sourceIdentity;
-    _rules = sourceIdentity == 'none'
-        ? const []
+    final rules = sourceIdentity == 'none'
+        ? const <ClassReminderRule>[]
         : await _repository.loadRelevantRules(
             sourceIdentity: sourceIdentity,
             now: _now(),
           );
+    if (revision != _reloadRevision ||
+        sourceIdentity != _sourceProvider.currentSourceIdentity) {
+      return;
+    }
+    _activeSourceIdentity = sourceIdentity;
+    _rules = rules;
     notifyListeners();
   }
 
@@ -314,9 +336,7 @@ class ClassReminderController extends ChangeNotifier {
     if (manifest.isNotEmpty) {
       await _repository.applyManifestChanges(
         upserts: const [],
-        removedOccurrenceIdentities: manifest
-            .map((row) => row.occurrenceIdentity)
-            .toList(growable: false),
+        removals: manifest,
       );
     }
   }

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -33,6 +33,7 @@ class ClassReminderController extends ChangeNotifier {
 
   List<ClassReminderRule> _rules = const [];
   bool _permissionsGranted = false;
+  bool _permissionStateKnown = false;
   bool _initialized = false;
   int _reloadRevision = 0;
   Future<void> _sourceChangeFuture = Future<void>.value();
@@ -68,7 +69,8 @@ class ClassReminderController extends ChangeNotifier {
 
   bool get hasReminders => _rules.isNotEmpty;
   bool get permissionsGranted => _permissionsGranted;
-  bool get remindersPaused => hasReminders && !_permissionsGranted;
+  bool get remindersPaused =>
+      hasReminders && _permissionStateKnown && !_permissionsGranted;
   ReminderSyncQueue get queue => _queue;
 
   Future<void> initialize() async {
@@ -94,6 +96,7 @@ class ClassReminderController extends ChangeNotifier {
     bool scheduleWhenRestored = true,
   }) async {
     final previous = _permissionsGranted;
+    final wasKnown = _permissionStateKnown;
     try {
       final api = _notificationApi();
       final results = await Future.wait([
@@ -104,7 +107,8 @@ class ClassReminderController extends ChangeNotifier {
     } catch (_) {
       _permissionsGranted = false;
     }
-    if (previous != _permissionsGranted) notifyListeners();
+    _permissionStateKnown = true;
+    if (!wasKnown || previous != _permissionsGranted) notifyListeners();
     if (previous && !_permissionsGranted && hasReminders) {
       await _pauseSource(_activeSourceIdentity);
     }

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -26,6 +26,7 @@ class ClassReminderController extends ChangeNotifier {
   final ScheduleProvider _scheduleProvider;
   final ScheduleSourceProvider _sourceProvider;
   final ClassReminderCoordinator _coordinator;
+  final ClassReminderScheduler _scheduler;
   final NotificationApi Function() _notificationApi;
   final DateTime Function() _now;
   late final ReminderSyncQueue _queue;
@@ -45,6 +46,7 @@ class ClassReminderController extends ChangeNotifier {
   }) : _repository = repository,
        _scheduleProvider = scheduleProvider,
        _sourceProvider = sourceProvider,
+       _scheduler = scheduler,
        _coordinator = ClassReminderCoordinator(
          repository: repository,
          scheduler: scheduler,
@@ -79,6 +81,7 @@ class ClassReminderController extends ChangeNotifier {
 
   Future<void> onAppResumed() async {
     await _cleanupIfNeeded();
+    await _reloadRules();
     await refreshPermissionState();
   }
 
@@ -176,6 +179,17 @@ class ClassReminderController extends ChangeNotifier {
     );
     await _reloadRules();
     await reconcileUpcoming(waitForCompletion: false);
+  }
+
+  Future<void> clearForSourceChange() async {
+    final sourceIdentity = _sourceProvider.currentSourceIdentity;
+    final manifest = await _repository.loadManifestForSource(sourceIdentity);
+    for (final row in manifest) {
+      await _scheduler.cancel(row.notificationId);
+    }
+    await _repository.clearSource(sourceIdentity);
+    _rules = const [];
+    notifyListeners();
   }
 
   Future<void> reconcileUpcoming({required bool waitForCompletion}) async {

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -1,0 +1,316 @@
+import 'dart:async';
+
+import 'package:dualmate/common/logging/app_diagnostics.dart';
+import 'package:dualmate/common/logging/performance_telemetry.dart';
+import 'package:dualmate/common/ui/notification_api.dart';
+import 'package:dualmate/schedule/business/schedule_provider.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/canonical_class_name.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_coordinator.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+import 'package:dualmate/schedule/reminders/reminder_sync_queue.dart';
+import 'package:dualmate/schedule/service/schedule_source.dart';
+import 'package:flutter/foundation.dart';
+
+enum ReminderActivationResult { active, permissionsRequired }
+
+class ClassReminderController extends ChangeNotifier {
+  static const Duration upcomingWindow = Duration(days: 14);
+  static const Duration resumeCleanupStaleness = Duration(hours: 6);
+
+  final ClassReminderRepository _repository;
+  final ScheduleProvider _scheduleProvider;
+  final ScheduleSourceProvider _sourceProvider;
+  final ClassReminderCoordinator _coordinator;
+  final NotificationApi Function() _notificationApi;
+  final DateTime Function() _now;
+  late final ReminderSyncQueue _queue;
+
+  List<ClassReminderRule> _rules = const [];
+  bool _permissionsGranted = false;
+  bool _initialized = false;
+  DateTime? _lastCleanup;
+
+  ClassReminderController({
+    required ClassReminderRepository repository,
+    required ScheduleProvider scheduleProvider,
+    required ScheduleSourceProvider sourceProvider,
+    required ClassReminderScheduler scheduler,
+    required NotificationApi Function() notificationApi,
+    DateTime Function()? now,
+  }) : _repository = repository,
+       _scheduleProvider = scheduleProvider,
+       _sourceProvider = sourceProvider,
+       _coordinator = ClassReminderCoordinator(
+         repository: repository,
+         scheduler: scheduler,
+         now: now,
+       ),
+       _notificationApi = notificationApi,
+       _now = now ?? DateTime.now {
+    _queue = ReminderSyncQueue(
+      reconcile: _processRequest,
+      currentGeneration: () => _sourceProvider.sourceGeneration,
+      onError: _reportQueueFailure,
+    );
+    _scheduleProvider.addScheduleUpdatedCallback(_scheduleUpdated);
+    _sourceProvider.addDidChangeScheduleSourceCallback(_sourceChanged);
+  }
+
+  bool get hasReminders => _rules.isNotEmpty;
+  bool get permissionsGranted => _permissionsGranted;
+  bool get remindersPaused => hasReminders && !_permissionsGranted;
+  ReminderSyncQueue get queue => _queue;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    _initialized = true;
+    await _cleanupIfNeeded(force: true);
+    await _reloadRules();
+    await refreshPermissionState(scheduleWhenRestored: false);
+    if (hasReminders && permissionsGranted) {
+      await reconcileUpcoming(waitForCompletion: true);
+    }
+  }
+
+  Future<void> onAppResumed() async {
+    await _cleanupIfNeeded();
+    await refreshPermissionState();
+  }
+
+  Future<void> refreshPermissionState({
+    bool scheduleWhenRestored = true,
+  }) async {
+    final previous = _permissionsGranted;
+    try {
+      final api = _notificationApi();
+      final results = await Future.wait([
+        api.areNotificationsEnabled(),
+        api.canScheduleExactNotifications(),
+      ]);
+      _permissionsGranted = results.every((granted) => granted);
+    } catch (_) {
+      _permissionsGranted = false;
+    }
+    if (previous != _permissionsGranted) notifyListeners();
+    if (scheduleWhenRestored &&
+        !previous &&
+        _permissionsGranted &&
+        hasReminders) {
+      await reconcileUpcoming(waitForCompletion: false);
+    }
+  }
+
+  Future<void> openReliablePermissionSettings() async {
+    try {
+      final api = _notificationApi();
+      if (!await api.areNotificationsEnabled()) {
+        await api.requestRuntimePermission();
+      }
+      if (!await api.canScheduleExactNotifications()) {
+        await api.requestExactAlarmPermission();
+      }
+    } finally {
+      await refreshPermissionState();
+    }
+  }
+
+  ClassReminderRule? ruleFor(ScheduleEntry entry) {
+    final canonical = CanonicalClassName.fromTitle(entry.title);
+    final recurring = _rules.where(
+      (rule) =>
+          rule.scope == ClassReminderScope.recurring &&
+          rule.canonicalTitle == canonical,
+    );
+    if (recurring.isNotEmpty) return recurring.first;
+    final oneTime = _rules.where(
+      (rule) =>
+          rule.scope == ClassReminderScope.oneTime &&
+          rule.canonicalTitle == canonical &&
+          rule.occurrenceStart == entry.start,
+    );
+    return oneTime.isEmpty ? null : oneTime.first;
+  }
+
+  Future<ReminderActivationResult> saveReminder({
+    required ScheduleEntry entry,
+    required Duration offset,
+    required ClassReminderScope scope,
+  }) async {
+    await refreshPermissionState(scheduleWhenRestored: false);
+    if (!_permissionsGranted)
+      return ReminderActivationResult.permissionsRequired;
+
+    final canonical = CanonicalClassName.fromTitle(entry.title);
+    await _removeApplicableRules(entry, canonical: canonical);
+    final rule = ClassReminderRule(
+      id: ClassReminderIdentity.ruleId(
+        scope: scope,
+        canonicalTitle: canonical,
+        sourceIdentity: _sourceProvider.currentSourceIdentity,
+        occurrenceStart: scope == ClassReminderScope.oneTime
+            ? entry.start
+            : null,
+      ),
+      scope: scope,
+      canonicalTitle: canonical,
+      offset: offset,
+      sourceIdentity: _sourceProvider.currentSourceIdentity,
+      occurrenceStart: scope == ClassReminderScope.oneTime ? entry.start : null,
+      occurrenceEnd: scope == ClassReminderScope.oneTime ? entry.end : null,
+    );
+    await _repository.saveRule(rule);
+    await _reloadRules();
+    await reconcileUpcoming(waitForCompletion: false);
+    return ReminderActivationResult.active;
+  }
+
+  Future<void> removeReminder(ScheduleEntry entry) async {
+    await _removeApplicableRules(
+      entry,
+      canonical: CanonicalClassName.fromTitle(entry.title),
+    );
+    await _reloadRules();
+    await reconcileUpcoming(waitForCompletion: false);
+  }
+
+  Future<void> reconcileUpcoming({required bool waitForCompletion}) async {
+    final now = _now();
+    final end = now.add(upcomingWindow);
+    final schedule = await _scheduleProvider.getCachedSchedule(now, end);
+    _enqueue(schedule, now, end);
+    if (waitForCompletion) await _queue.drain();
+  }
+
+  Future<void> _scheduleUpdated(
+    Schedule schedule,
+    DateTime start,
+    DateTime end,
+  ) async {
+    _enqueue(schedule, start, end);
+  }
+
+  void _sourceChanged(ScheduleSource _, bool setupSuccess) {
+    if (!setupSuccess) return;
+    unawaited(() async {
+      await _reloadRules();
+      if (hasReminders && permissionsGranted) {
+        await reconcileUpcoming(waitForCompletion: false);
+      }
+    }());
+  }
+
+  void _enqueue(Schedule schedule, DateTime start, DateTime end) {
+    _queue.enqueue(
+      ReminderSyncRequest(
+        schedule: schedule,
+        start: start,
+        end: end,
+        sourceIdentity: _sourceProvider.currentSourceIdentity,
+        sourceGeneration: _sourceProvider.sourceGeneration,
+      ),
+    );
+  }
+
+  Future<void> _processRequest(ReminderSyncRequest request) async {
+    await refreshPermissionState(scheduleWhenRestored: false);
+    if (!_permissionsGranted) {
+      await _coordinator.pauseWindow(
+        start: request.start,
+        end: request.end,
+        sourceIdentity: request.sourceIdentity,
+      );
+      return;
+    }
+
+    final queueWait = _now().difference(request.enqueuedAt);
+    await PerformanceTelemetry.instance.measureTask(
+      'schedule.reminders.reconcile',
+      args: {
+        'windowStart': _dateOnly(request.start),
+        'windowEnd': _dateOnly(request.end),
+        'queueWaitMs': queueWait.inMilliseconds,
+        'coalescedRequestCount': request.coalescedRequestCount,
+      },
+      action: (task) async {
+        final result = await _coordinator.reconcile(
+          schedule: request.schedule,
+          start: request.start,
+          end: request.end,
+          sourceIdentity: request.sourceIdentity,
+        );
+        task.setData('scheduleEntriesExamined', result.scheduleEntriesExamined);
+        task.setData('reminderRulesLoaded', result.reminderRulesLoaded);
+        task.setData('manifestRowsLoaded', result.manifestRowsLoaded);
+        task.setData('alarmsScheduled', result.alarmsScheduled);
+        task.setData('alarmsCancelled', result.alarmsCancelled);
+        task.setData('expiredRowsDeleted', result.expiredRowsDeleted);
+      },
+    );
+    await _reloadRules();
+  }
+
+  Future<void> _removeApplicableRules(
+    ScheduleEntry entry, {
+    required String canonical,
+  }) async {
+    final applicable = _rules.where(
+      (rule) =>
+          rule.canonicalTitle == canonical &&
+          (rule.scope == ClassReminderScope.recurring ||
+              rule.occurrenceStart == entry.start),
+    );
+    for (final rule in applicable.toList(growable: false)) {
+      await _repository.deleteRule(rule.id);
+    }
+  }
+
+  Future<void> _reloadRules() async {
+    final sourceIdentity = _sourceProvider.currentSourceIdentity;
+    _rules = sourceIdentity == 'none'
+        ? const []
+        : await _repository.loadRelevantRules(
+            sourceIdentity: sourceIdentity,
+            now: _now(),
+          );
+    notifyListeners();
+  }
+
+  Future<void> _cleanupIfNeeded({bool force = false}) async {
+    final now = _now();
+    if (!force &&
+        _lastCleanup != null &&
+        now.difference(_lastCleanup!) < resumeCleanupStaleness) {
+      return;
+    }
+    try {
+      await _repository.deleteExpired(now);
+      _lastCleanup = now;
+    } catch (error, trace) {
+      await _reportQueueFailure(error, trace);
+    }
+  }
+
+  Future<void> _reportQueueFailure(Object error, StackTrace trace) {
+    return AppDiagnostics.instance.reportCaughtException(
+      error,
+      trace,
+      message: 'Class reminder reconciliation failed',
+      tags: {'feature': 'class_reminders'},
+    );
+  }
+
+  String _dateOnly(DateTime value) =>
+      '${value.year.toString().padLeft(4, '0')}-${value.month.toString().padLeft(2, '0')}-${value.day.toString().padLeft(2, '0')}';
+
+  @override
+  void dispose() {
+    _scheduleProvider.removeScheduleUpdatedCallback(_scheduleUpdated);
+    _sourceProvider.removeDidChangeScheduleSourceCallback(_sourceChanged);
+    super.dispose();
+  }
+}

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -35,6 +35,7 @@ class ClassReminderController extends ChangeNotifier {
   bool _permissionsGranted = false;
   bool _initialized = false;
   DateTime? _lastCleanup;
+  String _activeSourceIdentity = 'none';
 
   ClassReminderController({
     required ClassReminderRepository repository,
@@ -76,6 +77,8 @@ class ClassReminderController extends ChangeNotifier {
     await refreshPermissionState(scheduleWhenRestored: false);
     if (hasReminders && permissionsGranted) {
       await reconcileUpcoming(waitForCompletion: true);
+    } else if (hasReminders) {
+      await _pauseSource(_activeSourceIdentity);
     }
   }
 
@@ -100,6 +103,9 @@ class ClassReminderController extends ChangeNotifier {
       _permissionsGranted = false;
     }
     if (previous != _permissionsGranted) notifyListeners();
+    if (previous && !_permissionsGranted && hasReminders) {
+      await _pauseSource(_activeSourceIdentity);
+    }
     if (scheduleWhenRestored &&
         !previous &&
         _permissionsGranted &&
@@ -183,12 +189,10 @@ class ClassReminderController extends ChangeNotifier {
 
   Future<void> clearForSourceChange() async {
     final sourceIdentity = _sourceProvider.currentSourceIdentity;
-    final manifest = await _repository.loadManifestForSource(sourceIdentity);
-    for (final row in manifest) {
-      await _scheduler.cancel(row.notificationId);
-    }
+    await _pauseSource(sourceIdentity);
     await _repository.clearSource(sourceIdentity);
     _rules = const [];
+    _activeSourceIdentity = 'none';
     notifyListeners();
   }
 
@@ -211,6 +215,12 @@ class ClassReminderController extends ChangeNotifier {
   void _sourceChanged(ScheduleSource _, bool setupSuccess) {
     if (!setupSuccess) return;
     unawaited(() async {
+      final previousIdentity = _activeSourceIdentity;
+      final currentIdentity = _sourceProvider.currentSourceIdentity;
+      if (previousIdentity != 'none' && previousIdentity != currentIdentity) {
+        await _pauseSource(previousIdentity);
+        await _repository.clearSource(previousIdentity);
+      }
       await _reloadRules();
       if (hasReminders && permissionsGranted) {
         await reconcileUpcoming(waitForCompletion: false);
@@ -285,6 +295,7 @@ class ClassReminderController extends ChangeNotifier {
 
   Future<void> _reloadRules() async {
     final sourceIdentity = _sourceProvider.currentSourceIdentity;
+    _activeSourceIdentity = sourceIdentity;
     _rules = sourceIdentity == 'none'
         ? const []
         : await _repository.loadRelevantRules(
@@ -292,6 +303,22 @@ class ClassReminderController extends ChangeNotifier {
             now: _now(),
           );
     notifyListeners();
+  }
+
+  Future<void> _pauseSource(String sourceIdentity) async {
+    if (sourceIdentity == 'none') return;
+    final manifest = await _repository.loadManifestForSource(sourceIdentity);
+    for (final row in manifest) {
+      await _scheduler.cancel(row.notificationId);
+    }
+    if (manifest.isNotEmpty) {
+      await _repository.applyManifestChanges(
+        upserts: const [],
+        removedOccurrenceIdentities: manifest
+            .map((row) => row.occurrenceIdentity)
+            .toList(growable: false),
+      );
+    }
   }
 
   Future<void> _cleanupIfNeeded({bool force = false}) async {

--- a/lib/schedule/reminders/class_reminder_coordinator.dart
+++ b/lib/schedule/reminders/class_reminder_coordinator.dart
@@ -255,15 +255,8 @@ class ClassReminderCoordinator {
       (entry) => entry.start == rule.occurrenceStart,
     );
     if (sameTime.isNotEmpty) return [sameTime.first];
-    if (candidates.isNotEmpty) {
-      candidates.sort(
-        (a, b) => a.start
-            .difference(rule.occurrenceStart!)
-            .abs()
-            .compareTo(b.start.difference(rule.occurrenceStart!).abs()),
-      );
-      return [candidates.first];
-    }
+    if (candidates.length == 1) return candidates;
+    if (candidates.isNotEmpty) return const [];
     final renamedAtSameTime = entries
         .where((entry) => entry.start == rule.occurrenceStart)
         .toList(growable: false);

--- a/lib/schedule/reminders/class_reminder_coordinator.dart
+++ b/lib/schedule/reminders/class_reminder_coordinator.dart
@@ -54,20 +54,16 @@ class ClassReminderCoordinator {
       sourceIdentity: sourceIdentity,
       now: now,
     );
-    if (rules.isEmpty) {
-      return ReminderReconciliationResult(
-        expiredRowsDeleted: expiredRowsDeleted,
-      );
-    }
-
-    final entries = schedule.entries
-        .where(
-          (entry) =>
-              entry.start.isBefore(end) &&
-              entry.end.isAfter(start) &&
-              entry.start.isAfter(now),
-        )
-        .toList(growable: false);
+    final entries = rules.isEmpty
+        ? const <ScheduleEntry>[]
+        : schedule.entries
+              .where(
+                (entry) =>
+                    entry.start.isBefore(end) &&
+                    entry.end.isAfter(start) &&
+                    entry.start.isAfter(now),
+              )
+              .toList(growable: false);
     final canonicalByEntry = <ScheduleEntry, String>{
       for (final entry in entries)
         entry: CanonicalClassName.fromTitle(entry.title),
@@ -186,16 +182,14 @@ class ClassReminderCoordinator {
     if (upserts.isNotEmpty || removals.isNotEmpty) {
       await _repository.applyManifestChanges(
         upserts: upserts,
-        removedOccurrenceIdentities: removals
-            .map((row) => row.occurrenceIdentity)
-            .toList(growable: false),
+        removals: removals,
       );
     }
-    for (final rule in movedOneTimeRules) {
-      await _repository.saveRule(rule);
-    }
-    for (final ruleId in removedOneTimeRuleIds) {
-      await _repository.deleteRule(ruleId);
+    if (movedOneTimeRules.isNotEmpty || removedOneTimeRuleIds.isNotEmpty) {
+      await _repository.applyRuleChanges(
+        upserts: movedOneTimeRules,
+        removedRuleIds: removedOneTimeRuleIds,
+      );
     }
 
     return ReminderReconciliationResult(
@@ -224,9 +218,7 @@ class ClassReminderCoordinator {
     if (existing.isNotEmpty) {
       await _repository.applyManifestChanges(
         upserts: const [],
-        removedOccurrenceIdentities: existing
-            .map((row) => row.occurrenceIdentity)
-            .toList(growable: false),
+        removals: existing,
       );
     }
     return existing.length;
@@ -259,19 +251,23 @@ class ClassReminderCoordinator {
         .where((entry) => canonicalByEntry[entry] == rule.canonicalTitle)
         .toList(growable: false);
     if (rule.occurrenceStart == null) return const [];
-    final sameTime = entries.where(
+    final sameTime = candidates.where(
       (entry) => entry.start == rule.occurrenceStart,
     );
     if (sameTime.isNotEmpty) return [sameTime.first];
-    if (candidates.isEmpty) return const [];
-
-    candidates.sort(
-      (a, b) => a.start
-          .difference(rule.occurrenceStart!)
-          .abs()
-          .compareTo(b.start.difference(rule.occurrenceStart!).abs()),
-    );
-    return [candidates.first];
+    if (candidates.isNotEmpty) {
+      candidates.sort(
+        (a, b) => a.start
+            .difference(rule.occurrenceStart!)
+            .abs()
+            .compareTo(b.start.difference(rule.occurrenceStart!).abs()),
+      );
+      return [candidates.first];
+    }
+    final renamedAtSameTime = entries
+        .where((entry) => entry.start == rule.occurrenceStart)
+        .toList(growable: false);
+    return renamedAtSameTime.length == 1 ? renamedAtSameTime : const [];
   }
 
   static String _manifestKey(ScheduledClassNotification row) =>

--- a/lib/schedule/reminders/class_reminder_coordinator.dart
+++ b/lib/schedule/reminders/class_reminder_coordinator.dart
@@ -24,6 +24,8 @@ class ReminderReconciliationResult {
 }
 
 class ClassReminderCoordinator {
+  static const Duration _oneTimeMoveWindow = Duration(days: 3);
+
   final ClassReminderRepositoryApi _repository;
   final ClassReminderScheduler _scheduler;
   final DateTime Function() _now;
@@ -73,15 +75,18 @@ class ClassReminderCoordinator {
     final movedOneTimeRules = <ClassReminderRule>[];
     final removedOneTimeRuleIds = <String>[];
     for (final rule in rules) {
+      final oneTimeMatch = rule.isOneTime
+          ? _matchOneTime(rule, entries, canonicalByEntry)
+          : null;
       final matches = rule.scope == ClassReminderScope.recurring
           ? entries
                 .where(
                   (entry) => canonicalByEntry[entry] == rule.canonicalTitle,
                 )
                 .toList(growable: false)
-          : _matchOneTime(rule, entries, canonicalByEntry, start, end);
+          : oneTimeMatch!.entries;
 
-      if (rule.isOneTime && matches.isEmpty) {
+      if (rule.isOneTime && matches.isEmpty && oneTimeMatch!.confirmedMissing) {
         final originalStart = rule.occurrenceStart;
         if (originalStart != null &&
             !originalStart.isBefore(start) &&
@@ -91,9 +96,25 @@ class ClassReminderCoordinator {
       }
 
       for (final entry in matches) {
+        final canonicalTitle = canonicalByEntry[entry]!;
+        if (rule.isOneTime &&
+            (rule.occurrenceStart != entry.start ||
+                rule.canonicalTitle != canonicalTitle)) {
+          movedOneTimeRules.add(
+            ClassReminderRule(
+              id: rule.id,
+              scope: rule.scope,
+              canonicalTitle: canonicalTitle,
+              offset: rule.offset,
+              sourceIdentity: rule.sourceIdentity,
+              occurrenceStart: entry.start,
+              occurrenceEnd: entry.end,
+            ),
+          );
+        }
+
         final scheduledTime = entry.start.subtract(rule.offset);
         if (!scheduledTime.isAfter(now)) continue;
-        final canonicalTitle = canonicalByEntry[entry]!;
         final occurrenceIdentity = ClassReminderIdentity.occurrence(
           canonicalTitle: canonicalTitle,
           occurrenceStart: entry.start,
@@ -112,7 +133,7 @@ class ClassReminderCoordinator {
           scheduledTime: scheduledTime,
           classStart: entry.start,
           contentFingerprint: contentFingerprint(
-            title: canonicalTitle,
+            title: entry.title,
             start: entry.start,
             room: entry.room,
             offset: rule.offset,
@@ -122,7 +143,7 @@ class ClassReminderCoordinator {
           manifest: manifest,
           request: ClassReminderNotificationRequest(
             notificationId: notificationId,
-            className: canonicalTitle,
+            className: entry.title,
             classStart: entry.start,
             scheduledTime: scheduledTime,
             offset: rule.offset,
@@ -130,22 +151,6 @@ class ClassReminderCoordinator {
             occurrenceIdentity: occurrenceIdentity,
           ),
         );
-
-        if (rule.isOneTime &&
-            (rule.occurrenceStart != entry.start ||
-                rule.canonicalTitle != canonicalTitle)) {
-          movedOneTimeRules.add(
-            ClassReminderRule(
-              id: rule.id,
-              scope: rule.scope,
-              canonicalTitle: canonicalTitle,
-              offset: rule.offset,
-              sourceIdentity: rule.sourceIdentity,
-              occurrenceStart: entry.start,
-              occurrenceEnd: entry.end,
-            ),
-          );
-        }
       }
     }
 
@@ -240,27 +245,53 @@ class ClassReminderCoordinator {
     return hash.toRadixString(16).padLeft(8, '0');
   }
 
-  List<ScheduleEntry> _matchOneTime(
+  _OneTimeMatchResult _matchOneTime(
     ClassReminderRule rule,
     List<ScheduleEntry> entries,
     Map<ScheduleEntry, String> canonicalByEntry,
-    DateTime windowStart,
-    DateTime windowEnd,
   ) {
     final candidates = entries
         .where((entry) => canonicalByEntry[entry] == rule.canonicalTitle)
         .toList(growable: false);
-    if (rule.occurrenceStart == null) return const [];
-    final sameTime = candidates.where(
-      (entry) => entry.start == rule.occurrenceStart,
-    );
-    if (sameTime.isNotEmpty) return [sameTime.first];
-    if (candidates.length == 1) return candidates;
-    if (candidates.isNotEmpty) return const [];
+    final originalStart = rule.occurrenceStart;
+    if (originalStart == null) {
+      return const _OneTimeMatchResult(confirmedMissing: true);
+    }
+    final sameTime = candidates.where((entry) => entry.start == originalStart);
+    if (sameTime.isNotEmpty) {
+      return _OneTimeMatchResult(entries: [sameTime.first]);
+    }
+
     final renamedAtSameTime = entries
-        .where((entry) => entry.start == rule.occurrenceStart)
+        .where((entry) => entry.start == originalStart)
         .toList(growable: false);
-    return renamedAtSameTime.length == 1 ? renamedAtSameTime : const [];
+    if (renamedAtSameTime.length == 1) {
+      return _OneTimeMatchResult(entries: renamedAtSameTime);
+    }
+
+    if (candidates.isEmpty) {
+      return const _OneTimeMatchResult(confirmedMissing: true);
+    }
+
+    final sorted = List<ScheduleEntry>.from(candidates)
+      ..sort(
+        (left, right) => left.start
+            .difference(originalStart)
+            .abs()
+            .compareTo(right.start.difference(originalStart).abs()),
+      );
+    final nearestDistance = sorted.first.start.difference(originalStart).abs();
+    final tied =
+        sorted.length > 1 &&
+        sorted[1].start.difference(originalStart).abs() == nearestDistance;
+    if (!tied && nearestDistance <= _oneTimeMoveWindow) {
+      return _OneTimeMatchResult(entries: [sorted.first]);
+    }
+
+    // Preserve the rule when there are plausible same-title occurrences but
+    // no unique safe rematch. A later authoritative refresh may disambiguate
+    // it; silently deleting it would be irreversible.
+    return const _OneTimeMatchResult();
   }
 
   static String _manifestKey(ScheduledClassNotification row) =>
@@ -281,4 +312,14 @@ class _DesiredNotification {
   final ClassReminderNotificationRequest request;
 
   const _DesiredNotification({required this.manifest, required this.request});
+}
+
+class _OneTimeMatchResult {
+  final List<ScheduleEntry> entries;
+  final bool confirmedMissing;
+
+  const _OneTimeMatchResult({
+    this.entries = const [],
+    this.confirmedMissing = false,
+  });
 }

--- a/lib/schedule/reminders/class_reminder_coordinator.dart
+++ b/lib/schedule/reminders/class_reminder_coordinator.dart
@@ -135,7 +135,9 @@ class ClassReminderCoordinator {
           ),
         );
 
-        if (rule.isOneTime && rule.occurrenceStart != entry.start) {
+        if (rule.isOneTime &&
+            (rule.occurrenceStart != entry.start ||
+                rule.canonicalTitle != canonicalTitle)) {
           movedOneTimeRules.add(
             ClassReminderRule(
               id: rule.id,
@@ -256,7 +258,12 @@ class ClassReminderCoordinator {
     final candidates = entries
         .where((entry) => canonicalByEntry[entry] == rule.canonicalTitle)
         .toList(growable: false);
-    if (candidates.isEmpty || rule.occurrenceStart == null) return const [];
+    if (rule.occurrenceStart == null) return const [];
+    final sameTime = entries.where(
+      (entry) => entry.start == rule.occurrenceStart,
+    );
+    if (sameTime.isNotEmpty) return [sameTime.first];
+    if (candidates.isEmpty) return const [];
 
     candidates.sort(
       (a, b) => a.start

--- a/lib/schedule/reminders/class_reminder_coordinator.dart
+++ b/lib/schedule/reminders/class_reminder_coordinator.dart
@@ -1,0 +1,288 @@
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/canonical_class_name.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+
+class ReminderReconciliationResult {
+  final int scheduleEntriesExamined;
+  final int reminderRulesLoaded;
+  final int manifestRowsLoaded;
+  final int alarmsScheduled;
+  final int alarmsCancelled;
+  final int expiredRowsDeleted;
+
+  const ReminderReconciliationResult({
+    this.scheduleEntriesExamined = 0,
+    this.reminderRulesLoaded = 0,
+    this.manifestRowsLoaded = 0,
+    this.alarmsScheduled = 0,
+    this.alarmsCancelled = 0,
+    this.expiredRowsDeleted = 0,
+  });
+}
+
+class ClassReminderCoordinator {
+  final ClassReminderRepositoryApi _repository;
+  final ClassReminderScheduler _scheduler;
+  final DateTime Function() _now;
+
+  ClassReminderCoordinator({
+    required ClassReminderRepositoryApi repository,
+    required ClassReminderScheduler scheduler,
+    DateTime Function()? now,
+  }) : _repository = repository,
+       _scheduler = scheduler,
+       _now = now ?? DateTime.now;
+
+  Future<ReminderReconciliationResult> reconcile({
+    required Schedule schedule,
+    required DateTime start,
+    required DateTime end,
+    required String sourceIdentity,
+  }) async {
+    final now = _now();
+    var expiredRowsDeleted = 0;
+    try {
+      expiredRowsDeleted = (await _repository.deleteExpired(now)).total;
+    } catch (_) {
+      // Cleanup is best-effort and must never block schedule reconciliation.
+    }
+
+    final rules = await _repository.loadRelevantRules(
+      sourceIdentity: sourceIdentity,
+      now: now,
+    );
+    if (rules.isEmpty) {
+      return ReminderReconciliationResult(
+        expiredRowsDeleted: expiredRowsDeleted,
+      );
+    }
+
+    final entries = schedule.entries
+        .where(
+          (entry) =>
+              entry.start.isBefore(end) &&
+              entry.end.isAfter(start) &&
+              entry.start.isAfter(now),
+        )
+        .toList(growable: false);
+    final canonicalByEntry = <ScheduleEntry, String>{
+      for (final entry in entries)
+        entry: CanonicalClassName.fromTitle(entry.title),
+    };
+
+    final desired = <String, _DesiredNotification>{};
+    final movedOneTimeRules = <ClassReminderRule>[];
+    final removedOneTimeRuleIds = <String>[];
+    for (final rule in rules) {
+      final matches = rule.scope == ClassReminderScope.recurring
+          ? entries
+                .where(
+                  (entry) => canonicalByEntry[entry] == rule.canonicalTitle,
+                )
+                .toList(growable: false)
+          : _matchOneTime(rule, entries, canonicalByEntry, start, end);
+
+      if (rule.isOneTime && matches.isEmpty) {
+        final originalStart = rule.occurrenceStart;
+        if (originalStart != null &&
+            !originalStart.isBefore(start) &&
+            originalStart.isBefore(end)) {
+          removedOneTimeRuleIds.add(rule.id);
+        }
+      }
+
+      for (final entry in matches) {
+        final scheduledTime = entry.start.subtract(rule.offset);
+        if (!scheduledTime.isAfter(now)) continue;
+        final canonicalTitle = canonicalByEntry[entry]!;
+        final occurrenceIdentity = ClassReminderIdentity.occurrence(
+          canonicalTitle: canonicalTitle,
+          occurrenceStart: entry.start,
+          sourceIdentity: sourceIdentity,
+        );
+        final notificationId = ClassReminderIdentity.notificationId(
+          ruleId: rule.id,
+          occurrenceStart: entry.start,
+          sourceIdentity: sourceIdentity,
+        );
+        final manifest = ScheduledClassNotification(
+          ruleId: rule.id,
+          occurrenceIdentity: occurrenceIdentity,
+          sourceIdentity: sourceIdentity,
+          notificationId: notificationId,
+          scheduledTime: scheduledTime,
+          classStart: entry.start,
+          contentFingerprint: contentFingerprint(
+            title: canonicalTitle,
+            start: entry.start,
+            room: entry.room,
+            offset: rule.offset,
+          ),
+        );
+        desired[_manifestKey(manifest)] = _DesiredNotification(
+          manifest: manifest,
+          request: ClassReminderNotificationRequest(
+            notificationId: notificationId,
+            className: canonicalTitle,
+            classStart: entry.start,
+            scheduledTime: scheduledTime,
+            offset: rule.offset,
+            room: entry.room,
+            occurrenceIdentity: occurrenceIdentity,
+          ),
+        );
+
+        if (rule.isOneTime && rule.occurrenceStart != entry.start) {
+          movedOneTimeRules.add(
+            ClassReminderRule(
+              id: rule.id,
+              scope: rule.scope,
+              canonicalTitle: canonicalTitle,
+              offset: rule.offset,
+              sourceIdentity: rule.sourceIdentity,
+              occurrenceStart: entry.start,
+              occurrenceEnd: entry.end,
+            ),
+          );
+        }
+      }
+    }
+
+    final existingRows = await _repository.loadManifestForWindow(
+      sourceIdentity: sourceIdentity,
+      start: start,
+      end: end,
+    );
+    final existing = {for (final row in existingRows) _manifestKey(row): row};
+    final removals = <ScheduledClassNotification>[];
+    final upserts = <ScheduledClassNotification>[];
+    final requests = <ClassReminderNotificationRequest>[];
+
+    for (final entry in existing.entries) {
+      final wanted = desired[entry.key]?.manifest;
+      if (wanted == null || !_manifestMatches(entry.value, wanted)) {
+        removals.add(entry.value);
+      }
+    }
+    for (final entry in desired.entries) {
+      final old = existing[entry.key];
+      if (old == null || !_manifestMatches(old, entry.value.manifest)) {
+        upserts.add(entry.value.manifest);
+        requests.add(entry.value.request);
+      }
+    }
+
+    for (final row in removals) {
+      await _scheduler.cancel(row.notificationId);
+    }
+    for (final request in requests) {
+      await _scheduler.schedule(request);
+    }
+    if (upserts.isNotEmpty || removals.isNotEmpty) {
+      await _repository.applyManifestChanges(
+        upserts: upserts,
+        removedOccurrenceIdentities: removals
+            .map((row) => row.occurrenceIdentity)
+            .toList(growable: false),
+      );
+    }
+    for (final rule in movedOneTimeRules) {
+      await _repository.saveRule(rule);
+    }
+    for (final ruleId in removedOneTimeRuleIds) {
+      await _repository.deleteRule(ruleId);
+    }
+
+    return ReminderReconciliationResult(
+      scheduleEntriesExamined: entries.length,
+      reminderRulesLoaded: rules.length,
+      manifestRowsLoaded: existingRows.length,
+      alarmsScheduled: requests.length,
+      alarmsCancelled: removals.length,
+      expiredRowsDeleted: expiredRowsDeleted,
+    );
+  }
+
+  Future<int> pauseWindow({
+    required DateTime start,
+    required DateTime end,
+    required String sourceIdentity,
+  }) async {
+    final existing = await _repository.loadManifestForWindow(
+      sourceIdentity: sourceIdentity,
+      start: start,
+      end: end,
+    );
+    for (final row in existing) {
+      await _scheduler.cancel(row.notificationId);
+    }
+    if (existing.isNotEmpty) {
+      await _repository.applyManifestChanges(
+        upserts: const [],
+        removedOccurrenceIdentities: existing
+            .map((row) => row.occurrenceIdentity)
+            .toList(growable: false),
+      );
+    }
+    return existing.length;
+  }
+
+  static String contentFingerprint({
+    required String title,
+    required DateTime start,
+    required String room,
+    required Duration offset,
+  }) {
+    final input =
+        '$title|${start.toUtc().millisecondsSinceEpoch}|$room|${offset.inMinutes}';
+    var hash = 0x811c9dc5;
+    for (final byte in input.codeUnits) {
+      hash ^= byte;
+      hash = (hash * 0x01000193) & 0xffffffff;
+    }
+    return hash.toRadixString(16).padLeft(8, '0');
+  }
+
+  List<ScheduleEntry> _matchOneTime(
+    ClassReminderRule rule,
+    List<ScheduleEntry> entries,
+    Map<ScheduleEntry, String> canonicalByEntry,
+    DateTime windowStart,
+    DateTime windowEnd,
+  ) {
+    final candidates = entries
+        .where((entry) => canonicalByEntry[entry] == rule.canonicalTitle)
+        .toList(growable: false);
+    if (candidates.isEmpty || rule.occurrenceStart == null) return const [];
+
+    candidates.sort(
+      (a, b) => a.start
+          .difference(rule.occurrenceStart!)
+          .abs()
+          .compareTo(b.start.difference(rule.occurrenceStart!).abs()),
+    );
+    return [candidates.first];
+  }
+
+  static String _manifestKey(ScheduledClassNotification row) =>
+      '${row.ruleId}|${row.occurrenceIdentity}';
+
+  static bool _manifestMatches(
+    ScheduledClassNotification old,
+    ScheduledClassNotification wanted,
+  ) =>
+      old.notificationId == wanted.notificationId &&
+      old.scheduledTime == wanted.scheduledTime &&
+      old.classStart == wanted.classStart &&
+      old.contentFingerprint == wanted.contentFingerprint;
+}
+
+class _DesiredNotification {
+  final ScheduledClassNotification manifest;
+  final ClassReminderNotificationRequest request;
+
+  const _DesiredNotification({required this.manifest, required this.request});
+}

--- a/lib/schedule/reminders/class_reminder_repository.dart
+++ b/lib/schedule/reminders/class_reminder_repository.dart
@@ -1,0 +1,206 @@
+import 'package:dualmate/common/data/database_access.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+
+class ExpiredReminderDeletionCount {
+  final int oneTimeRules;
+  final int manifestRows;
+
+  const ExpiredReminderDeletionCount({
+    required this.oneTimeRules,
+    required this.manifestRows,
+  });
+
+  int get total => oneTimeRules + manifestRows;
+}
+
+class ClassReminderRepository {
+  static const rulesTable = 'ClassReminderRules';
+  static const manifestTable = 'ScheduledClassNotifications';
+
+  final DatabaseAccess _database;
+
+  ClassReminderRepository(this._database);
+
+  Future<bool> hasAnyRules({String? sourceIdentity}) async {
+    final rows = await _database.queryRows(
+      rulesTable,
+      columns: const ['id'],
+      where: sourceIdentity == null ? null : 'sourceIdentity=?',
+      whereArgs: sourceIdentity == null ? null : [sourceIdentity],
+      limit: 1,
+    );
+    return rows.isNotEmpty;
+  }
+
+  Future<List<ClassReminderRule>> loadRelevantRules({
+    required String sourceIdentity,
+    required DateTime now,
+  }) async {
+    final rows = await _database.queryRows(
+      rulesTable,
+      where: 'sourceIdentity=? AND (scope=? OR occurrenceStart>?)',
+      whereArgs: [
+        sourceIdentity,
+        ClassReminderScope.recurring.index,
+        now.millisecondsSinceEpoch,
+      ],
+    );
+    return rows.map(_ruleFromMap).toList(growable: false);
+  }
+
+  Future<List<ClassReminderRule>> loadRulesForTitle({
+    required String sourceIdentity,
+    required String canonicalTitle,
+    required DateTime now,
+  }) async {
+    final rows = await _database.queryRows(
+      rulesTable,
+      where:
+          'sourceIdentity=? AND canonicalTitle=? AND (scope=? OR occurrenceStart>?)',
+      whereArgs: [
+        sourceIdentity,
+        canonicalTitle,
+        ClassReminderScope.recurring.index,
+        now.millisecondsSinceEpoch,
+      ],
+    );
+    return rows.map(_ruleFromMap).toList(growable: false);
+  }
+
+  Future<void> saveRule(ClassReminderRule rule) {
+    return _database.insertOrReplace(rulesTable, _ruleToMap(rule)).then((_) {});
+  }
+
+  Future<void> deleteRule(String ruleId) async {
+    await _database.deleteWhere(rulesTable, where: 'id=?', whereArgs: [ruleId]);
+  }
+
+  Future<List<ScheduledClassNotification>> loadManifestForWindow({
+    required String sourceIdentity,
+    required DateTime start,
+    required DateTime end,
+  }) async {
+    final rows = await _database.queryRows(
+      manifestTable,
+      where: 'sourceIdentity=? AND classStart>=? AND classStart<?',
+      whereArgs: [
+        sourceIdentity,
+        start.millisecondsSinceEpoch,
+        end.millisecondsSinceEpoch,
+      ],
+    );
+    return rows.map(_manifestFromMap).toList(growable: false);
+  }
+
+  Future<void> applyManifestChanges({
+    required List<ScheduledClassNotification> upserts,
+    required List<String> removedOccurrenceIdentities,
+  }) async {
+    if (removedOccurrenceIdentities.isNotEmpty) {
+      final placeholders = List.filled(
+        removedOccurrenceIdentities.length,
+        '?',
+      ).join(',');
+      await _database.deleteWhere(
+        manifestTable,
+        where: 'occurrenceIdentity IN ($placeholders)',
+        whereArgs: removedOccurrenceIdentities,
+      );
+    }
+    await _database.insertOrReplaceBatch(
+      manifestTable,
+      upserts.map(_manifestToMap).toList(growable: false),
+    );
+  }
+
+  Future<ExpiredReminderDeletionCount> deleteExpired(DateTime now) async {
+    final cutoff = now.millisecondsSinceEpoch;
+    final deletedRules = await _database.deleteWhere(
+      rulesTable,
+      where: 'scope=? AND occurrenceStart<=?',
+      whereArgs: [ClassReminderScope.oneTime.index, cutoff],
+    );
+    final deletedManifest = await _database.deleteWhere(
+      manifestTable,
+      where: 'classStart<=?',
+      whereArgs: [cutoff],
+    );
+    return ExpiredReminderDeletionCount(
+      oneTimeRules: deletedRules,
+      manifestRows: deletedManifest,
+    );
+  }
+
+  Future<void> clearSource(String sourceIdentity) async {
+    await Future.wait([
+      _database.deleteWhere(
+        rulesTable,
+        where: 'sourceIdentity=?',
+        whereArgs: [sourceIdentity],
+      ),
+      _database.deleteWhere(
+        manifestTable,
+        where: 'sourceIdentity=?',
+        whereArgs: [sourceIdentity],
+      ),
+    ]);
+  }
+
+  Future<void> clearAll() async {
+    await Future.wait([
+      _database.deleteWhere(rulesTable, where: '1=1'),
+      _database.deleteWhere(manifestTable, where: '1=1'),
+    ]);
+  }
+
+  ClassReminderRule _ruleFromMap(Map<String, dynamic> row) {
+    return ClassReminderRule(
+      id: row['id'] as String,
+      scope: ClassReminderScope.values[row['scope'] as int],
+      canonicalTitle: row['canonicalTitle'] as String,
+      offset: Duration(minutes: row['offsetMinutes'] as int),
+      sourceIdentity: row['sourceIdentity'] as String,
+      occurrenceStart: _optionalDate(row['occurrenceStart']),
+      occurrenceEnd: _optionalDate(row['occurrenceEnd']),
+    );
+  }
+
+  Map<String, dynamic> _ruleToMap(ClassReminderRule rule) => {
+    'id': rule.id,
+    'scope': rule.scope.index,
+    'canonicalTitle': rule.canonicalTitle,
+    'offsetMinutes': rule.offset.inMinutes,
+    'sourceIdentity': rule.sourceIdentity,
+    'occurrenceStart': rule.occurrenceStart?.millisecondsSinceEpoch,
+    'occurrenceEnd': rule.occurrenceEnd?.millisecondsSinceEpoch,
+  };
+
+  ScheduledClassNotification _manifestFromMap(Map<String, dynamic> row) {
+    return ScheduledClassNotification(
+      ruleId: row['ruleId'] as String,
+      occurrenceIdentity: row['occurrenceIdentity'] as String,
+      sourceIdentity: row['sourceIdentity'] as String,
+      notificationId: row['notificationId'] as int,
+      scheduledTime: DateTime.fromMillisecondsSinceEpoch(
+        row['scheduledTime'] as int,
+      ),
+      classStart: DateTime.fromMillisecondsSinceEpoch(row['classStart'] as int),
+      contentFingerprint: row['contentFingerprint'] as String,
+    );
+  }
+
+  Map<String, dynamic> _manifestToMap(ScheduledClassNotification row) => {
+    'ruleId': row.ruleId,
+    'occurrenceIdentity': row.occurrenceIdentity,
+    'sourceIdentity': row.sourceIdentity,
+    'notificationId': row.notificationId,
+    'scheduledTime': row.scheduledTime.millisecondsSinceEpoch,
+    'classStart': row.classStart.millisecondsSinceEpoch,
+    'contentFingerprint': row.contentFingerprint,
+  };
+
+  DateTime? _optionalDate(Object? milliseconds) {
+    if (milliseconds is! int) return null;
+    return DateTime.fromMillisecondsSinceEpoch(milliseconds);
+  }
+}

--- a/lib/schedule/reminders/class_reminder_repository.dart
+++ b/lib/schedule/reminders/class_reminder_repository.dart
@@ -1,5 +1,6 @@
 import 'package:dualmate/common/data/database_access.dart';
 import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:sqflite/sqflite.dart';
 
 class ExpiredReminderDeletionCount {
   final int oneTimeRules;
@@ -27,7 +28,12 @@ abstract interface class ClassReminderRepositoryApi {
 
   Future<void> applyManifestChanges({
     required List<ScheduledClassNotification> upserts,
-    required List<String> removedOccurrenceIdentities,
+    required List<ScheduledClassNotification> removals,
+  });
+
+  Future<void> applyRuleChanges({
+    required List<ClassReminderRule> upserts,
+    required List<String> removedRuleIds,
   });
 
   Future<ExpiredReminderDeletionCount> deleteExpired(DateTime now);
@@ -129,23 +135,49 @@ class ClassReminderRepository implements ClassReminderRepositoryApi {
 
   Future<void> applyManifestChanges({
     required List<ScheduledClassNotification> upserts,
-    required List<String> removedOccurrenceIdentities,
+    required List<ScheduledClassNotification> removals,
   }) async {
-    if (removedOccurrenceIdentities.isNotEmpty) {
-      final placeholders = List.filled(
-        removedOccurrenceIdentities.length,
-        '?',
-      ).join(',');
-      await _database.deleteWhere(
-        manifestTable,
-        where: 'occurrenceIdentity IN ($placeholders)',
-        whereArgs: removedOccurrenceIdentities,
-      );
-    }
-    await _database.insertOrReplaceBatch(
-      manifestTable,
-      upserts.map(_manifestToMap).toList(growable: false),
-    );
+    if (upserts.isEmpty && removals.isEmpty) return;
+    await _database.transaction((executor) async {
+      final batch = executor.batch();
+      for (final row in removals) {
+        batch.delete(
+          manifestTable,
+          where: 'ruleId=? AND occurrenceIdentity=?',
+          whereArgs: [row.ruleId, row.occurrenceIdentity],
+        );
+      }
+      for (final row in upserts) {
+        batch.insert(
+          manifestTable,
+          _manifestToMap(row),
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      }
+      await batch.commit(noResult: true);
+    });
+  }
+
+  @override
+  Future<void> applyRuleChanges({
+    required List<ClassReminderRule> upserts,
+    required List<String> removedRuleIds,
+  }) async {
+    if (upserts.isEmpty && removedRuleIds.isEmpty) return;
+    await _database.transaction((executor) async {
+      final batch = executor.batch();
+      for (final ruleId in removedRuleIds) {
+        batch.delete(rulesTable, where: 'id=?', whereArgs: [ruleId]);
+      }
+      for (final rule in upserts) {
+        batch.insert(
+          rulesTable,
+          _ruleToMap(rule),
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      }
+      await batch.commit(noResult: true);
+    });
   }
 
   Future<ExpiredReminderDeletionCount> deleteExpired(DateTime now) async {

--- a/lib/schedule/reminders/class_reminder_repository.dart
+++ b/lib/schedule/reminders/class_reminder_repository.dart
@@ -13,7 +13,31 @@ class ExpiredReminderDeletionCount {
   int get total => oneTimeRules + manifestRows;
 }
 
-class ClassReminderRepository {
+abstract interface class ClassReminderRepositoryApi {
+  Future<List<ClassReminderRule>> loadRelevantRules({
+    required String sourceIdentity,
+    required DateTime now,
+  });
+
+  Future<List<ScheduledClassNotification>> loadManifestForWindow({
+    required String sourceIdentity,
+    required DateTime start,
+    required DateTime end,
+  });
+
+  Future<void> applyManifestChanges({
+    required List<ScheduledClassNotification> upserts,
+    required List<String> removedOccurrenceIdentities,
+  });
+
+  Future<ExpiredReminderDeletionCount> deleteExpired(DateTime now);
+
+  Future<void> saveRule(ClassReminderRule rule);
+
+  Future<void> deleteRule(String ruleId);
+}
+
+class ClassReminderRepository implements ClassReminderRepositoryApi {
   static const rulesTable = 'ClassReminderRules';
   static const manifestTable = 'ScheduledClassNotifications';
 

--- a/lib/schedule/reminders/class_reminder_repository.dart
+++ b/lib/schedule/reminders/class_reminder_repository.dart
@@ -56,6 +56,17 @@ class ClassReminderRepository implements ClassReminderRepositoryApi {
     return rows.isNotEmpty;
   }
 
+  Future<List<ScheduledClassNotification>> loadManifestForSource(
+    String sourceIdentity,
+  ) async {
+    final rows = await _database.queryRows(
+      manifestTable,
+      where: 'sourceIdentity=?',
+      whereArgs: [sourceIdentity],
+    );
+    return rows.map(_manifestFromMap).toList(growable: false);
+  }
+
   Future<List<ClassReminderRule>> loadRelevantRules({
     required String sourceIdentity,
     required DateTime now,

--- a/lib/schedule/reminders/class_reminder_scheduler.dart
+++ b/lib/schedule/reminders/class_reminder_scheduler.dart
@@ -1,0 +1,25 @@
+class ClassReminderNotificationRequest {
+  final int notificationId;
+  final String className;
+  final DateTime classStart;
+  final DateTime scheduledTime;
+  final Duration offset;
+  final String room;
+  final String occurrenceIdentity;
+
+  const ClassReminderNotificationRequest({
+    required this.notificationId,
+    required this.className,
+    required this.classStart,
+    required this.scheduledTime,
+    required this.offset,
+    required this.room,
+    required this.occurrenceIdentity,
+  });
+}
+
+abstract interface class ClassReminderScheduler {
+  Future<void> schedule(ClassReminderNotificationRequest request);
+
+  Future<void> cancel(int notificationId);
+}

--- a/lib/schedule/reminders/platform_class_reminder_scheduler.dart
+++ b/lib/schedule/reminders/platform_class_reminder_scheduler.dart
@@ -7,8 +7,14 @@ import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
 
 class PlatformClassReminderScheduler implements ClassReminderScheduler {
   final NotificationApi Function() _notificationApi;
+  final Future<String?> Function() _languageCode;
 
-  PlatformClassReminderScheduler(this._notificationApi);
+  PlatformClassReminderScheduler(
+    this._notificationApi, {
+    Future<String?> Function()? languageCode,
+  }) : _languageCode =
+           languageCode ??
+           (() async => PlatformDispatcher.instance.locale.languageCode);
 
   @override
   Future<void> cancel(int notificationId) {
@@ -16,11 +22,14 @@ class PlatformClassReminderScheduler implements ClassReminderScheduler {
   }
 
   @override
-  Future<void> schedule(ClassReminderNotificationRequest request) {
-    final isGerman = PlatformDispatcher.instance.locale.languageCode == 'de';
-    final offsetText = request.offset.inMinutes == 60
-        ? (isGerman ? '1 Stunde' : '1 hour')
-        : '${request.offset.inMinutes} ${isGerman ? 'Minuten' : 'minutes'}';
+  Future<void> schedule(ClassReminderNotificationRequest request) async {
+    final isGerman =
+        (await _languageCode())?.split(RegExp('[-_]')).first == 'de';
+    final offsetText = switch (request.offset.inMinutes) {
+      60 => isGerman ? '1 Stunde' : '1 hour',
+      1 => isGerman ? '1 Minute' : '1 minute',
+      final minutes => '$minutes ${isGerman ? 'Minuten' : 'minutes'}',
+    };
     final title = isGerman
         ? '${request.className} beginnt in $offsetText'
         : '${request.className} starts in $offsetText';
@@ -30,7 +39,7 @@ class PlatformClassReminderScheduler implements ClassReminderScheduler {
     final body = isGerman
         ? 'Die Veranstaltung beginnt um $time${room.isEmpty ? '.' : ' in $room.'}'
         : 'The class begins at $time${room.isEmpty ? '.' : ' in $room.'}';
-    return _notificationApi().scheduleExactNotification(
+    await _notificationApi().scheduleExactNotification(
       id: request.notificationId,
       title: title,
       body: body,

--- a/lib/schedule/reminders/platform_class_reminder_scheduler.dart
+++ b/lib/schedule/reminders/platform_class_reminder_scheduler.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:dualmate/common/ui/notification_api.dart';
+import 'package:dualmate/common/util/widget_navigation_payload.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+
+class PlatformClassReminderScheduler implements ClassReminderScheduler {
+  final NotificationApi Function() _notificationApi;
+
+  PlatformClassReminderScheduler(this._notificationApi);
+
+  @override
+  Future<void> cancel(int notificationId) {
+    return _notificationApi().cancelNotification(notificationId);
+  }
+
+  @override
+  Future<void> schedule(ClassReminderNotificationRequest request) {
+    final isGerman = PlatformDispatcher.instance.locale.languageCode == 'de';
+    final offsetText = request.offset.inMinutes == 60
+        ? (isGerman ? '1 Stunde' : '1 hour')
+        : '${request.offset.inMinutes} ${isGerman ? 'Minuten' : 'minutes'}';
+    final title = isGerman
+        ? '${request.className} beginnt in $offsetText'
+        : '${request.className} starts in $offsetText';
+    final minute = request.classStart.minute.toString().padLeft(2, '0');
+    final time = '${request.classStart.hour}:$minute';
+    final room = request.room.trim();
+    final body = isGerman
+        ? 'Die Veranstaltung beginnt um $time${room.isEmpty ? '.' : ' in $room.'}'
+        : 'The class begins at $time${room.isEmpty ? '.' : ' in $room.'}';
+    return _notificationApi().scheduleExactNotification(
+      id: request.notificationId,
+      title: title,
+      body: body,
+      scheduledTime: request.scheduledTime,
+      payload: jsonEncode({
+        widgetScheduleEntryStart: request.classStart.millisecondsSinceEpoch,
+        widgetScheduleEntryTitle: request.className,
+        widgetScheduleDayStart: request.classStart.millisecondsSinceEpoch,
+      }),
+    );
+  }
+}

--- a/lib/schedule/reminders/platform_class_reminder_scheduler.dart
+++ b/lib/schedule/reminders/platform_class_reminder_scheduler.dart
@@ -23,8 +23,9 @@ class PlatformClassReminderScheduler implements ClassReminderScheduler {
 
   @override
   Future<void> schedule(ClassReminderNotificationRequest request) async {
-    final isGerman =
-        (await _languageCode())?.split(RegExp('[-_]')).first == 'de';
+    final languageCode = await _languageCode() ??
+        PlatformDispatcher.instance.locale.languageCode;
+    final isGerman = languageCode.split(RegExp('[-_]')).first == 'de';
     final offsetText = switch (request.offset.inMinutes) {
       60 => isGerman ? '1 Stunde' : '1 hour',
       1 => isGerman ? '1 Minute' : '1 minute',

--- a/lib/schedule/reminders/reminder_sync_queue.dart
+++ b/lib/schedule/reminders/reminder_sync_queue.dart
@@ -69,18 +69,25 @@ class ReminderSyncQueue {
   }
 
   Future<void> _process() async {
-    while (_pending.isNotEmpty) {
-      final request = _pending.removeAt(0);
-      if (request.sourceGeneration != _currentGeneration()) continue;
-      try {
-        await _reconcile(request);
-      } catch (error, trace) {
-        await _onError?.call(error, trace);
+    try {
+      while (_pending.isNotEmpty) {
+        final request = _pending.removeAt(0);
+        if (request.sourceGeneration != _currentGeneration()) continue;
+        try {
+          await _reconcile(request);
+        } catch (error, trace) {
+          try {
+            await _onError?.call(error, trace);
+          } catch (_) {
+            // Reporting must never wedge the serialized work queue.
+          }
+        }
       }
+    } finally {
+      _processing = false;
+      _idleCompleter?.complete();
+      _idleCompleter = null;
     }
-    _processing = false;
-    _idleCompleter?.complete();
-    _idleCompleter = null;
   }
 
   bool _overlaps(ReminderSyncRequest a, ReminderSyncRequest b) =>
@@ -88,7 +95,13 @@ class ReminderSyncQueue {
 
   ReminderSyncRequest _merge(ReminderSyncRequest a, ReminderSyncRequest b) {
     final entries = <String, ScheduleEntry>{};
-    for (final entry in [...a.schedule.entries, ...b.schedule.entries]) {
+    final overlapStart = a.start.isAfter(b.start) ? a.start : b.start;
+    final overlapEnd = a.end.isBefore(b.end) ? a.end : b.end;
+    final retainedOlderEntries = a.schedule.entries.where(
+      (entry) =>
+          !entry.start.isBefore(overlapEnd) || !entry.end.isAfter(overlapStart),
+    );
+    for (final entry in [...retainedOlderEntries, ...b.schedule.entries]) {
       final key =
           '${entry.start.toUtc().millisecondsSinceEpoch}|${entry.end.toUtc().millisecondsSinceEpoch}|${entry.title}';
       entries[key] = entry;

--- a/lib/schedule/reminders/reminder_sync_queue.dart
+++ b/lib/schedule/reminders/reminder_sync_queue.dart
@@ -30,7 +30,7 @@ class ReminderSyncQueue {
   final ReminderReconcileCallback _reconcile;
   final int Function() _currentGeneration;
   final Future<void> Function(Object error, StackTrace trace)? _onError;
-  final List<ReminderSyncRequest> _pending = [];
+  final List<Object> _pending = [];
   bool _processing = false;
   Completer<void>? _idleCompleter;
 
@@ -45,17 +45,26 @@ class ReminderSyncQueue {
   bool get isIdle => !_processing && _pending.isEmpty;
 
   void enqueue(ReminderSyncRequest request) {
-    final mergeIndex = _pending.indexWhere(
-      (pending) =>
-          pending.sourceGeneration == request.sourceGeneration &&
-          pending.sourceIdentity == request.sourceIdentity &&
-          _overlaps(pending, request),
-    );
+    final mergeIndex = _mergeIndex(request);
     if (mergeIndex >= 0) {
-      _pending[mergeIndex] = _merge(_pending[mergeIndex], request);
+      _pending[mergeIndex] = _merge(
+        _pending[mergeIndex] as ReminderSyncRequest,
+        request,
+      );
     } else {
       _pending.add(request);
     }
+    _startProcessing();
+  }
+
+  Future<void> runSerialized(Future<void> Function() operation) {
+    final completer = Completer<void>();
+    _pending.add(_SerializedReminderWork(operation, completer));
+    _startProcessing();
+    return completer.future;
+  }
+
+  void _startProcessing() {
     _idleCompleter ??= Completer<void>();
     if (!_processing) {
       _processing = true;
@@ -71,7 +80,17 @@ class ReminderSyncQueue {
   Future<void> _process() async {
     try {
       while (_pending.isNotEmpty) {
-        final request = _pending.removeAt(0);
+        final work = _pending.removeAt(0);
+        if (work is _SerializedReminderWork) {
+          try {
+            await work.operation();
+            work.completer.complete();
+          } catch (error, trace) {
+            work.completer.completeError(error, trace);
+          }
+          continue;
+        }
+        final request = work as ReminderSyncRequest;
         if (request.sourceGeneration != _currentGeneration()) continue;
         try {
           await _reconcile(request);
@@ -88,6 +107,20 @@ class ReminderSyncQueue {
       _idleCompleter?.complete();
       _idleCompleter = null;
     }
+  }
+
+  int _mergeIndex(ReminderSyncRequest request) {
+    for (var index = _pending.length - 1; index >= 0; index--) {
+      final pending = _pending[index];
+      if (pending is _SerializedReminderWork) break;
+      final pendingRequest = pending as ReminderSyncRequest;
+      if (pendingRequest.sourceGeneration == request.sourceGeneration &&
+          pendingRequest.sourceIdentity == request.sourceIdentity &&
+          _overlaps(pendingRequest, request)) {
+        return index;
+      }
+    }
+    return -1;
   }
 
   bool _overlaps(ReminderSyncRequest a, ReminderSyncRequest b) =>
@@ -118,4 +151,11 @@ class ReminderSyncQueue {
           : b.enqueuedAt,
     );
   }
+}
+
+class _SerializedReminderWork {
+  final Future<void> Function() operation;
+  final Completer<void> completer;
+
+  const _SerializedReminderWork(this.operation, this.completer);
 }

--- a/lib/schedule/reminders/reminder_sync_queue.dart
+++ b/lib/schedule/reminders/reminder_sync_queue.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+
+class ReminderSyncRequest {
+  final Schedule schedule;
+  final DateTime start;
+  final DateTime end;
+  final String sourceIdentity;
+  final int sourceGeneration;
+  final int coalescedRequestCount;
+  final DateTime enqueuedAt;
+
+  ReminderSyncRequest({
+    required this.schedule,
+    required this.start,
+    required this.end,
+    required this.sourceIdentity,
+    required this.sourceGeneration,
+    this.coalescedRequestCount = 1,
+    DateTime? enqueuedAt,
+  }) : enqueuedAt = enqueuedAt ?? DateTime.now();
+}
+
+typedef ReminderReconcileCallback =
+    Future<void> Function(ReminderSyncRequest request);
+
+class ReminderSyncQueue {
+  final ReminderReconcileCallback _reconcile;
+  final int Function() _currentGeneration;
+  final Future<void> Function(Object error, StackTrace trace)? _onError;
+  final List<ReminderSyncRequest> _pending = [];
+  bool _processing = false;
+  Completer<void>? _idleCompleter;
+
+  ReminderSyncQueue({
+    required ReminderReconcileCallback reconcile,
+    required int Function() currentGeneration,
+    Future<void> Function(Object error, StackTrace trace)? onError,
+  }) : _reconcile = reconcile,
+       _currentGeneration = currentGeneration,
+       _onError = onError;
+
+  bool get isIdle => !_processing && _pending.isEmpty;
+
+  void enqueue(ReminderSyncRequest request) {
+    final mergeIndex = _pending.indexWhere(
+      (pending) =>
+          pending.sourceGeneration == request.sourceGeneration &&
+          pending.sourceIdentity == request.sourceIdentity &&
+          _overlaps(pending, request),
+    );
+    if (mergeIndex >= 0) {
+      _pending[mergeIndex] = _merge(_pending[mergeIndex], request);
+    } else {
+      _pending.add(request);
+    }
+    _idleCompleter ??= Completer<void>();
+    if (!_processing) {
+      _processing = true;
+      unawaited(_process());
+    }
+  }
+
+  Future<void> drain() async {
+    if (isIdle) return;
+    await _idleCompleter?.future;
+  }
+
+  Future<void> _process() async {
+    while (_pending.isNotEmpty) {
+      final request = _pending.removeAt(0);
+      if (request.sourceGeneration != _currentGeneration()) continue;
+      try {
+        await _reconcile(request);
+      } catch (error, trace) {
+        await _onError?.call(error, trace);
+      }
+    }
+    _processing = false;
+    _idleCompleter?.complete();
+    _idleCompleter = null;
+  }
+
+  bool _overlaps(ReminderSyncRequest a, ReminderSyncRequest b) =>
+      !a.end.isBefore(b.start) && !b.end.isBefore(a.start);
+
+  ReminderSyncRequest _merge(ReminderSyncRequest a, ReminderSyncRequest b) {
+    final entries = <String, ScheduleEntry>{};
+    for (final entry in [...a.schedule.entries, ...b.schedule.entries]) {
+      final key =
+          '${entry.start.toUtc().millisecondsSinceEpoch}|${entry.end.toUtc().millisecondsSinceEpoch}|${entry.title}';
+      entries[key] = entry;
+    }
+    return ReminderSyncRequest(
+      schedule: Schedule.fromList(entries.values.toList(growable: false)),
+      start: a.start.isBefore(b.start) ? a.start : b.start,
+      end: a.end.isAfter(b.end) ? a.end : b.end,
+      sourceIdentity: a.sourceIdentity,
+      sourceGeneration: a.sourceGeneration,
+      coalescedRequestCount: a.coalescedRequestCount + b.coalescedRequestCount,
+      enqueuedAt: a.enqueuedAt.isBefore(b.enqueuedAt)
+          ? a.enqueuedAt
+          : b.enqueuedAt,
+    );
+  }
+}

--- a/lib/schedule/service/schedule_prettifier.dart
+++ b/lib/schedule/service/schedule_prettifier.dart
@@ -25,9 +25,10 @@ class SchedulePrettifier {
     // begins with "Online - " it implies that it is online
     // In this case remove the online prefix and set the type correctly
 
-    final newTitle = CanonicalClassName.removeOnlineMarker(entry.title).trim();
+    final withoutMarker = CanonicalClassName.removeOnlineMarker(entry.title);
+    final newTitle = withoutMarker.trim();
 
-    if (newTitle == entry.title) {
+    if (withoutMarker == entry.title) {
       return entry;
     }
 
@@ -42,7 +43,10 @@ class SchedulePrettifier {
 
     final prefix = CanonicalClassName.courseCodePrefix(title);
     if (prefix == null) return entry;
-    details = '$prefix - $details';
+    final normalizedPrefix = prefix.replaceFirst(RegExp(r'\s*-\s*$'), '');
+    details = details.trim().isEmpty
+        ? normalizedPrefix
+        : '$normalizedPrefix - $details';
     title = CanonicalClassName.removeCourseCodePrefix(title).trim();
 
     return entry.copyWith(title: title, details: details);

--- a/lib/schedule/service/schedule_prettifier.dart
+++ b/lib/schedule/service/schedule_prettifier.dart
@@ -1,10 +1,8 @@
 import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/canonical_class_name.dart';
 
 class SchedulePrettifier {
-  final RegExp onlinePrefixRegExp = RegExp(r'\(?online\)?([ -]*)', caseSensitive: false);
-  final RegExp onlineSuffixRegExp = RegExp(r'([ -]*)\(?online\)?', caseSensitive: false);
-
   Schedule prettifySchedule(Schedule schedule) {
     var allEntries = <ScheduleEntry>[];
 
@@ -27,9 +25,7 @@ class SchedulePrettifier {
     // begins with "Online - " it implies that it is online
     // In this case remove the online prefix and set the type correctly
 
-    var newTitle = entry.title;
-    newTitle = newTitle.replaceFirst(onlinePrefixRegExp, "");
-    newTitle = newTitle.replaceFirst(onlineSuffixRegExp, "");
+    final newTitle = CanonicalClassName.removeOnlineMarker(entry.title).trim();
 
     if (newTitle == entry.title) {
       return entry;
@@ -44,34 +40,10 @@ class SchedulePrettifier {
     var title = entry.title;
     var details = entry.details;
 
-    var titleRegex =
-    RegExp("[A-Z]{3,}-?[A-Z]+[0-9]*[A-Z]*[0-9]*[\/]?[A-Z]*[0-9]*[ ]*-?");
-    var match = titleRegex.firstMatch(entry.title);
-
-    if (match != null && match.start == 0) {
-      details = title.substring(0, match.end) + " - $details";
-      title = title.substring(match.end).trim();
-    } else {
-      var first = title
-          .split(" ")
-          .first;
-
-      // Prettify titles: T3MB9025 Fluidmechanik -> Fluidmechanik
-
-      // The title can not be prettified, if the first word is not only uppercase
-      // or less than 2 charcters long
-      if (!(first == first.toUpperCase() && first.length >= 3)) return entry;
-
-      var numberCount = first
-          .split(new RegExp("[0-9]"))
-          .length;
-
-      // If there are less thant two numbers in the title, do not prettify it
-      if (numberCount < 2) return entry;
-
-      details = title.substring(0, first.length) + " - $details";
-      title = title.substring(first.length).trim();
-    }
+    final prefix = CanonicalClassName.courseCodePrefix(title);
+    if (prefix == null) return entry;
+    details = '$prefix - $details';
+    title = CanonicalClassName.removeCourseCodePrefix(title).trim();
 
     return entry.copyWith(title: title, details: details);
   }

--- a/lib/schedule/ui/schedule_page.dart
+++ b/lib/schedule/ui/schedule_page.dart
@@ -150,25 +150,7 @@ class _SchedulePageState extends State<SchedulePage> {
     final container = KiwiContainer();
     if (!container.isRegistered<ClassReminderController>()) return child;
     final controller = container.resolve<ClassReminderController>();
-    return AnimatedBuilder(
-      animation: controller,
-      child: child,
-      builder: (context, schedule) {
-        if (!controller.remindersPaused) return schedule!;
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 12),
-              child: ClassReminderPausedNotice(
-                onFixPermissions: controller.openReliablePermissionSettings,
-              ),
-            ),
-            Expanded(child: schedule!),
-          ],
-        );
-      },
-    );
+    return ClassReminderPauseAwareContent(controller: controller, child: child);
   }
 
   @override
@@ -300,5 +282,54 @@ class _SchedulePageState extends State<SchedulePage> {
         debugLabel: 'schedule.filterWarmup',
       );
     });
+  }
+}
+
+class ClassReminderPauseAwareContent extends StatelessWidget {
+  final ClassReminderController controller;
+  final Widget child;
+
+  const ClassReminderPauseAwareContent({
+    super.key,
+    required this.controller,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: controller,
+      child: child,
+      builder: (context, schedule) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ClipRect(
+              child: AnimatedAlign(
+                duration: const Duration(milliseconds: 180),
+                curve: Curves.easeOutCubic,
+                alignment: Alignment.topCenter,
+                heightFactor: controller.remindersPaused ? 1 : 0,
+                child: IgnorePointer(
+                  ignoring: !controller.remindersPaused,
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 120),
+                    opacity: controller.remindersPaused ? 1 : 0,
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 12),
+                      child: ClassReminderPausedNotice(
+                        onFixPermissions:
+                            controller.openReliablePermissionSettings,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Expanded(child: schedule!),
+          ],
+        );
+      },
+    );
   }
 }

--- a/lib/schedule/ui/schedule_page.dart
+++ b/lib/schedule/ui/schedule_page.dart
@@ -11,6 +11,7 @@ import 'package:dualmate/schedule/ui/weeklyschedule/weekly_schedule_page.dart';
 import 'package:dualmate/schedule/ui/widgets/schedule_empty_state.dart';
 import 'package:dualmate/schedule/ui/widgets/schedule_empty_state_placeholder.dart';
 import 'package:dualmate/schedule/ui/widgets/select_source_dialog.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:dualmate/ui/banner_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -138,9 +139,66 @@ class _SchedulePageState extends State<SchedulePage> {
             );
           }
 
-          return weeklyPage;
+          return _withReminderState(weeklyPage);
         },
       ),
+    );
+  }
+
+  Widget _withReminderState(Widget child) {
+    final container = KiwiContainer();
+    if (!container.isRegistered<ClassReminderController>()) return child;
+    final controller = container.resolve<ClassReminderController>();
+    return AnimatedBuilder(
+      animation: controller,
+      child: child,
+      builder: (context, schedule) {
+        if (!controller.remindersPaused) return schedule!;
+        final colors = Theme.of(context).colorScheme;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Material(
+              color: colors.tertiaryContainer,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 12, 12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      Icons.notifications_paused_outlined,
+                      color: colors.onTertiaryContainer,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            L.of(context).classReminderPausedTitle,
+                            style: Theme.of(context).textTheme.titleSmall
+                                ?.copyWith(color: colors.onTertiaryContainer),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            L.of(context).classReminderPausedMessage,
+                            style: TextStyle(color: colors.onTertiaryContainer),
+                          ),
+                        ],
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: controller.openReliablePermissionSettings,
+                      child: Text(L.of(context).classReminderFixPermissions),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Expanded(child: schedule!),
+          ],
+        );
+      },
     );
   }
 

--- a/lib/schedule/ui/schedule_page.dart
+++ b/lib/schedule/ui/schedule_page.dart
@@ -4,14 +4,15 @@ import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:dualmate/schedule/ui/viewmodels/schedule_view_model.dart';
 import 'package:dualmate/schedule/ui/viewmodels/weekly_schedule_view_model.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/filter/filter_view_model.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/weekly_schedule_page.dart';
+import 'package:dualmate/schedule/ui/widgets/class_reminder_paused_notice.dart';
 import 'package:dualmate/schedule/ui/widgets/schedule_empty_state.dart';
 import 'package:dualmate/schedule/ui/widgets/schedule_empty_state_placeholder.dart';
 import 'package:dualmate/schedule/ui/widgets/select_source_dialog.dart';
-import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:dualmate/ui/banner_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -154,45 +155,13 @@ class _SchedulePageState extends State<SchedulePage> {
       child: child,
       builder: (context, schedule) {
         if (!controller.remindersPaused) return schedule!;
-        final colors = Theme.of(context).colorScheme;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Material(
-              color: colors.tertiaryContainer,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 12, 12, 12),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Icon(
-                      Icons.notifications_paused_outlined,
-                      color: colors.onTertiaryContainer,
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            L.of(context).classReminderPausedTitle,
-                            style: Theme.of(context).textTheme.titleSmall
-                                ?.copyWith(color: colors.onTertiaryContainer),
-                          ),
-                          const SizedBox(height: 2),
-                          Text(
-                            L.of(context).classReminderPausedMessage,
-                            style: TextStyle(color: colors.onTertiaryContainer),
-                          ),
-                        ],
-                      ),
-                    ),
-                    TextButton(
-                      onPressed: controller.openReliablePermissionSettings,
-                      child: Text(L.of(context).classReminderFixPermissions),
-                    ),
-                  ],
-                ),
+            Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: ClassReminderPausedNotice(
+                onFixPermissions: controller.openReliablePermissionSettings,
               ),
             ),
             Expanded(child: schedule!),

--- a/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
@@ -32,6 +32,7 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
   bool _isHandlingPop = false;
   bool _didInitializeViewModel = false;
   ClassReminderController? _reminderController;
+  Future<void>? _pendingDisplayChange;
 
   @override
   void initState() {
@@ -237,6 +238,7 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
       if (!_didInitializeViewModel || _hasInitError) {
         return;
       }
+      await _pendingDisplayChange;
       didChangeFilters = await _viewModel.applyFilter();
       applySucceeded = true;
     } on FilterValidationException catch (e, trace) {
@@ -266,6 +268,17 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
   }
 
   Future<bool> _handleDisplayChange(
+    ScheduleEntryFilterState state,
+    bool displayed,
+  ) {
+    final future = _doDisplayChange(state, displayed);
+    if (!displayed) {
+      _pendingDisplayChange = future.then((_) {}).catchError((_) {});
+    }
+    return future;
+  }
+
+  Future<bool> _doDisplayChange(
     ScheduleEntryFilterState state,
     bool displayed,
   ) async {
@@ -310,6 +323,8 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
     if (choice == _HiddenReminderChoice.remove) {
       try {
         await reminders.removeRemindersForTitle(state.entryName);
+        // Update the model even if the row widget is already disposed.
+        state.isDisplayed = false;
       } catch (error, trace) {
         debugPrint('Failed to remove reminders for hidden class: $error');
         debugPrint('$trace');

--- a/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/filter/filter_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -9,8 +12,13 @@ import 'package:property_change_notifier/property_change_notifier.dart';
 
 class ScheduleFilterPage extends StatefulWidget {
   final Future<void>? preloadFuture;
+  final ClassReminderController? reminderController;
 
-  const ScheduleFilterPage({super.key, this.preloadFuture});
+  const ScheduleFilterPage({
+    super.key,
+    this.preloadFuture,
+    this.reminderController,
+  });
 
   @override
   State<ScheduleFilterPage> createState() => _ScheduleFilterPageState();
@@ -23,6 +31,7 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
   bool _hasInitError = false;
   bool _isHandlingPop = false;
   bool _didInitializeViewModel = false;
+  ClassReminderController? _reminderController;
 
   @override
   void initState() {
@@ -31,6 +40,12 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
       KiwiContainer().resolve<ScheduleEntryRepository>(),
       KiwiContainer().resolve<ScheduleFilterRepository>(),
     );
+    _reminderController = widget.reminderController;
+    final container = KiwiContainer();
+    if (_reminderController == null &&
+        container.isRegistered<ClassReminderController>()) {
+      _reminderController = container.resolve<ClassReminderController>();
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeDeferred();
     });
@@ -108,52 +123,78 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
               child: _isLoading
                   ? const Center(child: CircularProgressIndicator())
                   : _hasInitError
-                      ? _buildInitErrorState(context)
-                      : Stack(
-                          fit: StackFit.expand,
-                          children: [
-                            PropertyChangeProvider<FilterViewModel, String>(
-                              value: _viewModel,
-                              child: PropertyChangeConsumer<FilterViewModel,
-                                  String>(
+                  ? _buildInitErrorState(context)
+                  : Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        PropertyChangeProvider<FilterViewModel, String>(
+                          value: _viewModel,
+                          child:
+                              PropertyChangeConsumer<FilterViewModel, String>(
                                 properties: const ["filterStates"],
-                                builder: (
-                                  BuildContext _,
-                                  FilterViewModel? viewModel,
-                                  Set<String>? ___,
-                                ) {
-                                  if (viewModel == null) return Container();
-                                  return AnimatedSlide(
-                                    duration: const Duration(milliseconds: 220),
-                                    curve: Curves.easeOutCubic,
-                                    offset: _showLoadedList
-                                        ? Offset.zero
-                                        : const Offset(0, 0.03),
-                                    child: AnimatedOpacity(
-                                      duration:
-                                          const Duration(milliseconds: 220),
-                                      curve: Curves.easeOutCubic,
-                                      opacity: _showLoadedList ? 1 : 0,
-                                      child: ListView.builder(
-                                        itemCount:
-                                            viewModel.filterStates.length,
-                                        itemExtent: 56,
-                                        scrollCacheExtent: const ScrollCacheExtent.pixels(320),
-                                        itemBuilder: (context, index) =>
-                                            FilterStateRow(
-                                                viewModel.filterStates[index]),
-                                      ),
-                                    ),
-                                  );
-                                },
+                                builder:
+                                    (
+                                      BuildContext _,
+                                      FilterViewModel? viewModel,
+                                      Set<String>? ___,
+                                    ) {
+                                      if (viewModel == null) return Container();
+                                      Widget buildList() => AnimatedSlide(
+                                        duration: const Duration(
+                                          milliseconds: 220,
+                                        ),
+                                        curve: Curves.easeOutCubic,
+                                        offset: _showLoadedList
+                                            ? Offset.zero
+                                            : const Offset(0, 0.03),
+                                        child: AnimatedOpacity(
+                                          duration: const Duration(
+                                            milliseconds: 220,
+                                          ),
+                                          curve: Curves.easeOutCubic,
+                                          opacity: _showLoadedList ? 1 : 0,
+                                          child: ListView.builder(
+                                            itemCount:
+                                                viewModel.filterStates.length,
+                                            itemExtent: 56,
+                                            scrollCacheExtent:
+                                                const ScrollCacheExtent.pixels(
+                                                  320,
+                                                ),
+                                            itemBuilder: (context, index) {
+                                              final state =
+                                                  viewModel.filterStates[index];
+                                              return FilterStateRow(
+                                                state,
+                                                hasReminder:
+                                                    _reminderController
+                                                        ?.hasReminderForTitle(
+                                                          state.entryName,
+                                                        ) ??
+                                                    false,
+                                                onDisplayChanged: (displayed) =>
+                                                    _handleDisplayChange(
+                                                      state,
+                                                      displayed,
+                                                    ),
+                                              );
+                                            },
+                                          ),
+                                        ),
+                                      );
+                                      final reminders = _reminderController;
+                                      if (reminders == null) return buildList();
+                                      return AnimatedBuilder(
+                                        animation: reminders,
+                                        builder: (_, __) => buildList(),
+                                      );
+                                    },
                               ),
-                            ),
-                            if (!_showLoadedList)
-                              const Center(
-                                child: CircularProgressIndicator(),
-                              ),
-                          ],
                         ),
+                        if (!_showLoadedList)
+                          const Center(child: CircularProgressIndicator()),
+                      ],
+                    ),
             ),
           ],
         ),
@@ -168,10 +209,7 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              L.of(context).filterLoadError,
-              textAlign: TextAlign.center,
-            ),
+            Text(L.of(context).filterLoadError, textAlign: TextAlign.center),
             const SizedBox(height: 12),
             FilledButton(
               onPressed: () {
@@ -204,27 +242,21 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
     } on FilterValidationException catch (e, trace) {
       debugPrint('Failed to validate schedule filter: $e');
       debugPrint('$trace');
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(L.of(context).filterSaveError),
-        ),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(L.of(context).filterSaveError)));
     } on FilterSaveException catch (e, trace) {
       debugPrint('Failed to persist schedule filter: $e');
       debugPrint('$trace');
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(L.of(context).filterSaveError),
-        ),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(L.of(context).filterSaveError)));
     } catch (e, trace) {
       debugPrint('Failed to apply schedule filter: $e');
       debugPrint('$trace');
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(L.of(context).filterSaveError),
-        ),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(L.of(context).filterSaveError)));
     } finally {
       if (applySucceeded && mounted) {
         Navigator.of(context).pop(didChangeFilters);
@@ -232,13 +264,79 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
       _isHandlingPop = false;
     }
   }
+
+  Future<bool> _handleDisplayChange(
+    ScheduleEntryFilterState state,
+    bool displayed,
+  ) async {
+    final reminders = _reminderController;
+    if (displayed ||
+        reminders == null ||
+        !reminders.hasReminderForTitle(state.entryName)) {
+      return true;
+    }
+
+    final strings = L.of(context);
+    final choice = await showDialog<_HiddenReminderChoice>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(
+          strings.filterReminderHideTitle.replaceAll(
+            '{className}',
+            state.entryName,
+          ),
+        ),
+        content: Text(strings.filterReminderHideMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(strings.classReminderPermissionCancel),
+          ),
+          TextButton(
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(_HiddenReminderChoice.keep),
+            child: Text(strings.filterReminderKeep),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(_HiddenReminderChoice.remove),
+            child: Text(strings.filterReminderRemove),
+          ),
+        ],
+      ),
+    );
+
+    if (choice == null) return false;
+    if (choice == _HiddenReminderChoice.remove) {
+      try {
+        await reminders.removeRemindersForTitle(state.entryName);
+      } catch (error, trace) {
+        debugPrint('Failed to remove reminders for hidden class: $error');
+        debugPrint('$trace');
+        if (mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(strings.filterSaveError)));
+        }
+        return false;
+      }
+    }
+    return true;
+  }
 }
+
+enum _HiddenReminderChoice { keep, remove }
 
 class FilterStateRow extends StatefulWidget {
   final ScheduleEntryFilterState filterState;
+  final bool hasReminder;
+  final Future<bool> Function(bool displayed)? onDisplayChanged;
 
-  FilterStateRow(this.filterState)
-      : super(key: ValueKey(filterState.entryName));
+  FilterStateRow(
+    this.filterState, {
+    this.hasReminder = false,
+    this.onDisplayChanged,
+  }) : super(key: ValueKey(filterState.entryName));
 
   @override
   _FilterStateRowState createState() => _FilterStateRowState();
@@ -246,6 +344,7 @@ class FilterStateRow extends StatefulWidget {
 
 class _FilterStateRowState extends State<FilterStateRow> {
   bool isChecked = false;
+  bool _isChanging = false;
 
   @override
   void initState() {
@@ -267,12 +366,7 @@ class _FilterStateRowState extends State<FilterStateRow> {
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: () {
-        setState(() {
-          isChecked = !isChecked;
-          widget.filterState.isDisplayed = isChecked;
-        });
-      },
+      onTap: () => unawaited(_setChecked(!isChecked)),
       child: SizedBox(
         height: 56,
         child: Row(
@@ -280,11 +374,7 @@ class _FilterStateRowState extends State<FilterStateRow> {
             Checkbox(
               value: isChecked,
               onChanged: (checked) {
-                if (checked == null) return;
-                setState(() {
-                  isChecked = checked;
-                  widget.filterState.isDisplayed = isChecked;
-                });
+                if (checked != null) unawaited(_setChecked(checked));
               },
             ),
             Expanded(
@@ -294,10 +384,34 @@ class _FilterStateRowState extends State<FilterStateRow> {
                 overflow: TextOverflow.ellipsis,
               ),
             ),
+            if (widget.hasReminder)
+              Padding(
+                padding: const EdgeInsets.only(left: 8),
+                child: Icon(
+                  Icons.notifications,
+                  size: 18,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
             const SizedBox(width: 12),
           ],
         ),
       ),
     );
+  }
+
+  Future<void> _setChecked(bool checked) async {
+    if (checked == isChecked || _isChanging) return;
+    _isChanging = true;
+    try {
+      final accepted = await widget.onDisplayChanged?.call(checked) ?? true;
+      if (!accepted || !mounted) return;
+      setState(() {
+        isChecked = checked;
+        widget.filterState.isDisplayed = checked;
+      });
+    } finally {
+      _isChanging = false;
+    }
   }
 }

--- a/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
+++ b/lib/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart
@@ -32,7 +32,7 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
   bool _isHandlingPop = false;
   bool _didInitializeViewModel = false;
   ClassReminderController? _reminderController;
-  Future<void>? _pendingDisplayChange;
+  final Set<Future<void>> _pendingDisplayChanges = {};
 
   @override
   void initState() {
@@ -238,7 +238,7 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
       if (!_didInitializeViewModel || _hasInitError) {
         return;
       }
-      await _pendingDisplayChange;
+      await _awaitPendingDisplayChanges();
       didChangeFilters = await _viewModel.applyFilter();
       applySucceeded = true;
     } on FilterValidationException catch (e, trace) {
@@ -272,10 +272,19 @@ class _ScheduleFilterPageState extends State<ScheduleFilterPage> {
     bool displayed,
   ) {
     final future = _doDisplayChange(state, displayed);
-    if (!displayed) {
-      _pendingDisplayChange = future.then((_) {}).catchError((_) {});
-    }
+    late final Future<void> trackedFuture;
+    trackedFuture = future
+        .then<void>((_) {})
+        .catchError((_) {})
+        .whenComplete(() => _pendingDisplayChanges.remove(trackedFuture));
+    _pendingDisplayChanges.add(trackedFuture);
     return future;
+  }
+
+  Future<void> _awaitPendingDisplayChanges() async {
+    while (_pendingDisplayChanges.isNotEmpty) {
+      await Future.wait(List<Future<void>>.of(_pendingDisplayChanges));
+    }
   }
 
   Future<bool> _doDisplayChange(

--- a/lib/schedule/ui/weeklyschedule/reminder_configuration_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/reminder_configuration_sheet.dart
@@ -1,0 +1,206 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class ReminderConfigurationSheet extends StatefulWidget {
+  final ClassReminderRule? existingRule;
+  final Future<void> Function(Duration offset, ClassReminderScope scope) onSave;
+  final Future<void> Function()? onRemove;
+
+  const ReminderConfigurationSheet({
+    super.key,
+    required this.existingRule,
+    required this.onSave,
+    this.onRemove,
+  });
+
+  @override
+  State<ReminderConfigurationSheet> createState() =>
+      _ReminderConfigurationSheetState();
+}
+
+class _ReminderConfigurationSheetState
+    extends State<ReminderConfigurationSheet> {
+  static const _presetMinutes = [5, 15, 30, 60];
+  late int _minutes;
+  late ClassReminderScope _scope;
+  late bool _custom;
+  late final TextEditingController _customController;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _minutes = widget.existingRule?.offset.inMinutes ?? 15;
+    _scope = widget.existingRule?.scope ?? ClassReminderScope.oneTime;
+    _custom = !_presetMinutes.contains(_minutes);
+    _customController = TextEditingController(text: '$_minutes');
+  }
+
+  @override
+  void dispose() {
+    _customController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final strings = L.of(context);
+    return SafeArea(
+      top: false,
+      child: SingleChildScrollView(
+        padding: EdgeInsets.fromLTRB(
+          24,
+          12,
+          24,
+          24 + MediaQuery.viewInsetsOf(context).bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: Container(
+                width: 32,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              strings.classReminderSheetTitle,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 12),
+            RadioGroup<int>(
+              groupValue: _custom ? -1 : _minutes,
+              onChanged: (value) {
+                if (_saving) return;
+                setState(() {
+                  _custom = value == -1;
+                  if (!_custom) _minutes = value!;
+                });
+              },
+              child: Column(
+                children: [
+                  for (final minutes in _presetMinutes)
+                    RadioListTile<int>(
+                      contentPadding: EdgeInsets.zero,
+                      value: minutes,
+                      title: Text(_offsetLabel(strings, minutes)),
+                    ),
+                  RadioListTile<int>(
+                    contentPadding: EdgeInsets.zero,
+                    value: -1,
+                    title: Text(strings.classReminderCustom),
+                  ),
+                ],
+              ),
+            ),
+            if (_custom)
+              Padding(
+                padding: const EdgeInsets.only(left: 16, right: 16, bottom: 12),
+                child: TextField(
+                  controller: _customController,
+                  autofocus: true,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  decoration: InputDecoration(
+                    labelText: strings.classReminderCustomMinutes,
+                    suffixText: 'min',
+                  ),
+                ),
+              ),
+            const Divider(height: 24),
+            SegmentedButton<ClassReminderScope>(
+              segments: [
+                ButtonSegment(
+                  value: ClassReminderScope.oneTime,
+                  label: Text(strings.classReminderThisOccurrence),
+                  icon: const Icon(Icons.event_outlined),
+                ),
+                ButtonSegment(
+                  value: ClassReminderScope.recurring,
+                  label: Text(strings.classReminderEveryOccurrence),
+                  icon: const Icon(Icons.event_repeat_outlined),
+                ),
+              ],
+              selected: {_scope},
+              onSelectionChanged: _saving
+                  ? null
+                  : (selection) => setState(() => _scope = selection.first),
+            ),
+            if (_scope == ClassReminderScope.recurring) ...[
+              const SizedBox(height: 16),
+              Card(
+                color: Theme.of(context).colorScheme.secondaryContainer,
+                elevation: 0,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Icon(Icons.info_outline),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              strings.classReminderMatchingTitle,
+                              style: Theme.of(context).textTheme.titleSmall,
+                            ),
+                            const SizedBox(height: 4),
+                            Text(strings.classReminderMatchingDescription),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              onPressed: _saving ? null : _save,
+              icon: const Icon(Icons.notifications_active_outlined),
+              label: Text(strings.classReminderSave),
+            ),
+            if (widget.existingRule != null && widget.onRemove != null)
+              TextButton(
+                onPressed: _saving ? null : _remove,
+                child: Text(strings.classReminderRemove),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _offsetLabel(L strings, int minutes) => switch (minutes) {
+    5 => strings.classReminderFiveMinutes,
+    15 => strings.classReminderFifteenMinutes,
+    30 => strings.classReminderThirtyMinutes,
+    60 => strings.classReminderOneHour,
+    _ => strings.classReminderCustom,
+  };
+
+  Future<void> _save() async {
+    final customMinutes = int.tryParse(_customController.text);
+    final minutes = _custom ? customMinutes : _minutes;
+    if (minutes == null || minutes <= 0) return;
+    setState(() => _saving = true);
+    await widget.onSave(Duration(minutes: minutes), _scope);
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  Future<void> _remove() async {
+    setState(() => _saving = true);
+    await widget.onRemove!();
+    if (mounted) Navigator.of(context).pop();
+  }
+}

--- a/lib/schedule/ui/weeklyschedule/reminder_configuration_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/reminder_configuration_sheet.dart
@@ -136,32 +136,48 @@ class _ReminderConfigurationSheetState
             ),
             if (_scope == ClassReminderScope.recurring) ...[
               const SizedBox(height: 16),
-              Card(
-                color: Theme.of(context).colorScheme.secondaryContainer,
-                elevation: 0,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Icon(Icons.info_outline),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              strings.classReminderMatchingTitle,
-                              style: Theme.of(context).textTheme.titleSmall,
+              Builder(
+                builder: (context) {
+                  final colors = Theme.of(context).colorScheme;
+                  return Card(
+                    color: colors.secondaryContainer,
+                    elevation: 0,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Icon(
+                            Icons.info_outline,
+                            color: colors.onSecondaryContainer,
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  strings.classReminderMatchingTitle,
+                                  style: Theme.of(context).textTheme.titleSmall
+                                      ?.copyWith(
+                                        color: colors.onSecondaryContainer,
+                                      ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  strings.classReminderMatchingDescription,
+                                  style: TextStyle(
+                                    color: colors.onSecondaryContainer,
+                                  ),
+                                ),
+                              ],
                             ),
-                            const SizedBox(height: 4),
-                            Text(strings.classReminderMatchingDescription),
-                          ],
-                        ),
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
-                ),
+                    ),
+                  );
+                },
               ),
             ],
             const SizedBox(height: 20),

--- a/lib/schedule/ui/weeklyschedule/reminder_configuration_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/reminder_configuration_sheet.dart
@@ -109,6 +109,7 @@ class _ReminderConfigurationSheetState
                   autofocus: true,
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  onChanged: (_) => setState(() {}),
                   decoration: InputDecoration(
                     labelText: strings.classReminderCustomMinutes,
                     suffixText: 'min',
@@ -182,7 +183,7 @@ class _ReminderConfigurationSheetState
             ],
             const SizedBox(height: 20),
             FilledButton.icon(
-              onPressed: _saving ? null : _save,
+              onPressed: _saving || !_canSave ? null : _save,
               icon: const Icon(Icons.notifications_active_outlined),
               label: Text(strings.classReminderSave),
             ),
@@ -204,6 +205,9 @@ class _ReminderConfigurationSheetState
     60 => strings.classReminderOneHour,
     _ => strings.classReminderCustom,
   };
+
+  bool get _canSave =>
+      !_custom || (int.tryParse(_customController.text) ?? 0) > 0;
 
   Future<void> _save() async {
     final customMinutes = int.tryParse(_customController.text);

--- a/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
@@ -3,9 +3,13 @@ import 'package:dualmate/common/ui/colors.dart';
 import 'package:dualmate/common/ui/schedule_entry_type_mappings.dart';
 import 'package:dualmate/common/ui/text_styles.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/reminder_configuration_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
+import 'package:kiwi/kiwi.dart';
 
 /// Expandable detail sheet for a schedule entry.
 ///
@@ -20,9 +24,13 @@ import 'package:intl/intl.dart';
 /// https://m3.material.io/styles/motion/transitions/transition-patterns
 class ScheduleEntryDetailBottomSheet extends StatefulWidget {
   final ScheduleEntry scheduleEntry;
+  final ClassReminderController? reminderController;
 
-  const ScheduleEntryDetailBottomSheet({Key? key, required this.scheduleEntry})
-    : super(key: key);
+  const ScheduleEntryDetailBottomSheet({
+    Key? key,
+    required this.scheduleEntry,
+    this.reminderController,
+  }) : super(key: key);
 
   @override
   State<ScheduleEntryDetailBottomSheet> createState() =>
@@ -49,6 +57,7 @@ class _ScheduleEntryDetailBottomSheetState
   final DraggableScrollableController _controller =
       DraggableScrollableController();
   bool _isSnapping = false;
+  ClassReminderController? _reminderController;
 
   // The state the sheet currently sits within tolerance of, so a haptic fires
   // exactly once each time it *arrives* at a state — by snap or by manual drag.
@@ -59,13 +68,25 @@ class _ScheduleEntryDetailBottomSheetState
   void initState() {
     super.initState();
     _controller.addListener(_onSizeChanged);
+    _reminderController = widget.reminderController;
+    final container = KiwiContainer();
+    if (_reminderController == null &&
+        container.isRegistered<ClassReminderController>()) {
+      _reminderController = container.resolve<ClassReminderController>();
+    }
+    _reminderController?.addListener(_onReminderStateChanged);
   }
 
   @override
   void dispose() {
+    _reminderController?.removeListener(_onReminderStateChanged);
     _controller.removeListener(_onSizeChanged);
     _controller.dispose();
     super.dispose();
+  }
+
+  void _onReminderStateChanged() {
+    if (mounted) setState(() {});
   }
 
   /// Fires a selection haptic whenever the sheet arrives at a settle state and
@@ -251,6 +272,7 @@ class _ScheduleEntryDetailBottomSheetState
                   ),
                 ),
               ),
+              if (_reminderController != null) _buildReminderButton(context),
             ],
           ),
         ),
@@ -283,6 +305,86 @@ class _ScheduleEntryDetailBottomSheetState
             ? Container()
             : Text(widget.scheduleEntry.details),
       ],
+    );
+  }
+
+  Widget _buildReminderButton(BuildContext context) {
+    final controller = _reminderController!;
+    final rule = controller.ruleFor(widget.scheduleEntry);
+    final paused = rule != null && !controller.permissionsGranted;
+    final icon = paused
+        ? Icons.notifications_off_outlined
+        : rule == null
+        ? Icons.notifications_none_outlined
+        : Icons.notifications;
+    return IconButton(
+      key: const ValueKey('class-reminder-button'),
+      onPressed: () => _openReminderConfiguration(context, rule),
+      icon: Icon(icon),
+      color: paused ? Theme.of(context).colorScheme.tertiary : null,
+      tooltip: rule == null
+          ? L.of(context).classReminderTooltipAdd
+          : L.of(context).classReminderTooltipEdit,
+    );
+  }
+
+  Future<void> _openReminderConfiguration(
+    BuildContext context,
+    ClassReminderRule? existingRule,
+  ) async {
+    final controller = _reminderController!;
+    await showModalBottomSheet<void>(
+      context: context,
+      useRootNavigator: true,
+      isScrollControlled: true,
+      showDragHandle: false,
+      builder: (sheetContext) => ReminderConfigurationSheet(
+        existingRule: existingRule,
+        onSave: (offset, scope) async {
+          var result = await controller.saveReminder(
+            entry: widget.scheduleEntry,
+            offset: offset,
+            scope: scope,
+          );
+          if (result != ReminderActivationResult.permissionsRequired ||
+              !sheetContext.mounted) {
+            return;
+          }
+          final openSettings = await showDialog<bool>(
+            context: sheetContext,
+            builder: (dialogContext) => AlertDialog(
+              title: Text(L.of(dialogContext).classReminderPermissionTitle),
+              content: Text(L.of(dialogContext).classReminderPermissionMessage),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(false),
+                  child: Text(
+                    L.of(dialogContext).classReminderPermissionCancel,
+                  ),
+                ),
+                FilledButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(true),
+                  child: Text(
+                    L.of(dialogContext).classReminderPermissionOpenSettings,
+                  ),
+                ),
+              ],
+            ),
+          );
+          if (openSettings != true) return;
+          await controller.openReliablePermissionSettings();
+          if (controller.permissionsGranted) {
+            result = await controller.saveReminder(
+              entry: widget.scheduleEntry,
+              offset: offset,
+              scope: scope,
+            );
+          }
+        },
+        onRemove: existingRule == null
+            ? null
+            : () => controller.removeReminder(widget.scheduleEntry),
+      ),
     );
   }
 }

--- a/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
@@ -222,58 +222,55 @@ class _ScheduleEntryDetailBottomSheetState
         ),
         Padding(
           padding: const EdgeInsets.fromLTRB(0, 0, 0, 16.0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: <Widget>[
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: <Widget>[
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.baseline,
-                    textBaseline: TextBaseline.alphabetic,
-                    children: <Widget>[
-                      Text(
-                        L.of(context).scheduleEntryDetailFrom,
-                        style: textStyleScheduleEntryBottomPageTimeFromTo(
-                          context,
-                        ),
+          child: ScheduleEntryDetailHeaderLayout(
+            leading: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.baseline,
+                  textBaseline: TextBaseline.alphabetic,
+                  children: <Widget>[
+                    Text(
+                      L.of(context).scheduleEntryDetailFrom,
+                      style: textStyleScheduleEntryBottomPageTimeFromTo(
+                        context,
                       ),
-                      Text(
-                        timeStart,
-                        style: textStyleScheduleEntryBottomPageTime(context),
-                      ),
-                    ],
-                  ),
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.baseline,
-                    textBaseline: TextBaseline.alphabetic,
-                    children: <Widget>[
-                      Text(
-                        L.of(context).scheduleEntryDetailTo,
-                        style: textStyleScheduleEntryBottomPageTimeFromTo(
-                          context,
-                        ),
-                      ),
-                      Text(
-                        timeEnd,
-                        style: textStyleScheduleEntryBottomPageTime(context),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-              Flexible(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 0, 0, 0),
-                  child: Text(
-                    widget.scheduleEntry.title,
-                    softWrap: true,
-                    style: textStyleScheduleEntryBottomPageTitle(context),
-                  ),
+                    ),
+                    Text(
+                      timeStart,
+                      style: textStyleScheduleEntryBottomPageTime(context),
+                    ),
+                  ],
                 ),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.baseline,
+                  textBaseline: TextBaseline.alphabetic,
+                  children: <Widget>[
+                    Text(
+                      L.of(context).scheduleEntryDetailTo,
+                      style: textStyleScheduleEntryBottomPageTimeFromTo(
+                        context,
+                      ),
+                    ),
+                    Text(
+                      timeEnd,
+                      style: textStyleScheduleEntryBottomPageTime(context),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            title: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 0, 0),
+              child: Text(
+                widget.scheduleEntry.title,
+                softWrap: true,
+                style: textStyleScheduleEntryBottomPageTitle(context),
               ),
-              if (_reminderController != null) _buildReminderButton(context),
-            ],
+            ),
+            trailing: _reminderController == null
+                ? null
+                : _buildReminderButton(context),
           ),
         ),
         Padding(
@@ -385,6 +382,46 @@ class _ScheduleEntryDetailBottomSheetState
             ? null
             : () => controller.removeReminder(widget.scheduleEntry),
       ),
+    );
+  }
+}
+
+/// Keeps the detail action independent from the title's intrinsic width.
+///
+/// The trailing action is overlaid at the header's top-right edge while the
+/// content reserves one Material touch-target width for it.
+class ScheduleEntryDetailHeaderLayout extends StatelessWidget {
+  static const double _trailingExtent = 48;
+
+  final Widget leading;
+  final Widget title;
+  final Widget? trailing;
+
+  const ScheduleEntryDetailHeaderLayout({
+    super.key,
+    required this.leading,
+    required this.title,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Padding(
+          padding: EdgeInsets.only(
+            right: trailing == null ? 0 : _trailingExtent,
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              leading,
+              Expanded(child: title),
+            ],
+          ),
+        ),
+        if (trailing != null) Positioned(top: 0, right: 0, child: trailing!),
+      ],
     );
   }
 }

--- a/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
@@ -308,7 +308,7 @@ class _ScheduleEntryDetailBottomSheetState
   Widget _buildReminderButton(BuildContext context) {
     final controller = _reminderController!;
     final rule = controller.ruleFor(widget.scheduleEntry);
-    final paused = rule != null && !controller.permissionsGranted;
+    final paused = rule != null && controller.remindersPaused;
     final icon = paused
         ? Icons.notifications_off_outlined
         : rule == null
@@ -316,7 +316,9 @@ class _ScheduleEntryDetailBottomSheetState
         : Icons.notifications;
     return IconButton(
       key: const ValueKey('class-reminder-button'),
-      onPressed: () => _openReminderConfiguration(context, rule),
+      onPressed: controller.isInitialized
+          ? () => _openReminderConfiguration(context, rule)
+          : null,
       icon: Icon(icon),
       color: paused ? Theme.of(context).colorScheme.tertiary : null,
       tooltip: rule == null

--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -6,6 +6,7 @@ import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
 import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:dualmate/schedule/ui/viewmodels/weekly_schedule_view_model.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart';
@@ -14,6 +15,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:kiwi/kiwi.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -38,6 +40,7 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
 
   late final PageController _weekPageController;
   late WeeklyScheduleViewModel viewModel;
+  ClassReminderController? _reminderController;
 
   bool _isApplyingWidgetPayload = false;
   bool _pagerInitialized = false;
@@ -54,6 +57,10 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
   void initState() {
     super.initState();
     _weekPageController = PageController(initialPage: _initialPageIndex);
+    final container = KiwiContainer();
+    if (container.isRegistered<ClassReminderController>()) {
+      _reminderController = container.resolve<ClassReminderController>();
+    }
     WidgetsBinding.instance.addObserver(this);
     WidgetNavigationPayloadStore.instance.addListener(_handleWidgetPayload);
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -396,6 +403,7 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage>
               preparedData: pageData.renderData,
               viewportListenable: animatesViewport ? viewportListenable : null,
               targetViewport: targetViewport,
+              reminderController: _reminderController,
             ),
           );
         },

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart
@@ -3,9 +3,7 @@ import 'dart:math' as math;
 import 'package:dualmate/common/ui/schedule_entry_type_mappings.dart';
 import 'package:dualmate/common/ui/text_styles.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
-import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:flutter/material.dart';
-import 'package:kiwi/kiwi.dart';
 
 typedef ScheduleEntryTapCallback = Function(ScheduleEntry entry);
 
@@ -95,95 +93,75 @@ class ScheduleEntryWidget extends StatelessWidget {
     final borderWidth = isDense ? 0.5 : 0.6;
     final overflow = isDense ? TextOverflow.clip : TextOverflow.ellipsis;
 
-    ClassReminderController? reminderController;
-    final container = KiwiContainer();
-    if (container.isRegistered<ClassReminderController>()) {
-      reminderController = container.resolve<ClassReminderController>();
-    }
+    final hasReminder = reminderActive ?? false;
+    final isReminderPaused = hasReminder && reminderPaused;
 
-    Widget buildEntry() {
-      final reminderRule = reminderController?.ruleFor(scheduleEntry);
-      final hasReminder = reminderActive ?? reminderRule != null;
-      final isReminderPaused = reminderActive != null
-          ? reminderPaused
-          : reminderRule != null &&
-                !(reminderController?.permissionsGranted ?? false);
-
-      return DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: borderRadius,
-          boxShadow: shadowOpacity == 0
-              ? null
-              : [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: shadowOpacity),
-                    blurRadius: 3,
-                    offset: const Offset(0, 1),
-                  ),
-                ],
-        ),
-        child: Material(
-          type: MaterialType.transparency,
-          child: Ink(
-            decoration: BoxDecoration(
-              color: color,
-              borderRadius: borderRadius,
-              border: Border.all(
-                color: Colors.black.withValues(alpha: 0.08),
-                width: borderWidth,
-              ),
-            ),
-            child: InkWell(
-              borderRadius: borderRadius,
-              onTap: () {
-                onScheduleEntryTap(scheduleEntry);
-              },
-              child: Padding(
-                padding: EdgeInsets.symmetric(
-                  horizontal: horizontalPadding,
-                  vertical: verticalPadding,
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: borderRadius,
+        boxShadow: shadowOpacity == 0
+            ? null
+            : [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: shadowOpacity),
+                  blurRadius: 3,
+                  offset: const Offset(0, 1),
                 ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(
-                      child: Text(
-                        scheduleEntry.title,
-                        maxLines: maxLines,
-                        softWrap: true,
-                        overflow: overflow,
-                        textAlign: TextAlign.left,
-                        style: textStyle,
-                      ),
+              ],
+      ),
+      child: Material(
+        type: MaterialType.transparency,
+        child: Ink(
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: borderRadius,
+            border: Border.all(
+              color: Colors.black.withValues(alpha: 0.08),
+              width: borderWidth,
+            ),
+          ),
+          child: InkWell(
+            borderRadius: borderRadius,
+            onTap: () {
+              onScheduleEntryTap(scheduleEntry);
+            },
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: horizontalPadding,
+                vertical: verticalPadding,
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      scheduleEntry.title,
+                      maxLines: maxLines,
+                      softWrap: true,
+                      overflow: overflow,
+                      textAlign: TextAlign.left,
+                      style: textStyle,
                     ),
-                    if (hasReminder && width >= 44)
-                      Padding(
-                        padding: const EdgeInsets.only(left: 1, top: 1),
-                        child: Icon(
-                          isReminderPaused
-                              ? Icons.notifications_off_outlined
-                              : Icons.notifications,
-                          size: isDense ? 11 : 13,
-                          color: textColor.withValues(
-                            alpha: isReminderPaused ? 0.7 : 0.95,
-                          ),
+                  ),
+                  if (hasReminder && width >= 44)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 1, top: 1),
+                      child: Icon(
+                        isReminderPaused
+                            ? Icons.notifications_off_outlined
+                            : Icons.notifications,
+                        size: isDense ? 11 : 13,
+                        color: textColor.withValues(
+                          alpha: isReminderPaused ? 0.7 : 0.95,
                         ),
                       ),
-                  ],
-                ),
+                    ),
+                ],
               ),
             ),
           ),
         ),
-      );
-    }
-
-    if (reminderController == null || reminderActive != null) {
-      return buildEntry();
-    }
-    return AnimatedBuilder(
-      animation: reminderController,
-      builder: (context, child) => buildEntry(),
+      ),
     );
   }
 }

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart
@@ -3,7 +3,9 @@ import 'dart:math' as math;
 import 'package:dualmate/common/ui/schedule_entry_type_mappings.dart';
 import 'package:dualmate/common/ui/text_styles.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:kiwi/kiwi.dart';
 
 typedef ScheduleEntryTapCallback = Function(ScheduleEntry entry);
 
@@ -12,6 +14,8 @@ class ScheduleEntryWidget extends StatelessWidget {
   final ScheduleEntryTapCallback onScheduleEntryTap;
   final double? renderedWidth;
   final double? renderedHeight;
+  final bool? reminderActive;
+  final bool reminderPaused;
 
   const ScheduleEntryWidget({
     Key? key,
@@ -19,6 +23,8 @@ class ScheduleEntryWidget extends StatelessWidget {
     required this.onScheduleEntryTap,
     this.renderedWidth,
     this.renderedHeight,
+    this.reminderActive,
+    this.reminderPaused = false,
   }) : super(key: key);
 
   @override
@@ -89,6 +95,18 @@ class ScheduleEntryWidget extends StatelessWidget {
     final borderWidth = isDense ? 0.5 : 0.6;
     final overflow = isDense ? TextOverflow.clip : TextOverflow.ellipsis;
 
+    ClassReminderController? reminderController;
+    final container = KiwiContainer();
+    if (container.isRegistered<ClassReminderController>()) {
+      reminderController = container.resolve<ClassReminderController>();
+    }
+    final reminderRule = reminderController?.ruleFor(scheduleEntry);
+    final hasReminder = reminderActive ?? reminderRule != null;
+    final isReminderPaused = reminderActive != null
+        ? reminderPaused
+        : reminderRule != null &&
+              !(reminderController?.permissionsGranted ?? false);
+
     return DecoratedBox(
       decoration: BoxDecoration(
         borderRadius: borderRadius,
@@ -123,13 +141,33 @@ class ScheduleEntryWidget extends StatelessWidget {
                 horizontal: horizontalPadding,
                 vertical: verticalPadding,
               ),
-              child: Text(
-                scheduleEntry.title,
-                maxLines: maxLines,
-                softWrap: true,
-                overflow: overflow,
-                textAlign: TextAlign.left,
-                style: textStyle,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      scheduleEntry.title,
+                      maxLines: maxLines,
+                      softWrap: true,
+                      overflow: overflow,
+                      textAlign: TextAlign.left,
+                      style: textStyle,
+                    ),
+                  ),
+                  if (hasReminder && width >= 44)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 1, top: 1),
+                      child: Icon(
+                        isReminderPaused
+                            ? Icons.notifications_off_outlined
+                            : Icons.notifications,
+                        size: isDense ? 11 : 13,
+                        color: textColor.withValues(
+                          alpha: isReminderPaused ? 0.7 : 0.95,
+                        ),
+                      ),
+                    ),
+                ],
               ),
             ),
           ),

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart
@@ -100,79 +100,90 @@ class ScheduleEntryWidget extends StatelessWidget {
     if (container.isRegistered<ClassReminderController>()) {
       reminderController = container.resolve<ClassReminderController>();
     }
-    final reminderRule = reminderController?.ruleFor(scheduleEntry);
-    final hasReminder = reminderActive ?? reminderRule != null;
-    final isReminderPaused = reminderActive != null
-        ? reminderPaused
-        : reminderRule != null &&
-              !(reminderController?.permissionsGranted ?? false);
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius: borderRadius,
-        boxShadow: shadowOpacity == 0
-            ? null
-            : [
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: shadowOpacity),
-                  blurRadius: 3,
-                  offset: const Offset(0, 1),
-                ),
-              ],
-      ),
-      child: Material(
-        type: MaterialType.transparency,
-        child: Ink(
-          decoration: BoxDecoration(
-            color: color,
-            borderRadius: borderRadius,
-            border: Border.all(
-              color: Colors.black.withValues(alpha: 0.08),
-              width: borderWidth,
-            ),
-          ),
-          child: InkWell(
-            borderRadius: borderRadius,
-            onTap: () {
-              onScheduleEntryTap(scheduleEntry);
-            },
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: horizontalPadding,
-                vertical: verticalPadding,
-              ),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: Text(
-                      scheduleEntry.title,
-                      maxLines: maxLines,
-                      softWrap: true,
-                      overflow: overflow,
-                      textAlign: TextAlign.left,
-                      style: textStyle,
-                    ),
+    Widget buildEntry() {
+      final reminderRule = reminderController?.ruleFor(scheduleEntry);
+      final hasReminder = reminderActive ?? reminderRule != null;
+      final isReminderPaused = reminderActive != null
+          ? reminderPaused
+          : reminderRule != null &&
+                !(reminderController?.permissionsGranted ?? false);
+
+      return DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: borderRadius,
+          boxShadow: shadowOpacity == 0
+              ? null
+              : [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: shadowOpacity),
+                    blurRadius: 3,
+                    offset: const Offset(0, 1),
                   ),
-                  if (hasReminder && width >= 44)
-                    Padding(
-                      padding: const EdgeInsets.only(left: 1, top: 1),
-                      child: Icon(
-                        isReminderPaused
-                            ? Icons.notifications_off_outlined
-                            : Icons.notifications,
-                        size: isDense ? 11 : 13,
-                        color: textColor.withValues(
-                          alpha: isReminderPaused ? 0.7 : 0.95,
-                        ),
+                ],
+        ),
+        child: Material(
+          type: MaterialType.transparency,
+          child: Ink(
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: borderRadius,
+              border: Border.all(
+                color: Colors.black.withValues(alpha: 0.08),
+                width: borderWidth,
+              ),
+            ),
+            child: InkWell(
+              borderRadius: borderRadius,
+              onTap: () {
+                onScheduleEntryTap(scheduleEntry);
+              },
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: horizontalPadding,
+                  vertical: verticalPadding,
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        scheduleEntry.title,
+                        maxLines: maxLines,
+                        softWrap: true,
+                        overflow: overflow,
+                        textAlign: TextAlign.left,
+                        style: textStyle,
                       ),
                     ),
-                ],
+                    if (hasReminder && width >= 44)
+                      Padding(
+                        padding: const EdgeInsets.only(left: 1, top: 1),
+                        child: Icon(
+                          isReminderPaused
+                              ? Icons.notifications_off_outlined
+                              : Icons.notifications,
+                          size: isDense ? 11 : 13,
+                          color: textColor.withValues(
+                            alpha: isReminderPaused ? 0.7 : 0.95,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
               ),
             ),
           ),
         ),
-      ),
+      );
+    }
+
+    if (reminderController == null || reminderActive != null) {
+      return buildEntry();
+    }
+    return AnimatedBuilder(
+      animation: reminderController,
+      builder: (context, child) => buildEntry(),
     );
   }
 }

--- a/lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart
+++ b/lib/schedule/ui/weeklyschedule/widgets/schedule_widget.dart
@@ -3,6 +3,7 @@ import 'package:dualmate/common/ui/colors.dart';
 import 'package:dualmate/common/ui/text_styles.dart';
 import 'package:dualmate/common/util/date_utils.dart';
 import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_render_data.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart';
 import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_current_time_indicator.dart';
@@ -34,6 +35,7 @@ class ScheduleWidget extends StatelessWidget {
   final ScheduleRenderData? preparedData;
   final ValueListenable<ScheduleViewport>? viewportListenable;
   final ScheduleViewport? targetViewport;
+  final ClassReminderController? reminderController;
 
   const ScheduleWidget({
     Key? key,
@@ -48,6 +50,7 @@ class ScheduleWidget extends StatelessWidget {
     this.preparedData,
     this.viewportListenable,
     this.targetViewport,
+    this.reminderController,
   }) : super(key: key);
 
   @override
@@ -147,6 +150,7 @@ class ScheduleWidget extends StatelessWidget {
               viewport: viewport,
               targetViewport: target,
               onScheduleEntryTap: onScheduleEntryTap,
+              reminderController: reminderController,
             ),
           ),
         ),
@@ -292,18 +296,6 @@ class ScheduleWidget extends StatelessWidget {
       displayEndHour,
     );
 
-    var entryWidgets = <Widget>[];
-
-    entryWidgets = buildEntryWidgets(
-      renderData,
-      hourHeight,
-      minuteHeight,
-      width - timeLabelsWidth,
-      days,
-      layoutProfile,
-      displayStartHour,
-    );
-
     return Stack(
       fit: StackFit.expand,
       children: <Widget>[
@@ -325,7 +317,15 @@ class ScheduleWidget extends StatelessWidget {
               0,
               0,
             ),
-            child: Stack(clipBehavior: Clip.hardEdge, children: entryWidgets),
+            child: _buildReminderAwareEntryStack(
+              renderData,
+              hourHeight,
+              minuteHeight,
+              width - timeLabelsWidth,
+              days,
+              layoutProfile,
+              displayStartHour,
+            ),
           ),
         ),
         RepaintBoundary(
@@ -641,6 +641,7 @@ class ScheduleWidget extends StatelessWidget {
       var entryWidth = (rawEntryWidth - (horizontalInset * 2))
           .clamp(_minimumEventExtent, double.infinity)
           .toDouble();
+      final reminderRule = reminderController?.ruleFor(entry);
 
       var widget = Positioned(
         top: yStart,
@@ -652,6 +653,10 @@ class ScheduleWidget extends StatelessWidget {
           onScheduleEntryTap: onScheduleEntryTap,
           renderedWidth: entryWidth,
           renderedHeight: eventHeight,
+          reminderActive: reminderRule != null,
+          reminderPaused:
+              reminderRule != null &&
+              (reminderController?.remindersPaused ?? false),
         ),
       );
 
@@ -659,6 +664,36 @@ class ScheduleWidget extends StatelessWidget {
     }
 
     return entryWidgets;
+  }
+
+  Widget _buildReminderAwareEntryStack(
+    ScheduleRenderData renderData,
+    double hourHeight,
+    double minuteHeight,
+    double width,
+    int columns,
+    _ScheduleWidgetLayoutProfile layoutProfile,
+    double displayStartHour,
+  ) {
+    Widget buildEntries() => Stack(
+      clipBehavior: Clip.hardEdge,
+      children: buildEntryWidgets(
+        renderData,
+        hourHeight,
+        minuteHeight,
+        width,
+        columns,
+        layoutProfile,
+        displayStartHour,
+      ),
+    );
+
+    final reminders = reminderController;
+    if (reminders == null) return buildEntries();
+    return AnimatedBuilder(
+      animation: reminders,
+      builder: (_, __) => buildEntries(),
+    );
   }
 
   _ScheduleWidgetLayoutProfile _resolveLayoutProfile(double width, int days) {
@@ -698,6 +733,7 @@ class _AnimatedScheduleEntryLayer extends StatelessWidget {
   final ValueListenable<ScheduleViewport> viewport;
   final ScheduleViewport targetViewport;
   final ScheduleEntryTapCallback onScheduleEntryTap;
+  final ClassReminderController? reminderController;
 
   const _AnimatedScheduleEntryLayer({
     required this.renderData,
@@ -705,10 +741,20 @@ class _AnimatedScheduleEntryLayer extends StatelessWidget {
     required this.viewport,
     required this.targetViewport,
     required this.onScheduleEntryTap,
+    this.reminderController,
   });
 
   @override
   Widget build(BuildContext context) {
+    final reminders = reminderController;
+    if (reminders == null) return _buildContent();
+    return AnimatedBuilder(
+      animation: reminders,
+      builder: (_, __) => _buildContent(),
+    );
+  }
+
+  Widget _buildContent() {
     final slots = <_PreparedEntrySlot>[];
     for (
       var dayIndex = 0;
@@ -755,11 +801,16 @@ class _AnimatedScheduleEntryLayer extends StatelessWidget {
   }
 
   Widget _buildEntry(_PreparedEntrySlot slot, Rect targetRect) {
+    final reminderRule = reminderController?.ruleFor(slot.entry.entry);
     return ScheduleEntryWidget(
       scheduleEntry: slot.entry.entry,
       onScheduleEntryTap: onScheduleEntryTap,
       renderedWidth: targetRect.width,
       renderedHeight: targetRect.height,
+      reminderActive: reminderRule != null,
+      reminderPaused:
+          reminderRule != null &&
+          (reminderController?.remindersPaused ?? false),
     );
   }
 }

--- a/lib/schedule/ui/widgets/class_reminder_paused_notice.dart
+++ b/lib/schedule/ui/widgets/class_reminder_paused_notice.dart
@@ -1,0 +1,20 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/ui/banner_widget.dart';
+import 'package:flutter/material.dart';
+
+class ClassReminderPausedNotice extends StatelessWidget {
+  final VoidCallback onFixPermissions;
+
+  const ClassReminderPausedNotice({super.key, required this.onFixPermissions});
+
+  @override
+  Widget build(BuildContext context) {
+    final strings = L.of(context);
+    return BannerWidget(
+      title: strings.classReminderPausedTitle,
+      message: strings.classReminderPausedMessage,
+      buttonText: strings.classReminderFixPermissions.toUpperCase(),
+      onButtonTap: onFixPermissions,
+    );
+  }
+}

--- a/lib/schedule/ui/widgets/enter_dualis_credentials_dialog.dart
+++ b/lib/schedule/ui/widgets/enter_dualis_credentials_dialog.dart
@@ -76,6 +76,8 @@ class EnterDualisCredentialsDialog {
         child: Text(L.of(context).dialogOk.toUpperCase()),
         onPressed: () async {
           final nextUsername = _usernameEditingController.text;
+          final previousSourceIdentity =
+              _scheduleSourceProvider.currentSourceIdentity;
           if (!await ScheduleSourceChangeConfirmation.confirmIfNeeded(
             context: context,
             sourceProvider: _scheduleSourceProvider,
@@ -89,8 +91,12 @@ class EnterDualisCredentialsDialog {
           );
           TextInput.finishAutofillContext(shouldSave: true);
           await _scheduleSourceProvider.setupForDualis();
+          await ScheduleSourceChangeConfirmation.finishCommittedChange(
+            sourceProvider: _scheduleSourceProvider,
+            previousSourceIdentity: previousSourceIdentity,
+          );
 
-          Navigator.of(context).pop();
+          if (context.mounted) Navigator.of(context).pop();
         },
       ),
     ];

--- a/lib/schedule/ui/widgets/enter_dualis_credentials_dialog.dart
+++ b/lib/schedule/ui/widgets/enter_dualis_credentials_dialog.dart
@@ -5,6 +5,8 @@ import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/ui/login_credentials_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:dualmate/schedule/ui/widgets/schedule_source_change_confirmation.dart';
 
 class EnterDualisCredentialsDialog {
   final PreferencesProvider _preferencesProvider;
@@ -73,11 +75,17 @@ class EnterDualisCredentialsDialog {
       TextButton(
         child: Text(L.of(context).dialogOk.toUpperCase()),
         onPressed: () async {
+          final nextUsername = _usernameEditingController.text;
+          if (!await ScheduleSourceChangeConfirmation.confirmIfNeeded(
+            context: context,
+            sourceProvider: _scheduleSourceProvider,
+            nextType: ScheduleSourceType.Dualis,
+            nextIdentityValue: nextUsername,
+          )) {
+            return;
+          }
           await _preferencesProvider.storeDualisCredentials(
-            Credentials(
-              _usernameEditingController.text,
-              _passwordEditingController.text,
-            ),
+            Credentials(nextUsername, _passwordEditingController.text),
           );
           TextInput.finishAutofillContext(shouldSave: true);
           await _scheduleSourceProvider.setupForDualis();

--- a/lib/schedule/ui/widgets/enter_ical_url.dart
+++ b/lib/schedule/ui/widgets/enter_ical_url.dart
@@ -4,6 +4,8 @@ import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/service/ical/ical_schedule_source.dart';
 import 'package:dualmate/schedule/ui/widgets/enter_url_dialog.dart';
 import 'package:flutter/widgets.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:dualmate/schedule/ui/widgets/schedule_source_change_confirmation.dart';
 
 class EnterIcalDialog extends EnterUrlDialog {
   final PreferencesProvider _preferencesProvider;
@@ -19,6 +21,16 @@ class EnterIcalDialog extends EnterUrlDialog {
   @override
   Future saveUrl(String url) async {
     await _scheduleSource.setupForIcal(url);
+  }
+
+  @override
+  Future<bool> confirmSave(BuildContext context, String url) {
+    return ScheduleSourceChangeConfirmation.confirmIfNeeded(
+      context: context,
+      sourceProvider: _scheduleSource,
+      nextType: ScheduleSourceType.Ical,
+      nextIdentityValue: url,
+    );
   }
 
   @override

--- a/lib/schedule/ui/widgets/enter_ical_url.dart
+++ b/lib/schedule/ui/widgets/enter_ical_url.dart
@@ -10,6 +10,7 @@ import 'package:dualmate/schedule/ui/widgets/schedule_source_change_confirmation
 class EnterIcalDialog extends EnterUrlDialog {
   final PreferencesProvider _preferencesProvider;
   final ScheduleSourceProvider _scheduleSource;
+  String _previousSourceIdentity = 'none';
 
   EnterIcalDialog(this._preferencesProvider, this._scheduleSource);
 
@@ -21,10 +22,15 @@ class EnterIcalDialog extends EnterUrlDialog {
   @override
   Future saveUrl(String url) async {
     await _scheduleSource.setupForIcal(url);
+    await ScheduleSourceChangeConfirmation.finishCommittedChange(
+      sourceProvider: _scheduleSource,
+      previousSourceIdentity: _previousSourceIdentity,
+    );
   }
 
   @override
   Future<bool> confirmSave(BuildContext context, String url) {
+    _previousSourceIdentity = _scheduleSource.currentSourceIdentity;
     return ScheduleSourceChangeConfirmation.confirmIfNeeded(
       context: context,
       sourceProvider: _scheduleSource,

--- a/lib/schedule/ui/widgets/enter_rapla_url_dialog.dart
+++ b/lib/schedule/ui/widgets/enter_rapla_url_dialog.dart
@@ -13,16 +13,22 @@ import 'package:dualmate/schedule/ui/widgets/schedule_source_change_confirmation
 class EnterRaplaUrlDialog extends EnterUrlDialog {
   final PreferencesProvider _preferencesProvider;
   final ScheduleSourceProvider _scheduleSource;
+  String _previousSourceIdentity = 'none';
 
   EnterRaplaUrlDialog(this._preferencesProvider, this._scheduleSource);
 
   @override
   Future saveUrl(String url) async {
     await _scheduleSource.setupForRapla(url);
+    await ScheduleSourceChangeConfirmation.finishCommittedChange(
+      sourceProvider: _scheduleSource,
+      previousSourceIdentity: _previousSourceIdentity,
+    );
   }
 
   @override
   Future<bool> confirmSave(BuildContext context, String url) {
+    _previousSourceIdentity = _scheduleSource.currentSourceIdentity;
     return ScheduleSourceChangeConfirmation.confirmIfNeeded(
       context: context,
       sourceProvider: _scheduleSource,

--- a/lib/schedule/ui/widgets/enter_rapla_url_dialog.dart
+++ b/lib/schedule/ui/widgets/enter_rapla_url_dialog.dart
@@ -4,6 +4,8 @@ import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/service/rapla/rapla_schedule_source.dart';
 import 'package:dualmate/schedule/ui/widgets/enter_url_dialog.dart';
 import 'package:flutter/material.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:dualmate/schedule/ui/widgets/schedule_source_change_confirmation.dart';
 
 ///
 /// Shows a dialog to enter and validate the url for rapla
@@ -17,6 +19,16 @@ class EnterRaplaUrlDialog extends EnterUrlDialog {
   @override
   Future saveUrl(String url) async {
     await _scheduleSource.setupForRapla(url);
+  }
+
+  @override
+  Future<bool> confirmSave(BuildContext context, String url) {
+    return ScheduleSourceChangeConfirmation.confirmIfNeeded(
+      context: context,
+      sourceProvider: _scheduleSource,
+      nextType: ScheduleSourceType.Rapla,
+      nextIdentityValue: url,
+    );
   }
 
   @override

--- a/lib/schedule/ui/widgets/enter_url_dialog.dart
+++ b/lib/schedule/ui/widgets/enter_url_dialog.dart
@@ -110,8 +110,8 @@ abstract class EnterUrlDialog {
                 ? null
                 : () async {
                     if (!await confirmSave(context, _url.value)) return;
-                    if (context.mounted) Navigator.of(context).pop();
                     await saveUrl(_url.value);
+                    if (context.mounted) Navigator.of(context).pop();
                   },
           ),
         ),

--- a/lib/schedule/ui/widgets/enter_url_dialog.dart
+++ b/lib/schedule/ui/widgets/enter_url_dialog.dart
@@ -109,8 +109,8 @@ abstract class EnterUrlDialog {
             onPressed: hasUrlError.value
                 ? null
                 : () async {
-                    Navigator.of(context).pop();
-
+                    if (!await confirmSave(context, _url.value)) return;
+                    if (context.mounted) Navigator.of(context).pop();
                     await saveUrl(_url.value);
                   },
           ),
@@ -143,6 +143,7 @@ abstract class EnterUrlDialog {
 
   bool isValidUrl(String url);
   Future saveUrl(String url);
+  Future<bool> confirmSave(BuildContext context, String url) async => true;
   Future<String> loadUrl();
 
   String title(BuildContext context);

--- a/lib/schedule/ui/widgets/schedule_source_change_confirmation.dart
+++ b/lib/schedule/ui/widgets/schedule_source_change_confirmation.dart
@@ -1,0 +1,44 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:kiwi/kiwi.dart';
+
+abstract final class ScheduleSourceChangeConfirmation {
+  static Future<bool> confirmIfNeeded({
+    required BuildContext context,
+    required ScheduleSourceProvider sourceProvider,
+    required ScheduleSourceType nextType,
+    required String nextIdentityValue,
+  }) async {
+    final container = KiwiContainer();
+    if (!sourceProvider.wouldChangeTo(nextType, nextIdentityValue) ||
+        !container.isRegistered<ClassReminderController>()) {
+      return true;
+    }
+    final reminders = container.resolve<ClassReminderController>();
+    if (!reminders.hasReminders) return true;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(L.of(dialogContext).classReminderSourceChangeTitle),
+        content: Text(L.of(dialogContext).classReminderSourceChangeMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(L.of(dialogContext).classReminderSourceChangeCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(L.of(dialogContext).classReminderSourceChangeConfirm),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return false;
+    await reminders.clearForSourceChange();
+    return true;
+  }
+}

--- a/lib/schedule/ui/widgets/schedule_source_change_confirmation.dart
+++ b/lib/schedule/ui/widgets/schedule_source_change_confirmation.dart
@@ -18,6 +18,7 @@ abstract final class ScheduleSourceChangeConfirmation {
       return true;
     }
     final reminders = container.resolve<ClassReminderController>();
+    await reminders.initialize();
     if (!reminders.hasReminders) return true;
 
     final confirmed = await showDialog<bool>(
@@ -37,8 +38,23 @@ abstract final class ScheduleSourceChangeConfirmation {
         ],
       ),
     );
-    if (confirmed != true) return false;
-    await reminders.clearForSourceChange();
-    return true;
+    return confirmed == true;
+  }
+
+  static Future<void> finishCommittedChange({
+    required ScheduleSourceProvider sourceProvider,
+    required String previousSourceIdentity,
+  }) async {
+    if (previousSourceIdentity == sourceProvider.currentSourceIdentity) return;
+    final container = KiwiContainer();
+    if (!container.isRegistered<ClassReminderController>()) return;
+    final reminders = container.resolve<ClassReminderController>();
+    if (sourceProvider.currentSourceIdentity == 'none') {
+      await reminders.clearForSourceChange(
+        sourceIdentity: previousSourceIdentity,
+      );
+    } else {
+      await reminders.waitForSourceChange();
+    }
   }
 }

--- a/lib/schedule/ui/widgets/select_mannheim_course_dialog.dart
+++ b/lib/schedule/ui/widgets/select_mannheim_course_dialog.dart
@@ -4,6 +4,8 @@ import 'package:dualmate/ui/onboarding/viewmodels/mannheim_view_model.dart';
 import 'package:dualmate/ui/onboarding/viewmodels/onboarding_view_model_base.dart';
 import 'package:dualmate/ui/onboarding/widgets/mannheim_page.dart';
 import 'package:flutter/material.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:dualmate/schedule/ui/widgets/schedule_source_change_confirmation.dart';
 import 'package:property_change_notifier/property_change_notifier.dart';
 
 class SelectMannheimCourseDialog {
@@ -11,9 +13,7 @@ class SelectMannheimCourseDialog {
 
   late MannheimViewModel _mannheimViewModel;
 
-  SelectMannheimCourseDialog(
-    this._scheduleSourceProvider,
-  );
+  SelectMannheimCourseDialog(this._scheduleSourceProvider);
 
   Future show(BuildContext context) async {
     _mannheimViewModel = MannheimViewModel(_scheduleSourceProvider);
@@ -63,6 +63,16 @@ class SelectMannheimCourseDialog {
       TextButton(
         child: Text(L.of(context).dialogOk.toUpperCase()),
         onPressed: () async {
+          final course = _mannheimViewModel.selectedCourse;
+          if (course == null) return;
+          if (!await ScheduleSourceChangeConfirmation.confirmIfNeeded(
+            context: context,
+            sourceProvider: _scheduleSourceProvider,
+            nextType: ScheduleSourceType.Mannheim,
+            nextIdentityValue: course.scheduleId,
+          )) {
+            return;
+          }
           await _mannheimViewModel.save();
           Navigator.of(context).pop();
         },

--- a/lib/schedule/ui/widgets/select_mannheim_course_dialog.dart
+++ b/lib/schedule/ui/widgets/select_mannheim_course_dialog.dart
@@ -65,6 +65,8 @@ class SelectMannheimCourseDialog {
         onPressed: () async {
           final course = _mannheimViewModel.selectedCourse;
           if (course == null) return;
+          final previousSourceIdentity =
+              _scheduleSourceProvider.currentSourceIdentity;
           if (!await ScheduleSourceChangeConfirmation.confirmIfNeeded(
             context: context,
             sourceProvider: _scheduleSourceProvider,
@@ -74,7 +76,11 @@ class SelectMannheimCourseDialog {
             return;
           }
           await _mannheimViewModel.save();
-          Navigator.of(context).pop();
+          await ScheduleSourceChangeConfirmation.finishCommittedChange(
+            sourceProvider: _scheduleSourceProvider,
+            previousSourceIdentity: previousSourceIdentity,
+          );
+          if (context.mounted) Navigator.of(context).pop();
         },
       ),
     ];

--- a/lib/schedule/ui/widgets/select_source_dialog.dart
+++ b/lib/schedule/ui/widgets/select_source_dialog.dart
@@ -6,6 +6,7 @@ import 'package:dualmate/schedule/ui/widgets/enter_dualis_credentials_dialog.dar
 import 'package:dualmate/schedule/ui/widgets/enter_ical_url.dart';
 import 'package:dualmate/schedule/ui/widgets/enter_rapla_url_dialog.dart';
 import 'package:dualmate/schedule/ui/widgets/select_mannheim_course_dialog.dart';
+import 'package:dualmate/schedule/ui/widgets/schedule_source_change_confirmation.dart';
 import 'package:flutter/material.dart';
 import 'package:kiwi/kiwi.dart';
 
@@ -90,6 +91,14 @@ class SelectSourceDialog {
   ) async {
     switch (type) {
       case ScheduleSourceType.None:
+        if (!await ScheduleSourceChangeConfirmation.confirmIfNeeded(
+          context: context,
+          sourceProvider: _scheduleSourceProvider,
+          nextType: ScheduleSourceType.None,
+          nextIdentityValue: '',
+        )) {
+          return;
+        }
         await _preferencesProvider.setScheduleSourceType(type.index);
         await _scheduleSourceProvider.setupScheduleSource();
         break;

--- a/lib/schedule/ui/widgets/select_source_dialog.dart
+++ b/lib/schedule/ui/widgets/select_source_dialog.dart
@@ -91,6 +91,8 @@ class SelectSourceDialog {
   ) async {
     switch (type) {
       case ScheduleSourceType.None:
+        final previousSourceIdentity =
+            _scheduleSourceProvider.currentSourceIdentity;
         if (!await ScheduleSourceChangeConfirmation.confirmIfNeeded(
           context: context,
           sourceProvider: _scheduleSourceProvider,
@@ -101,6 +103,10 @@ class SelectSourceDialog {
         }
         await _preferencesProvider.setScheduleSourceType(type.index);
         await _scheduleSourceProvider.setupScheduleSource();
+        await ScheduleSourceChangeConfirmation.finishCommittedChange(
+          sourceProvider: _scheduleSourceProvider,
+          previousSourceIdentity: previousSourceIdentity,
+        );
         break;
       case ScheduleSourceType.Rapla:
         await EnterRaplaUrlDialog(

--- a/lib/ui/banner_widget.dart
+++ b/lib/ui/banner_widget.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 
 class BannerWidget extends StatelessWidget {
+  final String? title;
   final String message;
   final String buttonText;
   final VoidCallback onButtonTap;
 
   const BannerWidget({
     Key? key,
+    this.title,
     required this.message,
     required this.buttonText,
     required this.onButtonTap,
@@ -31,21 +33,28 @@ class BannerWidget extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
-            Text(
-              message,
-            ),
+            if (title != null) ...[
+              Text(
+                title!,
+                style: Theme.of(
+                  context,
+                ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 4),
+            ],
+            Text(message),
             Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.fromLTRB(0, 12, 0, 0),
-                        child: FilledButton(
-                          onPressed: onButtonTap,
-                          child: Text(buttonText),
-                        ),
-                      ),
-                    ],
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(0, 12, 0, 0),
+                  child: FilledButton(
+                    onPressed: onButtonTap,
+                    child: Text(buttonText),
                   ),
+                ),
+              ],
+            ),
           ],
         ),
       ),

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -123,7 +123,7 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
       _fetchLaunchRoute();
       _fetchLaunchPayload();
       final container = KiwiContainer();
-      if (container.isRegistered<ClassReminderController>()) {
+      if (isInitialized && container.isRegistered<ClassReminderController>()) {
         unawaited(
           container
               .resolve<ClassReminderController>()

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -124,7 +124,19 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
       _fetchLaunchPayload();
       final container = KiwiContainer();
       if (container.isRegistered<ClassReminderController>()) {
-        unawaited(container.resolve<ClassReminderController>().onAppResumed());
+        unawaited(
+          container
+              .resolve<ClassReminderController>()
+              .onAppResumed()
+              .catchError((Object error, StackTrace trace) async {
+                await AppDiagnostics.instance.reportCaughtException(
+                  error,
+                  trace,
+                  message: 'Class reminder resume handling failed',
+                  tags: {'feature': 'class_reminders'},
+                );
+              }),
+        );
       }
     }
   }

--- a/lib/ui/root_page.dart
+++ b/lib/ui/root_page.dart
@@ -15,6 +15,7 @@ import 'package:dualmate/common/appstart/locale_preference_sync.dart';
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/util/launch_intent.dart';
 import 'package:dualmate/common/util/widget_navigation_payload.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:kiwi/kiwi.dart';
 import 'package:flutter/services.dart';
 import 'package:dualmate/ui/navigation/main_section_controller.dart';
@@ -121,6 +122,10 @@ class _RootPageState extends State<RootPage> with WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed) {
       _fetchLaunchRoute();
       _fetchLaunchPayload();
+      final container = KiwiContainer();
+      if (container.isRegistered<ClassReminderController>()) {
+        unawaited(container.resolve<ClassReminderController>().onAppResumed());
+      }
     }
   }
 

--- a/test/common/appstart/service_injector_reminder_test.dart
+++ b/test/common/appstart/service_injector_reminder_test.dart
@@ -1,0 +1,55 @@
+import 'package:dualmate/common/appstart/service_injector.dart';
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/ui/notification_api.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kiwi/kiwi.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('injected class reminders use DualMate saved language', () async {
+    SharedPreferences.setMockInitialValues({
+      PreferencesProvider.LastUsedLanguageCode: 'de-DE',
+    });
+    final api = _RecordingNotificationApi();
+    KiwiContainer().registerInstance<NotificationApi>(api);
+    addTearDown(KiwiContainer().clear);
+
+    injectServices(false);
+    injectServices(false);
+    await KiwiContainer()
+        .resolve<ClassReminderController>()
+        .refreshPermissionState();
+    final scheduler = KiwiContainer().resolve<ClassReminderScheduler>();
+    final classStart = DateTime(2026, 7, 24, 8, 30);
+    await scheduler.schedule(
+      ClassReminderNotificationRequest(
+        notificationId: -1,
+        className: 'Recht',
+        classStart: classStart,
+        scheduledTime: classStart.subtract(const Duration(minutes: 30)),
+        offset: const Duration(minutes: 30),
+        room: '',
+        occurrenceIdentity: 'recht',
+      ),
+    );
+
+    expect(api.title, 'Recht beginnt in 30 Minuten');
+  });
+}
+
+class _RecordingNotificationApi extends VoidNotificationApi {
+  String? title;
+
+  @override
+  Future<void> scheduleExactNotification({
+    required int id,
+    required String title,
+    required String body,
+    required DateTime scheduledTime,
+    required String payload,
+  }) async {
+    this.title = title;
+  }
+}

--- a/test/common/appstart/service_injector_reminder_test.dart
+++ b/test/common/appstart/service_injector_reminder_test.dart
@@ -17,7 +17,6 @@ void main() {
     addTearDown(KiwiContainer().clear);
 
     injectServices(false);
-    injectServices(false);
     await KiwiContainer()
         .resolve<ClassReminderController>()
         .refreshPermissionState();

--- a/test/common/ui/notification_api_test.dart
+++ b/test/common/ui/notification_api_test.dart
@@ -60,6 +60,79 @@ void main() {
     await Future<void>.delayed(Duration.zero);
   });
 
+  test('class reminder channel state is checked independently', () async {
+    final api = NotificationApi(
+      classReminderChannelChecker: (_) async => false,
+    );
+
+    expect(await api.areClassRemindersEnabled(), isFalse);
+  });
+
+  test('default checker detects a disabled Android reminder channel', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+    const channel = MethodChannel('dexterous.com/flutter/local_notifications');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          if (call.method != 'getNotificationChannels') return null;
+          return [
+            <String, Object?>{
+              'id': NotificationApi.classReminderChannelId,
+              'name': 'Class reminders',
+              'description': '',
+              'groupId': null,
+              'showBadge': true,
+              'importance': Importance.none.value,
+              'playSound': false,
+              'sound': null,
+              'enableVibration': true,
+              'vibrationPattern': null,
+              'enableLights': false,
+              'ledColor': 0,
+              'audioAttributesUsage': AudioAttributesUsage.notification.value,
+            },
+          ];
+        });
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    expect(await NotificationApi().areClassRemindersEnabled(), isFalse);
+  });
+
+  test('default checker allows a reminder channel not created yet', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+    const channel = MethodChannel('dexterous.com/flutter/local_notifications');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          if (call.method == 'getNotificationChannels') return <Object?>[];
+          return null;
+        });
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    expect(await NotificationApi().areClassRemindersEnabled(), isTrue);
+  });
+
+  test('class reminder settings use the dedicated channel opener', () async {
+    var opens = 0;
+    final api = NotificationApi(
+      classReminderSettingsOpener: () async {
+        opens++;
+        return true;
+      },
+    );
+
+    expect(await api.openClassReminderSettings(), isTrue);
+    expect(opens, 1);
+  });
+
   test(
     'class reminders use an exact alarm at the requested Berlin time',
     () async {

--- a/test/common/ui/notification_api_test.dart
+++ b/test/common/ui/notification_api_test.dart
@@ -1,10 +1,16 @@
 import 'dart:async';
 
 import 'package:dualmate/common/ui/notification_api.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('initialize does not wait for runtime permission completion', () async {
     final permissionCompleter = Completer<bool?>();
     var permissionRequested = false;
@@ -46,14 +52,57 @@ void main() {
     final api = NotificationApi(
       pluginInitializer: (_, __, ___) async => true,
       runtimePermissionRequester: (_) async {
-        throw PlatformException(
-          code: 'permission-error',
-          message: 'boom',
-        );
+        throw PlatformException(code: 'permission-error', message: 'boom');
       },
     );
 
     await api.initialize(requestRuntimePermission: true);
     await Future<void>.delayed(Duration.zero);
   });
+
+  test(
+    'class reminders use an exact alarm at the requested Berlin time',
+    () async {
+      tz_data.initializeTimeZones();
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      AndroidFlutterLocalNotificationsPlugin.registerWith();
+      const channel = MethodChannel(
+        'dexterous.com/flutter/local_notifications',
+      );
+      MethodCall? recordedCall;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            recordedCall = call;
+            return null;
+          });
+      addTearDown(() {
+        debugDefaultTargetPlatformOverride = null;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+      final scheduledTime = DateTime.now().add(const Duration(days: 1));
+
+      await NotificationApi().scheduleExactNotification(
+        id: -42,
+        title: 'Recht starts in 30 minutes',
+        body: 'The class begins at 08:30.',
+        scheduledTime: scheduledTime,
+        payload: '{"title":"Recht"}',
+      );
+
+      expect(recordedCall?.method, 'zonedSchedule');
+      final arguments = recordedCall?.arguments as Map<Object?, Object?>;
+      final expected = tz.TZDateTime.from(
+        scheduledTime,
+        tz.getLocation('Europe/Berlin'),
+      );
+      expect(arguments['id'], -42);
+      expect(arguments['title'], 'Recht starts in 30 minutes');
+      expect(arguments['scheduledDateTimeISO8601'], expected.toIso8601String());
+      expect(arguments['timeZoneName'], 'Europe/Berlin');
+      final platform = arguments['platformSpecifics'] as Map<Object?, Object?>;
+      expect(platform['channelId'], 'class_reminders');
+      expect(platform['scheduleMode'], 'exactAllowWhileIdle');
+    },
+  );
 }

--- a/test/schedule/business/schedule_provider_callback_ordering_test.dart
+++ b/test/schedule/business/schedule_provider_callback_ordering_test.dart
@@ -103,6 +103,46 @@ void main() {
     expect(capturedOrigin, ScheduleRefreshOrigin.userBrowsing);
   });
 
+  test(
+      'persisted callbacks receive unfiltered entries while UI callbacks are filtered',
+      () async {
+    final schedule = Schedule.fromList([
+      ScheduleEntry(
+        start: DateTime(2026, 2, 24, 9),
+        end: DateTime(2026, 2, 24, 10),
+        title: 'Math',
+        details: 'Lecture',
+        professor: 'Prof',
+        room: 'A1',
+        type: ScheduleEntryType.Class,
+      ),
+    ]);
+    final provider = ScheduleProvider(
+      _FakeScheduleSourceProvider(_FakeScheduleSource(schedule)),
+      _FakeScheduleEntryRepository(),
+      _FakeScheduleQueryInformationRepository(),
+      _FakePreferencesProvider(),
+      _FakeScheduleFilterRepository(['Math']),
+    );
+    Schedule? persisted;
+    Schedule? visible;
+    provider.addSchedulePersistedCallback((schedule, _, __) {
+      persisted = schedule;
+    });
+    provider.addScheduleUpdatedCallback((schedule, _, __) async {
+      visible = schedule;
+    });
+
+    await provider.getUpdatedSchedule(
+      DateTime(2026, 2, 24),
+      DateTime(2026, 2, 25),
+      CancellationToken(),
+    );
+
+    expect(persisted?.entries.map((entry) => entry.title), ['Math']);
+    expect(visible?.entries, isEmpty);
+  });
+
   test('schedule parse errors are reported through crash reporting', () async {
     final reportedErrors = <Object>[];
     final reportedTraces = <StackTrace>[];
@@ -246,8 +286,12 @@ class _FakePreferencesProvider implements PreferencesProvider {
 }
 
 class _FakeScheduleFilterRepository implements ScheduleFilterRepository {
+  final List<String> hiddenNames;
+
+  _FakeScheduleFilterRepository([this.hiddenNames = const []]);
+
   @override
-  Future<List<String>> queryAllHiddenNames() async => [];
+  Future<List<String>> queryAllHiddenNames() async => hiddenNames;
 
   @override
   dynamic noSuchMethod(Invocation invocation) {

--- a/test/schedule/business/schedule_source_identity_test.dart
+++ b/test/schedule/business/schedule_source_identity_test.dart
@@ -38,4 +38,47 @@ void main() {
       isNot(ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, second)),
     );
   });
+
+  test('Rapla identity with repeated key differs from either single-value URL', () {
+    const repeated =
+        'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B4&file=TINF25B5';
+    const singleFirst =
+        'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B4';
+    // Old Map.fromEntries collapsed repeated keys to the last sorted value
+    // (TINF25B5). The repeated identity must differ from that value too.
+    const singleLast =
+        'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B5';
+
+    final repeatedId = ScheduleSourceIdentity.create(
+      ScheduleSourceType.Rapla,
+      repeated,
+    );
+    expect(
+      repeatedId,
+      isNot(
+        ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, singleFirst),
+      ),
+    );
+    expect(
+      repeatedId,
+      isNot(
+        ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, singleLast),
+      ),
+    );
+  });
+
+  test(
+    'Rapla identity with repeated key is the same regardless of value order',
+    () {
+      const orderA =
+          'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B4&file=TINF25B5';
+      const orderB =
+          'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B5&file=TINF25B4';
+
+      expect(
+        ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, orderA),
+        ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, orderB),
+      );
+    },
+  );
 }

--- a/test/schedule/business/schedule_source_identity_test.dart
+++ b/test/schedule/business/schedule_source_identity_test.dart
@@ -1,0 +1,41 @@
+import 'package:dualmate/schedule/business/schedule_source_identity.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Rapla identity ignores navigation and date parameters', () {
+    const first =
+        'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B4&day=1&month=7&year=2026&next=%3E%3E';
+    const second =
+        'https://rapla.dhbw-karlsruhe.de/rapla?year=2027&file=TINF25B4&prev=%3C%3C&user=eisenbiegler&page=calendar&month=2&day=18';
+
+    expect(
+      ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, first),
+      ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, second),
+    );
+  });
+
+  test('Rapla identity normalizes omitted scheme and host casing', () {
+    const first =
+        'rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B4';
+    const second =
+        'https://RAPLA.DHBW-KARLSRUHE.DE/rapla?file=TINF25B4&user=eisenbiegler&page=calendar';
+
+    expect(
+      ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, first),
+      ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, second),
+    );
+  });
+
+  test('Rapla identity changes when the actual calendar changes', () {
+    const first =
+        'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B4';
+    const second =
+        'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=eisenbiegler&file=TINF25B5';
+
+    expect(
+      ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, first),
+      isNot(ScheduleSourceIdentity.create(ScheduleSourceType.Rapla, second)),
+    );
+  });
+}

--- a/test/schedule/business/schedule_source_provider_test.dart
+++ b/test/schedule/business/schedule_source_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_query_information_repository.dart';
+import 'package:dualmate/schedule/model/schedule_source_type.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -22,12 +23,42 @@ void main() {
       expect(queryRepo.deleteAllCalls, 1);
     });
   });
+
+  group('wouldChangeTo', () {
+    ScheduleSourceProvider _makeUnconfiguredProvider() =>
+        ScheduleSourceProvider(
+          _FakePreferencesProvider(),
+          false,
+          _RecordingEntryRepository(),
+          _RecordingQueryInformationRepository(),
+        );
+
+    test('reports no change for None type with empty value', () {
+      final provider = _makeUnconfiguredProvider();
+      expect(provider.wouldChangeTo(ScheduleSourceType.None, ''), isFalse);
+    });
+
+    test('reports no change for configured type with empty value', () {
+      final provider = _makeUnconfiguredProvider();
+      expect(provider.wouldChangeTo(ScheduleSourceType.Rapla, ''), isFalse);
+    });
+
+    test('reports change for configured type with non-empty value', () {
+      final provider = _makeUnconfiguredProvider();
+      expect(
+        provider.wouldChangeTo(
+          ScheduleSourceType.Rapla,
+          'https://rapla.dhbw-karlsruhe.de/rapla?page=calendar&user=test&file=TINF25B4',
+        ),
+        isTrue,
+      );
+    });
+  });
 }
 
 class _FakePreferencesProvider implements PreferencesProvider {
   @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      super.noSuchMethod(invocation);
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _RecordingEntryRepository implements ScheduleEntryRepository {
@@ -39,8 +70,7 @@ class _RecordingEntryRepository implements ScheduleEntryRepository {
   }
 
   @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      super.noSuchMethod(invocation);
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _RecordingQueryInformationRepository
@@ -53,6 +83,5 @@ class _RecordingQueryInformationRepository
   }
 
   @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      super.noSuchMethod(invocation);
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/schedule/reminders/canonical_class_name_test.dart
+++ b/test/schedule/reminders/canonical_class_name_test.dart
@@ -18,6 +18,7 @@ void main() {
         'Fluidmechanik',
       );
       expect(CanonicalClassName.fromTitle('W3WI_SE411 Recht'), 'Recht');
+      expect(CanonicalClassName.fromTitle('ABC12 - Seminar'), 'Seminar');
     });
 
     test('preserves meaningful title distinctions', () {

--- a/test/schedule/reminders/canonical_class_name_test.dart
+++ b/test/schedule/reminders/canonical_class_name_test.dart
@@ -21,6 +21,20 @@ void main() {
       expect(CanonicalClassName.fromTitle('ABC12 - Seminar'), 'Seminar');
     });
 
+    test('exposes and removes strict course-code prefixes', () {
+      const title = 'WWIA23B2 - Recht';
+
+      expect(CanonicalClassName.courseCodePrefix(title), 'WWIA23B2 -');
+      expect(CanonicalClassName.removeCourseCodePrefix(title), 'Recht');
+    });
+
+    test('recognizes fallback uppercase course-code prefixes', () {
+      const title = 'AB-12 Recht';
+
+      expect(CanonicalClassName.courseCodePrefix(title), 'AB-12');
+      expect(CanonicalClassName.fromTitle(title), 'Recht');
+    });
+
     test('preserves meaningful title distinctions', () {
       expect(CanonicalClassName.fromTitle('Recht II'), 'Recht II');
       expect(CanonicalClassName.fromTitle('Recht'), isNot('Recht II'));

--- a/test/schedule/reminders/canonical_class_name_test.dart
+++ b/test/schedule/reminders/canonical_class_name_test.dart
@@ -1,0 +1,39 @@
+import 'package:dualmate/schedule/reminders/canonical_class_name.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CanonicalClassName', () {
+    test(
+      'normalizes online prefixes and suffixes independently of display',
+      () {
+        expect(CanonicalClassName.fromTitle('Online - Recht'), 'Recht');
+        expect(CanonicalClassName.fromTitle('Recht online'), 'Recht');
+        expect(CanonicalClassName.fromTitle('(ONLINE) - Recht'), 'Recht');
+      },
+    );
+
+    test('removes recognized course-code prefixes', () {
+      expect(
+        CanonicalClassName.fromTitle('T3MB9025 Fluidmechanik'),
+        'Fluidmechanik',
+      );
+      expect(CanonicalClassName.fromTitle('W3WI_SE411 Recht'), 'Recht');
+    });
+
+    test('preserves meaningful title distinctions', () {
+      expect(CanonicalClassName.fromTitle('Recht II'), 'Recht II');
+      expect(CanonicalClassName.fromTitle('Recht'), isNot('Recht II'));
+    });
+
+    test(
+      'normalizes whitespace but keeps exact case-sensitive wording stable',
+      () {
+        expect(CanonicalClassName.fromTitle('  Recht   II  '), 'Recht II');
+        expect(
+          CanonicalClassName.fromTitle('Wirtschaftsrecht'),
+          isNot('Recht'),
+        );
+      },
+    );
+  });
+}

--- a/test/schedule/reminders/class_reminder_controller_startup_test.dart
+++ b/test/schedule/reminders/class_reminder_controller_startup_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
 import 'package:dualmate/common/data/database_access.dart';
+import 'package:dualmate/common/logging/diagnostic_exception_filter.dart';
 import 'package:dualmate/common/ui/notification_api.dart';
 import 'package:dualmate/schedule/business/schedule_provider.dart';
 import 'package:dualmate/schedule/business/schedule_source_provider.dart';
@@ -254,6 +255,48 @@ void main() {
     },
   );
 
+  test(
+    'permission check throws after granted: state becomes denied and pause path cancels alarms',
+    () async {
+      final scheduler = _RecordingScheduler();
+      final repository = _ManifestReminderRepository();
+      final source = _FakeScheduleSourceProvider();
+      // Start with granted; switch to throwing after initialization.
+      var throwOnCheck = false;
+      NotificationApi? apiFactory() {
+        if (throwOnCheck) return _ThrowingNotificationApi();
+        return _GrantedNotificationApi();
+      }
+
+      final controller = ClassReminderController(
+        repository: repository,
+        scheduleProvider: _FakeScheduleProvider(source),
+        sourceProvider: source,
+        scheduler: scheduler,
+        notificationApi: apiFactory,
+        now: () => DateTime(2026, 7, 20, 8),
+      );
+      addTearDown(controller.dispose);
+
+      // Initialize with granted permissions.
+      await controller.initialize();
+      expect(controller.permissionsGranted, isTrue);
+      expect(controller.permissionStateKnown, isTrue);
+
+      // Second check throws: state must flip to known/denied and pause path runs.
+      throwOnCheck = true;
+      await controller.refreshPermissionState();
+
+      expect(controller.permissionStateKnown, isTrue);
+      expect(controller.permissionsGranted, isFalse);
+      expect(controller.remindersPaused, isTrue);
+      expect(
+        scheduler.cancelledIds,
+        contains(_ManifestReminderRepository.manifestNotificationId),
+      );
+    },
+  );
+
   test('failed initialization can be retried', () async {
     final repository = _FailOnceReminderRepository();
     final source = _FakeScheduleSourceProvider();
@@ -475,3 +518,57 @@ class _FakeScheduleFilterRepository extends Fake
     implements ScheduleFilterRepository {}
 
 class _UnusedDatabaseAccess extends DatabaseAccess {}
+
+class _ThrowingNotificationApi extends VoidNotificationApi {
+  @override
+  Future<bool> areNotificationsEnabled() =>
+      Future.error(_PermissionCheckFailure());
+}
+
+/// An [ExpectedExternalFailure] so AppDiagnostics suppresses it without
+/// calling Sentry (which requires path_provider in tests).
+class _PermissionCheckFailure implements ExpectedExternalFailure, Exception {
+  @override
+  String toString() => 'Simulated permission check failure';
+}
+
+class _RecordingScheduler implements ClassReminderScheduler {
+  final List<int> cancelledIds = [];
+
+  @override
+  Future<void> cancel(int notificationId) async {
+    cancelledIds.add(notificationId);
+  }
+
+  @override
+  Future<void> schedule(ClassReminderNotificationRequest request) async {}
+}
+
+/// Repository that exposes a single manifest row so _pauseSource has something
+/// to cancel.
+class _ManifestReminderRepository extends _MemoryReminderRepository {
+  static const int manifestNotificationId = 42;
+
+  @override
+  Future<List<ScheduledClassNotification>> loadManifestForSource(
+    String sourceIdentity,
+  ) async => [
+    ScheduledClassNotification(
+      ruleId: 'recht',
+      occurrenceIdentity: 'occ1',
+      sourceIdentity: 'rapla:a',
+      notificationId: manifestNotificationId,
+      scheduledTime: DateTime.utc(2026, 7, 20, 10),
+      classStart: DateTime.utc(2026, 7, 20, 10),
+      contentFingerprint: 'fp',
+    ),
+  ];
+
+  @override
+  Future<void> applyManifestChanges({
+    required List<ScheduledClassNotification> upserts,
+    required List<ScheduledClassNotification> removals,
+  }) async {
+    // No-op: no real database in tests.
+  }
+}

--- a/test/schedule/reminders/class_reminder_controller_startup_test.dart
+++ b/test/schedule/reminders/class_reminder_controller_startup_test.dart
@@ -9,10 +9,12 @@ import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
 import 'package:dualmate/schedule/data/schedule_query_information_repository.dart';
 import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:dualmate/schedule/reminders/class_reminder.dart';
 import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
 import 'package:dualmate/schedule/reminders/class_reminder_repository.dart';
 import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+import 'package:dualmate/schedule/reminders/reminder_sync_queue.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -50,7 +52,11 @@ void main() {
       expect(find.text('paused banner'), findsNothing);
       expect(find.text('schedule'), findsOneWidget);
 
-      permissions.complete(notification: true, exactAlarm: true);
+      permissions.complete(
+        notification: true,
+        reminderChannel: true,
+        exactAlarm: true,
+      );
       await initialization;
       await tester.pump();
 
@@ -59,7 +65,11 @@ void main() {
     },
   );
 
-  for (final missingPermission in ['notifications', 'exact alarm']) {
+  for (final missingPermission in [
+    'notifications',
+    'reminder channel',
+    'exact alarm',
+  ]) {
     testWidgets(
       'startup renders paused after $missingPermission permission is denied',
       (tester) async {
@@ -93,6 +103,7 @@ void main() {
 
         permissions.complete(
           notification: missingPermission != 'notifications',
+          reminderChannel: missingPermission != 'reminder channel',
           exactAlarm: missingPermission != 'exact alarm',
         );
         await initialization;
@@ -102,22 +113,188 @@ void main() {
       },
     );
   }
+
+  testWidgets(
+    'missing notification service stays unknown instead of showing paused',
+    (tester) async {
+      final source = _FakeScheduleSourceProvider();
+      final controller = ClassReminderController(
+        repository: _MemoryReminderRepository(),
+        scheduleProvider: _FakeScheduleProvider(source),
+        sourceProvider: source,
+        scheduler: _NoopScheduler(),
+        notificationApi: () => null,
+        now: () => DateTime(2026, 7, 20, 8),
+      );
+      addTearDown(controller.dispose);
+
+      await controller.initialize();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text(controller.remindersPaused ? 'paused banner' : 'schedule'),
+        ),
+      );
+
+      expect(controller.hasReminders, isTrue);
+      expect(controller.permissionStateKnown, isFalse);
+      expect(find.text('paused banner'), findsNothing);
+      expect(find.text('schedule'), findsOneWidget);
+    },
+  );
+
+  test(
+    'fix permissions opens the disabled reminder channel settings',
+    () async {
+      final permissions = _ChannelDisabledNotificationApi();
+      final source = _FakeScheduleSourceProvider();
+      final controller = ClassReminderController(
+        repository: _MemoryReminderRepository(),
+        scheduleProvider: _FakeScheduleProvider(source),
+        sourceProvider: source,
+        scheduler: _NoopScheduler(),
+        notificationApi: () => permissions,
+        now: () => DateTime(2026, 7, 20, 8),
+      );
+      addTearDown(controller.dispose);
+
+      await controller.initialize();
+      expect(controller.remindersPaused, isTrue);
+
+      await controller.openReliablePermissionSettings();
+
+      expect(permissions.channelSettingsOpens, 1);
+      expect(permissions.runtimePermissionRequests, 0);
+      expect(permissions.exactAlarmPermissionRequests, 0);
+      expect(controller.permissionsGranted, isTrue);
+    },
+  );
+
+  test('fix permissions opens only one settings surface at a time', () async {
+    final permissions = _ChannelDisabledNotificationApi(
+      exactAlarmAllowed: false,
+    );
+    final source = _FakeScheduleSourceProvider();
+    final controller = ClassReminderController(
+      repository: _MemoryReminderRepository(),
+      scheduleProvider: _FakeScheduleProvider(source),
+      sourceProvider: source,
+      scheduler: _NoopScheduler(),
+      notificationApi: () => permissions,
+      now: () => DateTime(2026, 7, 20, 8),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    await controller.openReliablePermissionSettings();
+
+    expect(permissions.channelSettingsOpens, 1);
+    expect(permissions.exactAlarmPermissionRequests, 0);
+  });
+
+  test('unchanged resume does not notify schedule listeners', () async {
+    final source = _FakeScheduleSourceProvider();
+    final controller = ClassReminderController(
+      repository: _MemoryReminderRepository(),
+      scheduleProvider: _FakeScheduleProvider(source),
+      sourceProvider: source,
+      scheduler: _NoopScheduler(),
+      notificationApi: () => _GrantedNotificationApi(),
+      now: () => DateTime(2026, 7, 20, 8),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    var notifications = 0;
+    controller.addListener(() => notifications++);
+
+    await controller.onAppResumed();
+
+    expect(notifications, 0);
+  });
+
+  test(
+    'queued refresh does not cancel alarms while permissions are unknown',
+    () async {
+      final repository = _MemoryReminderRepository();
+      final source = _FakeScheduleSourceProvider();
+      final controller = ClassReminderController(
+        repository: repository,
+        scheduleProvider: _FakeScheduleProvider(source),
+        sourceProvider: source,
+        scheduler: _NoopScheduler(),
+        notificationApi: () => null,
+        now: () => DateTime(2026, 7, 20, 8),
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      final start = DateTime(2026, 7, 20);
+      controller.queue.enqueue(
+        ReminderSyncRequest(
+          schedule: Schedule.fromList([
+            ScheduleEntry(
+              start: DateTime(2026, 7, 20, 10),
+              end: DateTime(2026, 7, 20, 12),
+              title: 'Recht',
+              details: '',
+              professor: '',
+              room: '',
+              type: ScheduleEntryType.Class,
+            ),
+          ]),
+          start: start,
+          end: start.add(const Duration(days: 7)),
+          sourceIdentity: 'rapla:a',
+          sourceGeneration: 1,
+        ),
+      );
+
+      await controller.queue.drain();
+
+      expect(controller.permissionStateKnown, isFalse);
+      expect(repository.manifestWindowReads, 0);
+    },
+  );
+
+  test('failed initialization can be retried', () async {
+    final repository = _FailOnceReminderRepository();
+    final source = _FakeScheduleSourceProvider();
+    final controller = ClassReminderController(
+      repository: repository,
+      scheduleProvider: _FakeScheduleProvider(source),
+      sourceProvider: source,
+      scheduler: _NoopScheduler(),
+      notificationApi: () => _GrantedNotificationApi(),
+      now: () => DateTime(2026, 7, 20, 8),
+    );
+    addTearDown(controller.dispose);
+
+    await expectLater(controller.initialize(), throwsStateError);
+    await controller.initialize();
+
+    expect(controller.isInitialized, isTrue);
+    expect(repository.loadAttempts, greaterThanOrEqualTo(2));
+  });
 }
 
 class _DelayedNotificationApi extends VoidNotificationApi {
   final Completer<void> checksStarted = Completer<void>();
   final Completer<bool> _notificationPermission = Completer<bool>();
+  final Completer<bool> _reminderChannelPermission = Completer<bool>();
   final Completer<bool> _exactAlarmPermission = Completer<bool>();
   var _checks = 0;
 
-  void complete({required bool notification, required bool exactAlarm}) {
+  void complete({
+    required bool notification,
+    required bool reminderChannel,
+    required bool exactAlarm,
+  }) {
     _notificationPermission.complete(notification);
+    _reminderChannelPermission.complete(reminderChannel);
     _exactAlarmPermission.complete(exactAlarm);
   }
 
   void _didStartCheck() {
     _checks += 1;
-    if (_checks == 2) checksStarted.complete();
+    if (_checks == 3) checksStarted.complete();
   }
 
   @override
@@ -127,10 +304,65 @@ class _DelayedNotificationApi extends VoidNotificationApi {
   }
 
   @override
+  Future<bool> areClassRemindersEnabled() {
+    _didStartCheck();
+    return _reminderChannelPermission.future;
+  }
+
+  @override
   Future<bool> canScheduleExactNotifications() {
     _didStartCheck();
     return _exactAlarmPermission.future;
   }
+}
+
+class _ChannelDisabledNotificationApi extends VoidNotificationApi {
+  final bool exactAlarmAllowed;
+  bool channelEnabled = false;
+  int channelSettingsOpens = 0;
+  int runtimePermissionRequests = 0;
+  int exactAlarmPermissionRequests = 0;
+
+  _ChannelDisabledNotificationApi({this.exactAlarmAllowed = true});
+
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
+  @override
+  Future<bool> areClassRemindersEnabled() async => channelEnabled;
+
+  @override
+  Future<bool> canScheduleExactNotifications() async => exactAlarmAllowed;
+
+  @override
+  Future<bool?> requestRuntimePermission() async {
+    runtimePermissionRequests++;
+    return true;
+  }
+
+  @override
+  Future<bool> requestExactAlarmPermission() async {
+    exactAlarmPermissionRequests++;
+    return true;
+  }
+
+  @override
+  Future<bool> openClassReminderSettings() async {
+    channelSettingsOpens++;
+    channelEnabled = true;
+    return true;
+  }
+}
+
+class _GrantedNotificationApi extends VoidNotificationApi {
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
+  @override
+  Future<bool> areClassRemindersEnabled() async => true;
+
+  @override
+  Future<bool> canScheduleExactNotifications() async => true;
 }
 
 class _MemoryReminderRepository extends ClassReminderRepository {
@@ -145,6 +377,7 @@ class _MemoryReminderRepository extends ClassReminderRepository {
       sourceIdentity: 'rapla:a',
     ),
   ];
+  int manifestWindowReads = 0;
 
   @override
   Future<ExpiredReminderDeletionCount> deleteExpired(DateTime now) async {
@@ -162,12 +395,29 @@ class _MemoryReminderRepository extends ClassReminderRepository {
     required String sourceIdentity,
     required DateTime start,
     required DateTime end,
-  }) async => const [];
+  }) async {
+    manifestWindowReads++;
+    return const [];
+  }
 
   @override
   Future<List<ScheduledClassNotification>> loadManifestForSource(
     String sourceIdentity,
   ) async => const [];
+}
+
+class _FailOnceReminderRepository extends _MemoryReminderRepository {
+  int loadAttempts = 0;
+
+  @override
+  Future<List<ClassReminderRule>> loadRelevantRules({
+    required String sourceIdentity,
+    required DateTime now,
+  }) async {
+    loadAttempts++;
+    if (loadAttempts == 1) throw StateError('first load failed');
+    return super.loadRelevantRules(sourceIdentity: sourceIdentity, now: now);
+  }
 }
 
 class _FakeScheduleProvider extends ScheduleProvider {
@@ -181,7 +431,10 @@ class _FakeScheduleProvider extends ScheduleProvider {
       );
 
   @override
-  Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
+  Future<Schedule> getUnfilteredCachedSchedule(
+    DateTime start,
+    DateTime end,
+  ) async {
     return Schedule();
   }
 }

--- a/test/schedule/reminders/class_reminder_controller_startup_test.dart
+++ b/test/schedule/reminders/class_reminder_controller_startup_test.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+
+import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/data/database_access.dart';
+import 'package:dualmate/common/ui/notification_api.dart';
+import 'package:dualmate/schedule/business/schedule_provider.dart';
+import 'package:dualmate/schedule/business/schedule_source_provider.dart';
+import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
+import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
+import 'package:dualmate/schedule/data/schedule_query_information_repository.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'startup never renders paused while granted permissions are loading',
+    (tester) async {
+      final permissions = _DelayedNotificationApi();
+      final source = _FakeScheduleSourceProvider();
+      final controller = ClassReminderController(
+        repository: _MemoryReminderRepository(),
+        scheduleProvider: _FakeScheduleProvider(source),
+        sourceProvider: source,
+        scheduler: _NoopScheduler(),
+        notificationApi: () => permissions,
+        now: () => DateTime(2026, 7, 20, 8),
+      );
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AnimatedBuilder(
+            animation: controller,
+            builder: (context, _) =>
+                Text(controller.remindersPaused ? 'paused banner' : 'schedule'),
+          ),
+        ),
+      );
+
+      final initialization = controller.initialize();
+      await permissions.checksStarted.future;
+      await tester.pump();
+
+      expect(controller.hasReminders, isTrue);
+      expect(find.text('paused banner'), findsNothing);
+      expect(find.text('schedule'), findsOneWidget);
+
+      permissions.complete(notification: true, exactAlarm: true);
+      await initialization;
+      await tester.pump();
+
+      expect(find.text('paused banner'), findsNothing);
+      expect(find.text('schedule'), findsOneWidget);
+    },
+  );
+
+  for (final missingPermission in ['notifications', 'exact alarm']) {
+    testWidgets(
+      'startup renders paused after $missingPermission permission is denied',
+      (tester) async {
+        final permissions = _DelayedNotificationApi();
+        final source = _FakeScheduleSourceProvider();
+        final controller = ClassReminderController(
+          repository: _MemoryReminderRepository(),
+          scheduleProvider: _FakeScheduleProvider(source),
+          sourceProvider: source,
+          scheduler: _NoopScheduler(),
+          notificationApi: () => permissions,
+          now: () => DateTime(2026, 7, 20, 8),
+        );
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AnimatedBuilder(
+              animation: controller,
+              builder: (context, _) => Text(
+                controller.remindersPaused ? 'paused banner' : 'schedule',
+              ),
+            ),
+          ),
+        );
+
+        final initialization = controller.initialize();
+        await permissions.checksStarted.future;
+        await tester.pump();
+        expect(find.text('paused banner'), findsNothing);
+
+        permissions.complete(
+          notification: missingPermission != 'notifications',
+          exactAlarm: missingPermission != 'exact alarm',
+        );
+        await initialization;
+        await tester.pump();
+
+        expect(find.text('paused banner'), findsOneWidget);
+      },
+    );
+  }
+}
+
+class _DelayedNotificationApi extends VoidNotificationApi {
+  final Completer<void> checksStarted = Completer<void>();
+  final Completer<bool> _notificationPermission = Completer<bool>();
+  final Completer<bool> _exactAlarmPermission = Completer<bool>();
+  var _checks = 0;
+
+  void complete({required bool notification, required bool exactAlarm}) {
+    _notificationPermission.complete(notification);
+    _exactAlarmPermission.complete(exactAlarm);
+  }
+
+  void _didStartCheck() {
+    _checks += 1;
+    if (_checks == 2) checksStarted.complete();
+  }
+
+  @override
+  Future<bool> areNotificationsEnabled() {
+    _didStartCheck();
+    return _notificationPermission.future;
+  }
+
+  @override
+  Future<bool> canScheduleExactNotifications() {
+    _didStartCheck();
+    return _exactAlarmPermission.future;
+  }
+}
+
+class _MemoryReminderRepository extends ClassReminderRepository {
+  _MemoryReminderRepository() : super(_UnusedDatabaseAccess());
+
+  final rules = [
+    ClassReminderRule(
+      id: 'recht',
+      scope: ClassReminderScope.recurring,
+      canonicalTitle: 'Recht',
+      offset: const Duration(minutes: 30),
+      sourceIdentity: 'rapla:a',
+    ),
+  ];
+
+  @override
+  Future<ExpiredReminderDeletionCount> deleteExpired(DateTime now) async {
+    return const ExpiredReminderDeletionCount(oneTimeRules: 0, manifestRows: 0);
+  }
+
+  @override
+  Future<List<ClassReminderRule>> loadRelevantRules({
+    required String sourceIdentity,
+    required DateTime now,
+  }) async => rules;
+
+  @override
+  Future<List<ScheduledClassNotification>> loadManifestForWindow({
+    required String sourceIdentity,
+    required DateTime start,
+    required DateTime end,
+  }) async => const [];
+
+  @override
+  Future<List<ScheduledClassNotification>> loadManifestForSource(
+    String sourceIdentity,
+  ) async => const [];
+}
+
+class _FakeScheduleProvider extends ScheduleProvider {
+  _FakeScheduleProvider(ScheduleSourceProvider source)
+    : super(
+        source,
+        _FakeScheduleEntryRepository(),
+        _FakeScheduleQueryInformationRepository(),
+        _FakePreferencesProvider(),
+        _FakeScheduleFilterRepository(),
+      );
+
+  @override
+  Future<Schedule> getCachedSchedule(DateTime start, DateTime end) async {
+    return Schedule();
+  }
+}
+
+class _FakeScheduleSourceProvider extends ScheduleSourceProvider {
+  _FakeScheduleSourceProvider()
+    : super(
+        _FakePreferencesProvider(),
+        false,
+        _FakeScheduleEntryRepository(),
+        _FakeScheduleQueryInformationRepository(),
+      );
+
+  @override
+  String get currentSourceIdentity => 'rapla:a';
+
+  @override
+  int get sourceGeneration => 1;
+}
+
+class _NoopScheduler implements ClassReminderScheduler {
+  @override
+  Future<void> cancel(int notificationId) async {}
+
+  @override
+  Future<void> schedule(ClassReminderNotificationRequest request) async {}
+}
+
+class _FakePreferencesProvider extends Fake implements PreferencesProvider {}
+
+class _FakeScheduleEntryRepository extends Fake
+    implements ScheduleEntryRepository {}
+
+class _FakeScheduleQueryInformationRepository extends Fake
+    implements ScheduleQueryInformationRepository {}
+
+class _FakeScheduleFilterRepository extends Fake
+    implements ScheduleFilterRepository {}
+
+class _UnusedDatabaseAccess extends DatabaseAccess {}

--- a/test/schedule/reminders/class_reminder_coordinator_test.dart
+++ b/test/schedule/reminders/class_reminder_coordinator_test.dart
@@ -214,6 +214,42 @@ void main() {
     },
   );
 
+  test('ambiguous one-time rematch removes the obsolete reminder', () async {
+    final original = DateTime(2026, 7, 20, 10);
+    final rule = ClassReminderRule(
+      id: 'one',
+      scope: ClassReminderScope.oneTime,
+      canonicalTitle: 'Recht',
+      offset: const Duration(minutes: 15),
+      sourceIdentity: 'rapla:a',
+      occurrenceStart: original,
+      occurrenceEnd: original.add(const Duration(hours: 2)),
+    );
+    final repository = _MemoryRepository([rule]);
+    final oldManifest = _manifest(rule, original);
+    repository.manifest.add(oldManifest);
+    final scheduler = _RecordingScheduler();
+    final coordinator = ClassReminderCoordinator(
+      repository: repository,
+      scheduler: scheduler,
+      now: () => now,
+    );
+
+    await coordinator.reconcile(
+      schedule: Schedule.fromList([
+        _entry(DateTime(2026, 7, 20, 11), 'Recht'),
+        _entry(DateTime(2026, 7, 20, 12), 'Recht'),
+      ]),
+      start: windowStart,
+      end: windowEnd,
+      sourceIdentity: 'rapla:a',
+    );
+
+    expect(scheduler.scheduled, isEmpty);
+    expect(scheduler.cancelled, [oldManifest.notificationId]);
+    expect(repository.rules, isEmpty);
+  });
+
   test('pausing reminders cancels and removes manifest rows', () async {
     final rule = ClassReminderRule(
       id: 'recht',

--- a/test/schedule/reminders/class_reminder_coordinator_test.dart
+++ b/test/schedule/reminders/class_reminder_coordinator_test.dart
@@ -153,6 +153,39 @@ void main() {
       expect(repository.savedRules.single.occurrenceStart, moved);
     },
   );
+
+  test(
+    'one-time reminder survives a title edit at the same occurrence time',
+    () async {
+      final start = DateTime(2026, 7, 20, 10);
+      final rule = ClassReminderRule(
+        id: 'one',
+        scope: ClassReminderScope.oneTime,
+        canonicalTitle: 'Recht',
+        offset: const Duration(minutes: 15),
+        sourceIdentity: 'rapla:a',
+        occurrenceStart: start,
+        occurrenceEnd: start.add(const Duration(hours: 2)),
+      );
+      final repository = _MemoryRepository([rule]);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+
+      await coordinator.reconcile(
+        schedule: Schedule.fromList([_entry(start, 'Wirtschaftsrecht')]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(scheduler.scheduled, hasLength(1));
+      expect(repository.savedRules.single.canonicalTitle, 'Wirtschaftsrecht');
+    },
+  );
 }
 
 ScheduleEntry _entry(DateTime start, String title) => ScheduleEntry(

--- a/test/schedule/reminders/class_reminder_coordinator_test.dart
+++ b/test/schedule/reminders/class_reminder_coordinator_test.dart
@@ -45,6 +45,10 @@ void main() {
       expect(result.scheduleEntriesExamined, 3);
       expect(result.alarmsScheduled, 2);
       expect(scheduler.scheduled, hasLength(2));
+      expect(
+        scheduler.scheduled.map((request) => request.className),
+        containsAll(['Online - Recht', 'Recht online']),
+      );
     },
   );
 
@@ -284,7 +288,83 @@ void main() {
     },
   );
 
-  test('ambiguous one-time rematch removes the obsolete reminder', () async {
+  test(
+    'ambiguous one-time rematch preserves the rule for a later refresh',
+    () async {
+      final original = DateTime(2026, 7, 20, 10);
+      final rule = ClassReminderRule(
+        id: 'one',
+        scope: ClassReminderScope.oneTime,
+        canonicalTitle: 'Recht',
+        offset: const Duration(minutes: 15),
+        sourceIdentity: 'rapla:a',
+        occurrenceStart: original,
+        occurrenceEnd: original.add(const Duration(hours: 2)),
+      );
+      final repository = _MemoryRepository([rule]);
+      final oldManifest = _manifest(rule, original);
+      repository.manifest.add(oldManifest);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+
+      await coordinator.reconcile(
+        schedule: Schedule.fromList([
+          _entry(DateTime(2026, 7, 20, 9), 'Recht'),
+          _entry(DateTime(2026, 7, 20, 11), 'Recht'),
+        ]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(scheduler.scheduled, isEmpty);
+      expect(scheduler.cancelled, [oldManifest.notificationId]);
+      expect(repository.rules, [rule]);
+    },
+  );
+
+  test(
+    'one-time rematch chooses a unique nearest same-title occurrence',
+    () async {
+      final original = DateTime(2026, 7, 20, 10);
+      final moved = DateTime(2026, 7, 20, 11);
+      final rule = ClassReminderRule(
+        id: 'one',
+        scope: ClassReminderScope.oneTime,
+        canonicalTitle: 'Recht',
+        offset: const Duration(minutes: 15),
+        sourceIdentity: 'rapla:a',
+        occurrenceStart: original,
+        occurrenceEnd: original.add(const Duration(hours: 2)),
+      );
+      final repository = _MemoryRepository([rule]);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+
+      await coordinator.reconcile(
+        schedule: Schedule.fromList([
+          _entry(moved, 'Recht'),
+          _entry(DateTime(2026, 7, 22, 10), 'Recht'),
+        ]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(scheduler.scheduled.single.classStart, moved);
+      expect(repository.savedRules.single.occurrenceStart, moved);
+    },
+  );
+
+  test('confirmed removed one-time occurrence deletes its rule', () async {
     final original = DateTime(2026, 7, 20, 10);
     final rule = ClassReminderRule(
       id: 'one',
@@ -296,8 +376,6 @@ void main() {
       occurrenceEnd: original.add(const Duration(hours: 2)),
     );
     final repository = _MemoryRepository([rule]);
-    final oldManifest = _manifest(rule, original);
-    repository.manifest.add(oldManifest);
     final scheduler = _RecordingScheduler();
     final coordinator = ClassReminderCoordinator(
       repository: repository,
@@ -307,18 +385,50 @@ void main() {
 
     await coordinator.reconcile(
       schedule: Schedule.fromList([
-        _entry(DateTime(2026, 7, 20, 11), 'Recht'),
-        _entry(DateTime(2026, 7, 20, 12), 'Recht'),
+        _entry(DateTime(2026, 7, 20, 11), 'Marketing'),
       ]),
       start: windowStart,
       end: windowEnd,
       sourceIdentity: 'rapla:a',
     );
 
-    expect(scheduler.scheduled, isEmpty);
-    expect(scheduler.cancelled, [oldManifest.notificationId]);
     expect(repository.rules, isEmpty);
+    expect(scheduler.scheduled, isEmpty);
   });
+
+  test(
+    'moved one-time rule updates even when its notification time has passed',
+    () async {
+      final original = DateTime(2026, 7, 20, 9);
+      final moved = DateTime(2026, 7, 20, 8, 10);
+      final rule = ClassReminderRule(
+        id: 'one',
+        scope: ClassReminderScope.oneTime,
+        canonicalTitle: 'Recht',
+        offset: const Duration(minutes: 30),
+        sourceIdentity: 'rapla:a',
+        occurrenceStart: original,
+        occurrenceEnd: original.add(const Duration(hours: 2)),
+      );
+      final repository = _MemoryRepository([rule]);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+
+      await coordinator.reconcile(
+        schedule: Schedule.fromList([_entry(moved, 'Recht')]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(scheduler.scheduled, isEmpty);
+      expect(repository.savedRules.single.occurrenceStart, moved);
+    },
+  );
 
   test('pausing reminders cancels and removes manifest rows', () async {
     final rule = ClassReminderRule(

--- a/test/schedule/reminders/class_reminder_coordinator_test.dart
+++ b/test/schedule/reminders/class_reminder_coordinator_test.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_coordinator.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final now = DateTime(2026, 7, 20, 8);
+  final windowStart = DateTime(2026, 7, 20);
+  final windowEnd = DateTime(2026, 7, 27);
+
+  test(
+    'every canonical Recht occurrence receives a recurring reminder',
+    () async {
+      final repository = _MemoryRepository([
+        ClassReminderRule(
+          id: 'recht',
+          scope: ClassReminderScope.recurring,
+          canonicalTitle: 'Recht',
+          offset: const Duration(minutes: 15),
+          sourceIdentity: 'rapla:a',
+        ),
+      ]);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+      final schedule = Schedule.fromList([
+        _entry(DateTime(2026, 7, 20, 10), 'Online - Recht'),
+        _entry(DateTime(2026, 7, 22, 9), 'Recht online'),
+        _entry(DateTime(2026, 7, 23, 9), 'Recht II'),
+      ]);
+
+      final result = await coordinator.reconcile(
+        schedule: schedule,
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(result.scheduleEntriesExamined, 3);
+      expect(result.alarmsScheduled, 2);
+      expect(scheduler.scheduled, hasLength(2));
+    },
+  );
+
+  test(
+    'unchanged refresh performs no platform calls or manifest writes',
+    () async {
+      final rule = ClassReminderRule(
+        id: 'recht',
+        scope: ClassReminderScope.recurring,
+        canonicalTitle: 'Recht',
+        offset: const Duration(minutes: 15),
+        sourceIdentity: 'rapla:a',
+      );
+      final entry = _entry(DateTime(2026, 7, 20, 10), 'Recht');
+      final repository = _MemoryRepository([rule]);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+      await coordinator.reconcile(
+        schedule: Schedule.fromList([entry]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+      scheduler.scheduled.clear();
+      repository.manifestWriteCount = 0;
+
+      final result = await coordinator.reconcile(
+        schedule: Schedule.fromList([entry]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(result.alarmsScheduled, 0);
+      expect(result.alarmsCancelled, 0);
+      expect(scheduler.scheduled, isEmpty);
+      expect(scheduler.cancelled, isEmpty);
+      expect(repository.manifestWriteCount, 0);
+    },
+  );
+
+  test(
+    'returns before reading schedule or manifest when no rules exist',
+    () async {
+      final repository = _MemoryRepository([]);
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: _RecordingScheduler(),
+        now: () => now,
+      );
+
+      final result = await coordinator.reconcile(
+        schedule: Schedule.fromList([
+          _entry(DateTime(2026, 7, 20, 10), 'Recht'),
+        ]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(result.reminderRulesLoaded, 0);
+      expect(result.scheduleEntriesExamined, 0);
+      expect(repository.manifestReadCount, 0);
+    },
+  );
+
+  test(
+    'moved one-time occurrence replaces alarm and updates stored timing',
+    () async {
+      final original = DateTime(2026, 7, 20, 10);
+      final moved = DateTime(2026, 7, 20, 12);
+      final rule = ClassReminderRule(
+        id: 'one',
+        scope: ClassReminderScope.oneTime,
+        canonicalTitle: 'Recht',
+        offset: const Duration(minutes: 15),
+        sourceIdentity: 'rapla:a',
+        occurrenceStart: original,
+        occurrenceEnd: original.add(const Duration(hours: 2)),
+      );
+      final repository = _MemoryRepository([rule]);
+      final oldManifest = _manifest(rule, original);
+      repository.manifest.add(oldManifest);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+
+      await coordinator.reconcile(
+        schedule: Schedule.fromList([_entry(moved, 'Recht')]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(scheduler.cancelled, [oldManifest.notificationId]);
+      expect(scheduler.scheduled.single.classStart, moved);
+      expect(repository.savedRules.single.occurrenceStart, moved);
+    },
+  );
+}
+
+ScheduleEntry _entry(DateTime start, String title) => ScheduleEntry(
+  start: start,
+  end: start.add(const Duration(hours: 2)),
+  title: title,
+  details: '',
+  professor: 'Professor',
+  room: 'A101',
+  type: ScheduleEntryType.Class,
+);
+
+ScheduledClassNotification _manifest(ClassReminderRule rule, DateTime start) {
+  final occurrence = ClassReminderIdentity.occurrence(
+    canonicalTitle: rule.canonicalTitle,
+    occurrenceStart: start,
+    sourceIdentity: rule.sourceIdentity,
+  );
+  return ScheduledClassNotification(
+    ruleId: rule.id,
+    occurrenceIdentity: occurrence,
+    sourceIdentity: rule.sourceIdentity,
+    notificationId: ClassReminderIdentity.notificationId(
+      ruleId: rule.id,
+      occurrenceStart: start,
+      sourceIdentity: rule.sourceIdentity,
+    ),
+    scheduledTime: start.subtract(rule.offset),
+    classStart: start,
+    contentFingerprint: ClassReminderCoordinator.contentFingerprint(
+      title: rule.canonicalTitle,
+      start: start,
+      room: 'A101',
+      offset: rule.offset,
+    ),
+  );
+}
+
+class _MemoryRepository implements ClassReminderRepositoryApi {
+  final List<ClassReminderRule> rules;
+  final List<ScheduledClassNotification> manifest = [];
+  final List<ClassReminderRule> savedRules = [];
+  int manifestReadCount = 0;
+  int manifestWriteCount = 0;
+
+  _MemoryRepository(this.rules);
+
+  @override
+  Future<List<ClassReminderRule>> loadRelevantRules({
+    required String sourceIdentity,
+    required DateTime now,
+  }) async => List.of(rules);
+
+  @override
+  Future<List<ScheduledClassNotification>> loadManifestForWindow({
+    required String sourceIdentity,
+    required DateTime start,
+    required DateTime end,
+  }) async {
+    manifestReadCount++;
+    return List.of(manifest);
+  }
+
+  @override
+  Future<void> applyManifestChanges({
+    required List<ScheduledClassNotification> upserts,
+    required List<String> removedOccurrenceIdentities,
+  }) async {
+    manifestWriteCount++;
+    manifest.removeWhere(
+      (row) => removedOccurrenceIdentities.contains(row.occurrenceIdentity),
+    );
+    for (final row in upserts) {
+      manifest.removeWhere(
+        (old) =>
+            old.ruleId == row.ruleId &&
+            old.occurrenceIdentity == row.occurrenceIdentity,
+      );
+      manifest.add(row);
+    }
+  }
+
+  @override
+  Future<ExpiredReminderDeletionCount> deleteExpired(DateTime now) async =>
+      const ExpiredReminderDeletionCount(oneTimeRules: 0, manifestRows: 0);
+
+  @override
+  Future<void> saveRule(ClassReminderRule rule) async {
+    savedRules.add(rule);
+  }
+
+  @override
+  Future<void> deleteRule(String ruleId) async {
+    rules.removeWhere((rule) => rule.id == ruleId);
+  }
+}
+
+class _RecordingScheduler implements ClassReminderScheduler {
+  final List<ClassReminderNotificationRequest> scheduled = [];
+  final List<int> cancelled = [];
+
+  @override
+  Future<void> schedule(ClassReminderNotificationRequest request) async {
+    scheduled.add(request);
+  }
+
+  @override
+  Future<void> cancel(int notificationId) async {
+    cancelled.add(notificationId);
+  }
+}

--- a/test/schedule/reminders/class_reminder_coordinator_test.dart
+++ b/test/schedule/reminders/class_reminder_coordinator_test.dart
@@ -91,7 +91,7 @@ void main() {
   );
 
   test(
-    'returns before reading schedule or manifest when no rules exist',
+    'no rules treat the notification manifest as an empty desired set',
     () async {
       final repository = _MemoryRepository([]);
       final coordinator = ClassReminderCoordinator(
@@ -111,9 +111,38 @@ void main() {
 
       expect(result.reminderRulesLoaded, 0);
       expect(result.scheduleEntriesExamined, 0);
-      expect(repository.manifestReadCount, 0);
+      expect(repository.manifestReadCount, 1);
     },
   );
+
+  test('removing the final rule cancels its existing alarm', () async {
+    final removedRule = ClassReminderRule(
+      id: 'recht',
+      scope: ClassReminderScope.recurring,
+      canonicalTitle: 'Recht',
+      offset: const Duration(minutes: 15),
+      sourceIdentity: 'rapla:a',
+    );
+    final repository = _MemoryRepository([]);
+    final row = _manifest(removedRule, DateTime(2026, 7, 20, 10));
+    repository.manifest.add(row);
+    final scheduler = _RecordingScheduler();
+    final coordinator = ClassReminderCoordinator(
+      repository: repository,
+      scheduler: scheduler,
+      now: () => now,
+    );
+
+    await coordinator.reconcile(
+      schedule: Schedule.fromList(const []),
+      start: windowStart,
+      end: windowEnd,
+      sourceIdentity: 'rapla:a',
+    );
+
+    expect(scheduler.cancelled, [row.notificationId]);
+    expect(repository.manifest, isEmpty);
+  });
 
   test(
     'moved one-time occurrence replaces alarm and updates stored timing',
@@ -279,11 +308,15 @@ class _MemoryRepository implements ClassReminderRepositoryApi {
   @override
   Future<void> applyManifestChanges({
     required List<ScheduledClassNotification> upserts,
-    required List<String> removedOccurrenceIdentities,
+    required List<ScheduledClassNotification> removals,
   }) async {
     manifestWriteCount++;
     manifest.removeWhere(
-      (row) => removedOccurrenceIdentities.contains(row.occurrenceIdentity),
+      (row) => removals.any(
+        (removed) =>
+            removed.ruleId == row.ruleId &&
+            removed.occurrenceIdentity == row.occurrenceIdentity,
+      ),
     );
     for (final row in upserts) {
       manifest.removeWhere(
@@ -292,6 +325,19 @@ class _MemoryRepository implements ClassReminderRepositoryApi {
             old.occurrenceIdentity == row.occurrenceIdentity,
       );
       manifest.add(row);
+    }
+  }
+
+  @override
+  Future<void> applyRuleChanges({
+    required List<ClassReminderRule> upserts,
+    required List<String> removedRuleIds,
+  }) async {
+    rules.removeWhere((rule) => removedRuleIds.contains(rule.id));
+    for (final rule in upserts) {
+      rules.removeWhere((old) => old.id == rule.id);
+      rules.add(rule);
+      savedRules.add(rule);
     }
   }
 

--- a/test/schedule/reminders/class_reminder_coordinator_test.dart
+++ b/test/schedule/reminders/class_reminder_coordinator_test.dart
@@ -186,6 +186,35 @@ void main() {
       expect(repository.savedRules.single.canonicalTitle, 'Wirtschaftsrecht');
     },
   );
+
+  test('pausing reminders cancels and removes manifest rows', () async {
+    final rule = ClassReminderRule(
+      id: 'recht',
+      scope: ClassReminderScope.recurring,
+      canonicalTitle: 'Recht',
+      offset: const Duration(minutes: 15),
+      sourceIdentity: 'rapla:a',
+    );
+    final repository = _MemoryRepository([rule]);
+    final row = _manifest(rule, DateTime(2026, 7, 20, 10));
+    repository.manifest.add(row);
+    final scheduler = _RecordingScheduler();
+    final coordinator = ClassReminderCoordinator(
+      repository: repository,
+      scheduler: scheduler,
+      now: () => now,
+    );
+
+    final cancelled = await coordinator.pauseWindow(
+      start: windowStart,
+      end: windowEnd,
+      sourceIdentity: 'rapla:a',
+    );
+
+    expect(cancelled, 1);
+    expect(scheduler.cancelled, [row.notificationId]);
+    expect(repository.manifest, isEmpty);
+  });
 }
 
 ScheduleEntry _entry(DateTime start, String title) => ScheduleEntry(

--- a/test/schedule/reminders/class_reminder_coordinator_test.dart
+++ b/test/schedule/reminders/class_reminder_coordinator_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:dualmate/schedule/model/schedule.dart';
 import 'package:dualmate/schedule/model/schedule_entry.dart';
 import 'package:dualmate/schedule/reminders/class_reminder.dart';

--- a/test/schedule/reminders/class_reminder_coordinator_test.dart
+++ b/test/schedule/reminders/class_reminder_coordinator_test.dart
@@ -91,6 +91,76 @@ void main() {
   );
 
   test(
+    '30-minute reminder is scheduled exactly 30 minutes before class',
+    () async {
+      final classStart = DateTime(2026, 7, 20, 10);
+      final repository = _MemoryRepository([
+        ClassReminderRule(
+          id: 'recht',
+          scope: ClassReminderScope.recurring,
+          canonicalTitle: 'Recht',
+          offset: const Duration(minutes: 30),
+          sourceIdentity: 'rapla:a',
+        ),
+      ]);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+
+      await coordinator.reconcile(
+        schedule: Schedule.fromList([_entry(classStart, 'Recht')]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(scheduler.scheduled, hasLength(1));
+      expect(
+        scheduler.scheduled.single.scheduledTime,
+        classStart.subtract(const Duration(minutes: 30)),
+      );
+      expect(scheduler.scheduled.single.classStart, classStart);
+      expect(scheduler.scheduled.single.offset, const Duration(minutes: 30));
+    },
+  );
+
+  test(
+    'does not schedule a reminder whose notification time has passed',
+    () async {
+      final repository = _MemoryRepository([
+        ClassReminderRule(
+          id: 'recht',
+          scope: ClassReminderScope.recurring,
+          canonicalTitle: 'Recht',
+          offset: const Duration(minutes: 30),
+          sourceIdentity: 'rapla:a',
+        ),
+      ]);
+      final scheduler = _RecordingScheduler();
+      final coordinator = ClassReminderCoordinator(
+        repository: repository,
+        scheduler: scheduler,
+        now: () => now,
+      );
+
+      await coordinator.reconcile(
+        schedule: Schedule.fromList([
+          _entry(now.add(const Duration(minutes: 15)), 'Recht'),
+        ]),
+        start: windowStart,
+        end: windowEnd,
+        sourceIdentity: 'rapla:a',
+      );
+
+      expect(scheduler.scheduled, isEmpty);
+      expect(repository.manifest, isEmpty);
+    },
+  );
+
+  test(
     'no rules treat the notification manifest as an empty desired set',
     () async {
       final repository = _MemoryRepository([]);

--- a/test/schedule/reminders/class_reminder_identity_test.dart
+++ b/test/schedule/reminders/class_reminder_identity_test.dart
@@ -2,8 +2,34 @@ import 'package:dualmate/schedule/reminders/class_reminder.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('rule identifiers are deterministic and scope-specific', () {
+    final start = DateTime(2026, 7, 20, 9);
+    final recurring = ClassReminderIdentity.ruleId(
+      scope: ClassReminderScope.recurring,
+      canonicalTitle: 'Recht',
+      sourceIdentity: 'rapla:a',
+    );
+    final oneTime = ClassReminderIdentity.ruleId(
+      scope: ClassReminderScope.oneTime,
+      canonicalTitle: 'Recht',
+      sourceIdentity: 'rapla:a',
+      occurrenceStart: start,
+    );
+
+    expect(
+      ClassReminderIdentity.ruleId(
+        scope: ClassReminderScope.recurring,
+        canonicalTitle: 'Recht',
+        sourceIdentity: 'rapla:a',
+      ),
+      recurring,
+    );
+    expect(recurring, startsWith('class-reminder-'));
+    expect(oneTime, isNot(recurring));
+  });
+
   test(
-    'notification identifiers are deterministic, positive and source scoped',
+    'notification identifiers are deterministic, negative and source scoped',
     () {
       final occurrence = DateTime(2026, 7, 20, 9);
       final first = ClassReminderIdentity.notificationId(
@@ -23,8 +49,8 @@ void main() {
       );
 
       expect(first, repeat);
-      expect(first, greaterThan(0));
-      expect(first, lessThan(1 << 31));
+      expect(first, lessThan(0));
+      expect(first, greaterThanOrEqualTo(-(1 << 31)));
       expect(otherSource, isNot(first));
     },
   );

--- a/test/schedule/reminders/class_reminder_identity_test.dart
+++ b/test/schedule/reminders/class_reminder_identity_test.dart
@@ -1,0 +1,47 @@
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'notification identifiers are deterministic, positive and source scoped',
+    () {
+      final occurrence = DateTime(2026, 7, 20, 9);
+      final first = ClassReminderIdentity.notificationId(
+        ruleId: 'rule-1',
+        occurrenceStart: occurrence,
+        sourceIdentity: 'rapla:a',
+      );
+      final repeat = ClassReminderIdentity.notificationId(
+        ruleId: 'rule-1',
+        occurrenceStart: occurrence,
+        sourceIdentity: 'rapla:a',
+      );
+      final otherSource = ClassReminderIdentity.notificationId(
+        ruleId: 'rule-1',
+        occurrenceStart: occurrence,
+        sourceIdentity: 'rapla:b',
+      );
+
+      expect(first, repeat);
+      expect(first, greaterThan(0));
+      expect(first, lessThan(1 << 31));
+      expect(otherSource, isNot(first));
+    },
+  );
+
+  test('occurrence identity ignores room, professor and duration', () {
+    final start = DateTime(2026, 7, 20, 9);
+    expect(
+      ClassReminderIdentity.occurrence(
+        canonicalTitle: 'Recht',
+        occurrenceStart: start,
+        sourceIdentity: 'rapla:a',
+      ),
+      ClassReminderIdentity.occurrence(
+        canonicalTitle: 'Recht',
+        occurrenceStart: start,
+        sourceIdentity: 'rapla:a',
+      ),
+    );
+  });
+}

--- a/test/schedule/reminders/class_reminder_identity_test.dart
+++ b/test/schedule/reminders/class_reminder_identity_test.dart
@@ -29,19 +29,30 @@ void main() {
     },
   );
 
-  test('occurrence identity ignores room, professor and duration', () {
+  test('each occurrence identity input changes the identity', () {
     final start = DateTime(2026, 7, 20, 9);
-    expect(
-      ClassReminderIdentity.occurrence(
-        canonicalTitle: 'Recht',
-        occurrenceStart: start,
-        sourceIdentity: 'rapla:a',
-      ),
-      ClassReminderIdentity.occurrence(
-        canonicalTitle: 'Recht',
-        occurrenceStart: start,
-        sourceIdentity: 'rapla:a',
-      ),
+    final identity = ClassReminderIdentity.occurrence(
+      canonicalTitle: 'Recht',
+      occurrenceStart: start,
+      sourceIdentity: 'rapla:a',
     );
+    expect({
+      identity,
+      ClassReminderIdentity.occurrence(
+        canonicalTitle: 'Mathematik',
+        occurrenceStart: start,
+        sourceIdentity: 'rapla:a',
+      ),
+      ClassReminderIdentity.occurrence(
+        canonicalTitle: 'Recht',
+        occurrenceStart: start.add(const Duration(minutes: 1)),
+        sourceIdentity: 'rapla:a',
+      ),
+      ClassReminderIdentity.occurrence(
+        canonicalTitle: 'Recht',
+        occurrenceStart: start,
+        sourceIdentity: 'rapla:b',
+      ),
+    }, hasLength(4));
   });
 }

--- a/test/schedule/reminders/class_reminder_repository_test.dart
+++ b/test/schedule/reminders/class_reminder_repository_test.dart
@@ -1,0 +1,154 @@
+import 'package:dualmate/common/data/database_access.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ClassReminderRepository', () {
+    test('loads recurring and upcoming one-time rules in one query', () async {
+      final database = _RecordingDatabase()
+        ..queryResult = [
+          {
+            'id': 'recurring',
+            'scope': 1,
+            'canonicalTitle': 'Recht',
+            'offsetMinutes': 15,
+            'sourceIdentity': 'rapla:a',
+            'occurrenceStart': null,
+            'occurrenceEnd': null,
+          },
+          {
+            'id': 'one-time',
+            'scope': 0,
+            'canonicalTitle': 'Mathematik',
+            'offsetMinutes': 30,
+            'sourceIdentity': 'rapla:a',
+            'occurrenceStart': DateTime(2026, 7, 21, 9).millisecondsSinceEpoch,
+            'occurrenceEnd': DateTime(2026, 7, 21, 11).millisecondsSinceEpoch,
+          },
+        ];
+      final repository = ClassReminderRepository(database);
+
+      final rules = await repository.loadRelevantRules(
+        sourceIdentity: 'rapla:a',
+        now: DateTime(2026, 7, 20),
+      );
+
+      expect(rules, hasLength(2));
+      expect(rules.first.scope, ClassReminderScope.recurring);
+      expect(database.queries, hasLength(1));
+      expect(database.queries.single.where, contains('sourceIdentity=?'));
+      expect(database.queries.single.where, contains('occurrenceStart>?'));
+    });
+
+    test(
+      'cleanup bulk-deletes past occurrence data and keeps recurring rules',
+      () async {
+        final database = _RecordingDatabase()..deleteResults.addAll([2, 3]);
+        final repository = ClassReminderRepository(database);
+        final now = DateTime(2026, 7, 20, 10);
+
+        final result = await repository.deleteExpired(now);
+
+        expect(result.oneTimeRules, 2);
+        expect(result.manifestRows, 3);
+        expect(database.deletes, hasLength(2));
+        expect(database.deletes.first.where, 'scope=? AND occurrenceStart<=?');
+        expect(database.deletes.first.whereArgs, [
+          0,
+          now.millisecondsSinceEpoch,
+        ]);
+        expect(database.deletes.last.where, 'classStart<=?');
+      },
+    );
+
+    test('manifest changes are persisted with bulk operations', () async {
+      final database = _RecordingDatabase();
+      final repository = ClassReminderRepository(database);
+      final row = ScheduledClassNotification(
+        ruleId: 'rule',
+        occurrenceIdentity: 'occurrence',
+        sourceIdentity: 'rapla:a',
+        notificationId: 42,
+        scheduledTime: DateTime(2026, 7, 21, 8, 45),
+        classStart: DateTime(2026, 7, 21, 9),
+        contentFingerprint: 'fingerprint',
+      );
+
+      await repository.applyManifestChanges(
+        upserts: [row],
+        removedOccurrenceIdentities: ['old-a', 'old-b'],
+      );
+
+      expect(database.replaceBatches.single.rows, hasLength(1));
+      expect(database.deletes.single.where, contains('IN (?,?)'));
+      expect(database.deletes.single.whereArgs, ['old-a', 'old-b']);
+    });
+  });
+}
+
+class _QueryCall {
+  final String table;
+  final String? where;
+  final List<dynamic>? whereArgs;
+
+  _QueryCall(this.table, this.where, this.whereArgs);
+}
+
+class _DeleteCall {
+  final String table;
+  final String? where;
+  final List<dynamic>? whereArgs;
+
+  _DeleteCall(this.table, this.where, this.whereArgs);
+}
+
+class _ReplaceBatchCall {
+  final String table;
+  final List<Map<String, dynamic>> rows;
+
+  _ReplaceBatchCall(this.table, this.rows);
+}
+
+class _RecordingDatabase extends DatabaseAccess {
+  List<Map<String, dynamic>> queryResult = [];
+  final List<int> deleteResults = [];
+  final List<_QueryCall> queries = [];
+  final List<_DeleteCall> deletes = [];
+  final List<_ReplaceBatchCall> replaceBatches = [];
+
+  @override
+  Future<List<Map<String, dynamic>>> queryRows(
+    String table, {
+    bool? distinct,
+    List<String>? columns,
+    String? where,
+    List<dynamic>? whereArgs,
+    String? groupBy,
+    String? having,
+    String? orderBy,
+    int? limit,
+    int? offset,
+  }) async {
+    queries.add(_QueryCall(table, where, whereArgs));
+    return queryResult;
+  }
+
+  @override
+  Future<int> deleteWhere(
+    String table, {
+    String? where,
+    List<dynamic>? whereArgs,
+  }) async {
+    deletes.add(_DeleteCall(table, where, whereArgs));
+    return deleteResults.isEmpty ? 0 : deleteResults.removeAt(0);
+  }
+
+  @override
+  Future<void> insertOrReplaceBatch(
+    String table,
+    List<Map<String, dynamic>> rows,
+  ) async {
+    replaceBatches.add(_ReplaceBatchCall(table, rows));
+  }
+}

--- a/test/schedule/reminders/class_reminder_repository_test.dart
+++ b/test/schedule/reminders/class_reminder_repository_test.dart
@@ -2,6 +2,7 @@ import 'package:dualmate/common/data/database_access.dart';
 import 'package:dualmate/schedule/reminders/class_reminder.dart';
 import 'package:dualmate/schedule/reminders/class_reminder_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
 
 void main() {
   group('ClassReminderRepository', () {
@@ -75,14 +76,24 @@ void main() {
         contentFingerprint: 'fingerprint',
       );
 
-      await repository.applyManifestChanges(
-        upserts: [row],
-        removedOccurrenceIdentities: ['old-a', 'old-b'],
+      final old = ScheduledClassNotification(
+        ruleId: 'old-rule',
+        occurrenceIdentity: 'old-occurrence',
+        sourceIdentity: 'rapla:a',
+        notificationId: 41,
+        scheduledTime: DateTime(2026, 7, 20, 8, 45),
+        classStart: DateTime(2026, 7, 20, 9),
+        contentFingerprint: 'old',
       );
 
-      expect(database.replaceBatches.single.rows, hasLength(1));
-      expect(database.deletes.single.where, contains('IN (?,?)'));
-      expect(database.deletes.single.whereArgs, ['old-a', 'old-b']);
+      await repository.applyManifestChanges(upserts: [row], removals: [old]);
+
+      expect(database.batch.inserts, hasLength(1));
+      expect(database.batch.deletes.single.where, contains('ruleId=?'));
+      expect(database.batch.deletes.single.whereArgs, [
+        'old-rule',
+        'old-occurrence',
+      ]);
     });
   });
 }
@@ -116,6 +127,12 @@ class _RecordingDatabase extends DatabaseAccess {
   final List<_QueryCall> queries = [];
   final List<_DeleteCall> deletes = [];
   final List<_ReplaceBatchCall> replaceBatches = [];
+  final _RecordingBatch batch = _RecordingBatch();
+
+  @override
+  Future<T> transaction<T>(
+    Future<T> Function(DatabaseExecutor executor) action,
+  ) => action(_RecordingExecutor(batch));
 
   @override
   Future<List<Map<String, dynamic>>> queryRows(
@@ -151,4 +168,46 @@ class _RecordingDatabase extends DatabaseAccess {
   ) async {
     replaceBatches.add(_ReplaceBatchCall(table, rows));
   }
+}
+
+class _RecordingExecutor implements DatabaseExecutor {
+  final _RecordingBatch recordingBatch;
+
+  _RecordingExecutor(this.recordingBatch);
+
+  @override
+  Batch batch() => recordingBatch;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RecordingBatch implements Batch {
+  final List<_DeleteCall> deletes = [];
+  final List<Map<String, dynamic>> inserts = [];
+
+  @override
+  void delete(String table, {String? where, List<Object?>? whereArgs}) {
+    deletes.add(_DeleteCall(table, where, whereArgs));
+  }
+
+  @override
+  void insert(
+    String table,
+    Map<String, Object?> values, {
+    String? nullColumnHack,
+    ConflictAlgorithm? conflictAlgorithm,
+  }) {
+    inserts.add(values);
+  }
+
+  @override
+  Future<List<Object?>> commit({
+    bool? exclusive,
+    bool? noResult,
+    bool? continueOnError,
+  }) async => [];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/schedule/reminders/platform_class_reminder_scheduler_test.dart
+++ b/test/schedule/reminders/platform_class_reminder_scheduler_test.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:dualmate/common/ui/notification_api.dart';
+import 'package:dualmate/common/util/widget_navigation_payload.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_scheduler.dart';
+import 'package:dualmate/schedule/reminders/platform_class_reminder_scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('formats and schedules an English 30-minute reminder', (
+    tester,
+  ) async {
+    tester.binding.platformDispatcher.localeTestValue = const Locale('en');
+    final api = _RecordingNotificationApi();
+    final scheduler = PlatformClassReminderScheduler(() => api);
+    final classStart = DateTime(2026, 7, 24, 8, 30);
+    final scheduledTime = classStart.subtract(const Duration(minutes: 30));
+
+    await scheduler.schedule(
+      ClassReminderNotificationRequest(
+        notificationId: -123,
+        className: 'Recht',
+        classStart: classStart,
+        scheduledTime: scheduledTime,
+        offset: const Duration(minutes: 30),
+        room: '',
+        occurrenceIdentity: 'recht-occurrence',
+      ),
+    );
+
+    expect(api.id, -123);
+    expect(api.title, 'Recht starts in 30 minutes');
+    expect(api.body, 'The class begins at 8:30.');
+    expect(api.scheduledTime, scheduledTime);
+    final payload = jsonDecode(api.payload!) as Map<String, dynamic>;
+    expect(payload[widgetScheduleEntryTitle], 'Recht');
+    expect(
+      payload[widgetScheduleEntryStart],
+      classStart.millisecondsSinceEpoch,
+    );
+    expect(payload[widgetScheduleDayStart], classStart.millisecondsSinceEpoch);
+  });
+
+  testWidgets('formats a German one-hour reminder with its room', (
+    tester,
+  ) async {
+    tester.binding.platformDispatcher.localeTestValue = const Locale('de');
+    final api = _RecordingNotificationApi();
+    final scheduler = PlatformClassReminderScheduler(
+      () => api,
+      languageCode: () async => 'de-DE',
+    );
+    final classStart = DateTime(2026, 7, 24, 15);
+
+    await scheduler.schedule(
+      ClassReminderNotificationRequest(
+        notificationId: -456,
+        className: 'Recht',
+        classStart: classStart,
+        scheduledTime: classStart.subtract(const Duration(hours: 1)),
+        offset: const Duration(hours: 1),
+        room: 'H 301',
+        occurrenceIdentity: 'recht-occurrence',
+      ),
+    );
+
+    expect(api.title, 'Recht beginnt in 1 Stunde');
+    expect(api.body, 'Die Veranstaltung beginnt um 15:00 in H 301.');
+  });
+
+  test('uses singular wording for a custom one-minute reminder', () async {
+    final api = _RecordingNotificationApi();
+    final scheduler = PlatformClassReminderScheduler(
+      () => api,
+      languageCode: () async => 'de',
+    );
+    final classStart = DateTime(2026, 7, 24, 15);
+
+    await scheduler.schedule(
+      ClassReminderNotificationRequest(
+        notificationId: -457,
+        className: 'Recht',
+        classStart: classStart,
+        scheduledTime: classStart.subtract(const Duration(minutes: 1)),
+        offset: const Duration(minutes: 1),
+        room: '',
+        occurrenceIdentity: 'recht-occurrence',
+      ),
+    );
+
+    expect(api.title, 'Recht beginnt in 1 Minute');
+  });
+
+  test('cancels only the supplied class-reminder identifier', () async {
+    final api = _RecordingNotificationApi();
+    final scheduler = PlatformClassReminderScheduler(() => api);
+
+    await scheduler.cancel(-789);
+
+    expect(api.cancelledIds, [-789]);
+  });
+}
+
+class _RecordingNotificationApi extends VoidNotificationApi {
+  int? id;
+  String? title;
+  String? body;
+  DateTime? scheduledTime;
+  String? payload;
+  final List<int> cancelledIds = [];
+
+  @override
+  Future<void> scheduleExactNotification({
+    required int id,
+    required String title,
+    required String body,
+    required DateTime scheduledTime,
+    required String payload,
+  }) async {
+    this.id = id;
+    this.title = title;
+    this.body = body;
+    this.scheduledTime = scheduledTime;
+    this.payload = payload;
+  }
+
+  @override
+  Future<void> cancelNotification(int id) async {
+    cancelledIds.add(id);
+  }
+}

--- a/test/schedule/reminders/reminder_sync_queue_test.dart
+++ b/test/schedule/reminders/reminder_sync_queue_test.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/reminder_sync_queue.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'enqueue returns immediately while slow reconciliation continues',
+    () async {
+      final blocker = Completer<void>();
+      final queue = ReminderSyncQueue(
+        reconcile: (_) => blocker.future,
+        currentGeneration: () => 1,
+      );
+
+      queue.enqueue(_request(DateTime(2026, 7, 20), DateTime(2026, 7, 27)));
+
+      expect(queue.isIdle, isFalse);
+      blocker.complete();
+      await queue.drain();
+      expect(queue.isIdle, isTrue);
+    },
+  );
+
+  test(
+    'overlapping queued windows are coalesced and processed serially',
+    () async {
+      final firstBlocker = Completer<void>();
+      final requests = <ReminderSyncRequest>[];
+      var active = 0;
+      var maxActive = 0;
+      final queue = ReminderSyncQueue(
+        currentGeneration: () => 1,
+        reconcile: (request) async {
+          active++;
+          maxActive = active > maxActive ? active : maxActive;
+          requests.add(request);
+          if (requests.length == 1) await firstBlocker.future;
+          active--;
+        },
+      );
+
+      queue.enqueue(_request(DateTime(2026, 7, 20), DateTime(2026, 7, 27)));
+      await Future<void>.delayed(Duration.zero);
+      queue.enqueue(_request(DateTime(2026, 7, 24), DateTime(2026, 7, 31)));
+      queue.enqueue(_request(DateTime(2026, 7, 27), DateTime(2026, 8, 3)));
+      firstBlocker.complete();
+      await queue.drain();
+
+      expect(maxActive, 1);
+      expect(requests, hasLength(2));
+      expect(requests.last.start, DateTime(2026, 7, 24));
+      expect(requests.last.end, DateTime(2026, 8, 3));
+      expect(requests.last.coalescedRequestCount, 2);
+    },
+  );
+
+  test('stale source-generation work is discarded', () async {
+    var generation = 2;
+    var calls = 0;
+    final queue = ReminderSyncQueue(
+      currentGeneration: () => generation,
+      reconcile: (_) async => calls++,
+    );
+
+    queue.enqueue(
+      _request(DateTime(2026, 7, 20), DateTime(2026, 7, 27), generation: 1),
+    );
+    await queue.drain();
+
+    expect(calls, 0);
+  });
+}
+
+ReminderSyncRequest _request(
+  DateTime start,
+  DateTime end, {
+  int generation = 1,
+}) => ReminderSyncRequest(
+  schedule: Schedule.fromList([
+    ScheduleEntry(
+      start: start.add(const Duration(hours: 9)),
+      end: start.add(const Duration(hours: 11)),
+      title: 'Recht',
+      details: '',
+      professor: '',
+      room: '',
+      type: ScheduleEntryType.Class,
+    ),
+  ]),
+  start: start,
+  end: end,
+  sourceIdentity: 'rapla:a',
+  sourceGeneration: generation,
+);

--- a/test/schedule/reminders/reminder_sync_queue_test.dart
+++ b/test/schedule/reminders/reminder_sync_queue_test.dart
@@ -72,6 +72,48 @@ void main() {
 
     expect(calls, 0);
   });
+
+  test('newer overlapping snapshots replace stale entries', () async {
+    final firstBlocker = Completer<void>();
+    final requests = <ReminderSyncRequest>[];
+    final queue = ReminderSyncQueue(
+      currentGeneration: () => 1,
+      reconcile: (request) async {
+        requests.add(request);
+        if (requests.length == 1) await firstBlocker.future;
+      },
+    );
+    final firstStart = DateTime(2026, 7, 20);
+    queue.enqueue(_request(firstStart, DateTime(2026, 7, 21)));
+    await Future<void>.delayed(Duration.zero);
+    queue.enqueue(_request(DateTime(2026, 7, 22), DateTime(2026, 7, 29)));
+    queue.enqueue(
+      ReminderSyncRequest(
+        schedule: Schedule.fromList(const []),
+        start: DateTime(2026, 7, 22),
+        end: DateTime(2026, 7, 29),
+        sourceIdentity: 'rapla:a',
+        sourceGeneration: 1,
+      ),
+    );
+    firstBlocker.complete();
+    await queue.drain();
+
+    expect(requests.last.schedule.entries, isEmpty);
+  });
+
+  test('an error reporter failure cannot wedge the queue', () async {
+    final queue = ReminderSyncQueue(
+      currentGeneration: () => 1,
+      reconcile: (_) => Future<void>.error(StateError('reconcile')),
+      onError: (_, _) => Future<void>.error(StateError('report')),
+    );
+
+    queue.enqueue(_request(DateTime(2026, 7, 20), DateTime(2026, 7, 27)));
+    await queue.drain();
+
+    expect(queue.isIdle, isTrue);
+  });
 }
 
 ReminderSyncRequest _request(

--- a/test/schedule/reminders/reminder_sync_queue_test.dart
+++ b/test/schedule/reminders/reminder_sync_queue_test.dart
@@ -114,6 +114,51 @@ void main() {
 
     expect(queue.isIdle, isTrue);
   });
+
+  test(
+    'serialized work waits for active reconciliation and blocks newer work',
+    () async {
+      final reconcileBlocker = Completer<void>();
+      final cleanupBlocker = Completer<void>();
+      final events = <String>[];
+      var reconcileCount = 0;
+      final queue = ReminderSyncQueue(
+        currentGeneration: () => 1,
+        reconcile: (_) async {
+          reconcileCount++;
+          events.add('reconcile-$reconcileCount-start');
+          if (reconcileCount == 1) await reconcileBlocker.future;
+          events.add('reconcile-$reconcileCount-end');
+        },
+      );
+
+      queue.enqueue(_request(DateTime(2026, 7, 20), DateTime(2026, 7, 21)));
+      await Future<void>.delayed(Duration.zero);
+      final cleanup = queue.runSerialized(() async {
+        events.add('cleanup-start');
+        await cleanupBlocker.future;
+        events.add('cleanup-end');
+      });
+      queue.enqueue(_request(DateTime(2026, 7, 20), DateTime(2026, 7, 21)));
+
+      expect(events, ['reconcile-1-start']);
+      reconcileBlocker.complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(events, ['reconcile-1-start', 'reconcile-1-end', 'cleanup-start']);
+
+      cleanupBlocker.complete();
+      await cleanup;
+      await queue.drain();
+      expect(events, [
+        'reconcile-1-start',
+        'reconcile-1-end',
+        'cleanup-start',
+        'cleanup-end',
+        'reconcile-2-start',
+        'reconcile-2-end',
+      ]);
+    },
+  );
 }
 
 ReminderSyncRequest _request(

--- a/test/schedule/reminders/reminder_sync_queue_test.dart
+++ b/test/schedule/reminders/reminder_sync_queue_test.dart
@@ -159,12 +159,60 @@ void main() {
       ]);
     },
   );
+
+  test(
+    'serialized work reports its error without wedging later work',
+    () async {
+      var reconciliations = 0;
+      final queue = ReminderSyncQueue(
+        currentGeneration: () => 1,
+        reconcile: (_) async => reconciliations++,
+      );
+
+      final failed = queue.runSerialized(
+        () => Future<void>.error(StateError('cleanup failed')),
+      );
+      queue.enqueue(_request(DateTime(2026, 7, 20), DateTime(2026, 7, 21)));
+
+      await expectLater(failed, throwsStateError);
+      await queue.drain();
+      expect(reconciliations, 1);
+      expect(queue.isIdle, isTrue);
+    },
+  );
+
+  test('coalescing retains the earliest enqueue timestamp', () async {
+    final requests = <ReminderSyncRequest>[];
+    final queue = ReminderSyncQueue(
+      currentGeneration: () => 1,
+      reconcile: (request) async => requests.add(request),
+    );
+    final later = DateTime(2026, 7, 20, 12);
+    final earlier = DateTime(2026, 7, 20, 11);
+    final blocker = Completer<void>();
+    queue.runSerialized(() => blocker.future);
+    queue.enqueue(
+      _request(DateTime(2026, 7, 20), DateTime(2026, 7, 22), enqueuedAt: later),
+    );
+    queue.enqueue(
+      _request(
+        DateTime(2026, 7, 21),
+        DateTime(2026, 7, 23),
+        enqueuedAt: earlier,
+      ),
+    );
+
+    blocker.complete();
+    await queue.drain();
+    expect(requests.single.enqueuedAt, earlier);
+  });
 }
 
 ReminderSyncRequest _request(
   DateTime start,
   DateTime end, {
   int generation = 1,
+  DateTime? enqueuedAt,
 }) => ReminderSyncRequest(
   schedule: Schedule.fromList([
     ScheduleEntry(
@@ -181,4 +229,5 @@ ReminderSyncRequest _request(
   end: end,
   sourceIdentity: 'rapla:a',
   sourceGeneration: generation,
+  enqueuedAt: enqueuedAt,
 );

--- a/test/schedule/service/schedule_prettifier_test.dart
+++ b/test/schedule/service/schedule_prettifier_test.dart
@@ -1,0 +1,34 @@
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/service/schedule_prettifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('course-code separator is moved to details exactly once', () {
+    final result = SchedulePrettifier().prettifyScheduleEntry(
+      _entry(title: 'ABC12 - Seminar', details: 'Bring notes'),
+    );
+
+    expect(result.title, 'Seminar');
+    expect(result.details, 'ABC12 - Bring notes');
+  });
+
+  test('trimming alone does not mark a class as online', () {
+    final result = SchedulePrettifier().prettifyScheduleEntry(
+      _entry(title: ' Seminar '),
+    );
+
+    expect(result.title, ' Seminar ');
+    expect(result.type, ScheduleEntryType.Class);
+  });
+}
+
+ScheduleEntry _entry({required String title, String details = ''}) =>
+    ScheduleEntry(
+      start: DateTime(2026, 7, 20, 9),
+      end: DateTime(2026, 7, 20, 11),
+      title: title,
+      details: details,
+      professor: '',
+      room: '',
+      type: ScheduleEntryType.Class,
+    );

--- a/test/schedule/ui/class_reminder_pause_aware_content_test.dart
+++ b/test/schedule/ui/class_reminder_pause_aware_content_test.dart
@@ -1,0 +1,95 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:dualmate/schedule/ui/schedule_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'permission notice animation preserves the schedule child state',
+    (tester) async {
+      final reminders = _FakeReminderController();
+      await tester.pumpWidget(_app(reminders));
+
+      final stateBefore = tester.state<_StableScheduleState>(
+        find.byType(_StableSchedule),
+      );
+
+      reminders.paused = true;
+      reminders.notifyListeners();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text('Class reminders are paused'), findsOneWidget);
+      expect(
+        tester.state<_StableScheduleState>(find.byType(_StableSchedule)),
+        same(stateBefore),
+      );
+
+      reminders.paused = false;
+      reminders.notifyListeners();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        tester.state<_StableScheduleState>(find.byType(_StableSchedule)),
+        same(stateBefore),
+      );
+    },
+  );
+}
+
+Widget _app(ClassReminderController reminders) => MaterialApp(
+  locale: const Locale('en'),
+  supportedLocales: const [Locale('en'), Locale('de')],
+  localizationsDelegates: const [
+    LocalizationDelegate(),
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+  ],
+  home: Scaffold(
+    body: ClassReminderPauseAwareContent(
+      controller: reminders,
+      child: const _StableSchedule(),
+    ),
+  ),
+);
+
+class _StableSchedule extends StatefulWidget {
+  const _StableSchedule();
+
+  @override
+  State<_StableSchedule> createState() => _StableScheduleState();
+}
+
+class _StableScheduleState extends State<_StableSchedule> {
+  @override
+  Widget build(BuildContext context) => const SizedBox.expand();
+}
+
+class _FakeReminderController extends ChangeNotifier
+    implements ClassReminderController {
+  bool paused = false;
+
+  @override
+  bool get remindersPaused => paused;
+
+  @override
+  bool get permissionsGranted => !paused;
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  ClassReminderRule? ruleFor(ScheduleEntry entry) => null;
+
+  @override
+  Future<void> openReliablePermissionSettings() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/schedule/ui/notification/next_day_information_notification_test.dart
+++ b/test/schedule/ui/notification/next_day_information_notification_test.dart
@@ -130,11 +130,84 @@ void main() {
       expect(notificationApi.message, isEmpty);
     },
   );
+
+  test(
+    'run keeps its evening schedule but respects the disabled preference',
+    () async {
+      final now = DateTime(2026, 3, 8, 18);
+      final notificationApi = _RecordingNotificationApi();
+      final scheduler = _FakeWorkSchedulerService();
+      final notification = NextDayInformationNotification(
+        notificationApi,
+        _FakeScheduleEntryRepository([
+          _entry(DateTime(2026, 3, 9, 8), 'Recht'),
+        ]),
+        scheduler,
+        _FakePreferencesProvider(enabled: false),
+        now: () => now,
+      );
+
+      await notification.run();
+
+      expect(notificationApi.title, isEmpty);
+      expect(scheduler.scheduledAt, [DateTime(2026, 3, 8, 20)]);
+    },
+  );
+
+  test(
+    'run announces the first upcoming class rather than input order',
+    () async {
+      final now = DateTime(2026, 3, 8, 18);
+      final notificationApi = _RecordingNotificationApi();
+      final notification = NextDayInformationNotification(
+        notificationApi,
+        _FakeScheduleEntryRepository([
+          _entry(DateTime(2026, 3, 9, 8), 'Tomorrow'),
+          _entry(DateTime(2026, 3, 8, 19), 'Recht'),
+          _entry(DateTime(2026, 3, 8, 21), 'Later today'),
+        ]),
+        _FakeWorkSchedulerService(),
+        _FakePreferencesProvider(),
+        now: () => now,
+      );
+
+      await notification.run();
+
+      expect(notificationApi.message, contains('Recht'));
+      expect(notificationApi.message, contains('19:00'));
+      expect(notificationApi.message, isNot(contains('Tomorrow')));
+    },
+  );
+
+  test(
+    'cancel targets the next evening task and exposes the stable name',
+    () async {
+      final now = DateTime(2026, 3, 8, 21);
+      final scheduler = _FakeWorkSchedulerService();
+      final notification = NextDayInformationNotification(
+        _RecordingNotificationApi(),
+        _FakeScheduleEntryRepository(const []),
+        scheduler,
+        _FakePreferencesProvider(),
+        now: () => now,
+      );
+
+      await notification.cancel();
+
+      expect(notification.getName(), NextDayInformationNotification.name);
+      expect(scheduler.cancelledIds, hasLength(1));
+      expect(scheduler.cancelledIds.single, contains('3/9/2026'));
+    },
+  );
 }
 
 class _FakePreferencesProvider implements PreferencesProvider {
+  final bool enabled;
+
+  _FakePreferencesProvider({this.enabled = true});
+
   @override
-  Future<bool> getNotifyAboutNextDay() async => true;
+  Future<bool> getNotifyAboutNextDay() async => enabled;
 
   @override
   Future<String?> getLastUsedLanguageCode() async => 'en';
@@ -169,7 +242,8 @@ class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
     final schedule = Schedule();
     schedule.entries.addAll(
       entries.where(
-          (entry) => entry.end.isAfter(start) && entry.start.isBefore(end)),
+        (entry) => entry.end.isAfter(start) && entry.start.isBefore(end),
+      ),
     );
     return schedule;
   }
@@ -179,8 +253,13 @@ class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
 }
 
 class _FakeWorkSchedulerService implements WorkSchedulerService {
+  final List<DateTime> scheduledAt = [];
+  final List<String> cancelledIds = [];
+
   @override
-  Future<void> cancelTask(String id) async {}
+  Future<void> cancelTask(String id) async {
+    cancelledIds.add(id);
+  }
 
   @override
   Future<void> executeTask(String id) async {}
@@ -196,7 +275,9 @@ class _FakeWorkSchedulerService implements WorkSchedulerService {
     DateTime date,
     String id,
     String name,
-  ) async {}
+  ) async {
+    scheduledAt.add(date);
+  }
 
   @override
   Future<void> scheduleOneShotTaskIn(
@@ -212,3 +293,13 @@ class _FakeWorkSchedulerService implements WorkSchedulerService {
     bool needsNetwork = false,
   ]) async {}
 }
+
+ScheduleEntry _entry(DateTime start, String title) => ScheduleEntry(
+  start: start,
+  end: start.add(const Duration(hours: 1)),
+  title: title,
+  details: '',
+  professor: '',
+  room: '',
+  type: ScheduleEntryType.Class,
+);

--- a/test/schedule/ui/weeklyschedule/filter/schedule_filter_page_reminder_test.dart
+++ b/test/schedule/ui/weeklyschedule/filter/schedule_filter_page_reminder_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dualmate/common/i18n/localizations.dart';
 import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
 import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
@@ -102,6 +104,50 @@ void main() {
     expect(checkbox.value, isTrue);
     expect(find.text('Could not save filters'), findsOneWidget);
   });
+
+  testWidgets(
+    'back navigation during slow reminder removal waits and persists hidden class',
+    (tester) async {
+      final saveCompleter = Completer<void>();
+      final filterRepo = _CapturingFilterRepository();
+      KiwiContainer().clear();
+      FilterViewModel.resetCachedStateForTesting();
+      KiwiContainer().registerInstance<ScheduleEntryRepository>(
+        _FakeScheduleEntryRepository(),
+      );
+      KiwiContainer().registerInstance<ScheduleFilterRepository>(filterRepo);
+
+      final reminders = _SlowReminderController({
+        'Class A',
+      }, removalCompleter: saveCompleter);
+      await tester.pumpWidget(_app(reminders));
+      await tester.pumpAndSettle();
+
+      // Tap class to trigger hide dialog.
+      await tester.tap(find.text('Class A'));
+      await tester.pumpAndSettle();
+
+      // Choose "Hide and remove reminders" — removal is now pending.
+      await tester.tap(find.text('Hide and remove reminders'));
+      await tester.pump();
+
+      // Simulate back navigation before removal finishes.
+      final NavigatorState navigator = tester.state(find.byType(Navigator));
+      navigator.maybePop();
+      await tester.pump();
+
+      // Page must not have popped yet.
+      expect(find.byType(ScheduleFilterPage), findsOneWidget);
+
+      // Complete the removal.
+      saveCompleter.complete();
+      await tester.pumpAndSettle();
+
+      // Now the page should have popped and the hidden name saved.
+      expect(find.byType(ScheduleFilterPage), findsNothing);
+      expect(filterRepo.savedHiddenNames, contains('Class A'));
+    },
+  );
 }
 
 Widget _app(ClassReminderController reminders) {
@@ -141,6 +187,28 @@ class _FakeReminderController extends ChangeNotifier
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// Reminder controller whose removal waits on [removalCompleter].
+class _SlowReminderController extends ChangeNotifier
+    implements ClassReminderController {
+  final Set<String> activeTitles;
+  final Completer<void> removalCompleter;
+
+  _SlowReminderController(this.activeTitles, {required this.removalCompleter});
+
+  @override
+  bool hasReminderForTitle(String title) => activeTitles.contains(title);
+
+  @override
+  Future<void> removeRemindersForTitle(String title) async {
+    await removalCompleter.future;
+    activeTitles.remove(title);
+    notifyListeners();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
   @override
   Future<List<String>> queryAllNamesOfScheduleEntries() async => ['Class A'];
@@ -156,6 +224,22 @@ class _FakeScheduleFilterRepository implements ScheduleFilterRepository {
 
   @override
   Future<void> saveAllHiddenNames(List<String> hiddenNames) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('Unexpected call: $invocation');
+}
+
+class _CapturingFilterRepository implements ScheduleFilterRepository {
+  List<String> savedHiddenNames = [];
+
+  @override
+  Future<List<String>> queryAllHiddenNames() async => const [];
+
+  @override
+  Future<void> saveAllHiddenNames(List<String> hiddenNames) async {
+    savedHiddenNames = List.from(hiddenNames);
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) =>

--- a/test/schedule/ui/weeklyschedule/filter/schedule_filter_page_reminder_test.dart
+++ b/test/schedule/ui/weeklyschedule/filter/schedule_filter_page_reminder_test.dart
@@ -1,0 +1,163 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/data/schedule_entry_repository.dart';
+import 'package:dualmate/schedule/data/schedule_filter_repository.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/filter/filter_view_model.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/filter/schedule_filter_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kiwi/kiwi.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    KiwiContainer().clear();
+    FilterViewModel.resetCachedStateForTesting();
+    KiwiContainer().registerInstance<ScheduleEntryRepository>(
+      _FakeScheduleEntryRepository(),
+    );
+    KiwiContainer().registerInstance<ScheduleFilterRepository>(
+      _FakeScheduleFilterRepository(),
+    );
+  });
+
+  tearDown(() {
+    KiwiContainer().clear();
+    FilterViewModel.resetCachedStateForTesting();
+  });
+
+  testWidgets('hiding a class with reminders asks whether to remove them', (
+    tester,
+  ) async {
+    final reminders = _FakeReminderController({'Class A'});
+    await tester.pumpWidget(_app(reminders));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.notifications), findsOneWidget);
+    await tester.tap(find.text('Class A'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hide Class A?'), findsOneWidget);
+    expect(find.text('Keep reminders'), findsOneWidget);
+    expect(find.text('Hide and remove reminders'), findsOneWidget);
+
+    await tester.tap(find.text('Keep reminders'));
+    await tester.pumpAndSettle();
+
+    expect(reminders.removedTitles, isEmpty);
+    final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+    expect(checkbox.value, isFalse);
+  });
+
+  testWidgets('hide and remove deletes reminders before hiding the class', (
+    tester,
+  ) async {
+    final reminders = _FakeReminderController({'Class A'});
+    await tester.pumpWidget(_app(reminders));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Class A'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Hide and remove reminders'));
+    await tester.pumpAndSettle();
+
+    expect(reminders.removedTitles, ['Class A']);
+    final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+    expect(checkbox.value, isFalse);
+    expect(find.byIcon(Icons.notifications), findsNothing);
+  });
+
+  testWidgets('cancelling the popup leaves the class displayed', (
+    tester,
+  ) async {
+    final reminders = _FakeReminderController({'Class A'});
+    await tester.pumpWidget(_app(reminders));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Class A'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+    expect(checkbox.value, isTrue);
+    expect(reminders.removedTitles, isEmpty);
+  });
+
+  testWidgets('failed reminder removal keeps the class displayed', (
+    tester,
+  ) async {
+    final reminders = _FakeReminderController({'Class A'}, failRemoval: true);
+    await tester.pumpWidget(_app(reminders));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Class A'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Hide and remove reminders'));
+    await tester.pumpAndSettle();
+
+    final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+    expect(checkbox.value, isTrue);
+    expect(find.text('Could not save filters'), findsOneWidget);
+  });
+}
+
+Widget _app(ClassReminderController reminders) {
+  return MaterialApp(
+    locale: const Locale('en'),
+    supportedLocales: const [Locale('en'), Locale('de')],
+    localizationsDelegates: const [
+      LocalizationDelegate(),
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    home: ScheduleFilterPage(reminderController: reminders),
+  );
+}
+
+class _FakeReminderController extends ChangeNotifier
+    implements ClassReminderController {
+  final Set<String> activeTitles;
+  final bool failRemoval;
+  final List<String> removedTitles = [];
+
+  _FakeReminderController(this.activeTitles, {this.failRemoval = false});
+
+  @override
+  bool hasReminderForTitle(String title) => activeTitles.contains(title);
+
+  @override
+  Future<void> removeRemindersForTitle(String title) async {
+    if (failRemoval) throw StateError('remove failed');
+    removedTitles.add(title);
+    activeTitles.remove(title);
+    notifyListeners();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeScheduleEntryRepository implements ScheduleEntryRepository {
+  @override
+  Future<List<String>> queryAllNamesOfScheduleEntries() async => ['Class A'];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('Unexpected call: $invocation');
+}
+
+class _FakeScheduleFilterRepository implements ScheduleFilterRepository {
+  @override
+  Future<List<String>> queryAllHiddenNames() async => const [];
+
+  @override
+  Future<void> saveAllHiddenNames(List<String> hiddenNames) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('Unexpected call: $invocation');
+}

--- a/test/schedule/ui/weeklyschedule/filter/schedule_filter_page_reminder_test.dart
+++ b/test/schedule/ui/weeklyschedule/filter/schedule_filter_page_reminder_test.dart
@@ -105,6 +105,58 @@ void main() {
     expect(find.text('Could not save filters'), findsOneWidget);
   });
 
+  testWidgets('back navigation waits for every in-flight reminder removal', (
+    tester,
+  ) async {
+    final classARemoval = Completer<void>();
+    final classBRemoval = Completer<void>();
+    final filterRepo = _CapturingFilterRepository();
+    KiwiContainer().clear();
+    FilterViewModel.resetCachedStateForTesting();
+    KiwiContainer().registerInstance<ScheduleEntryRepository>(
+      _NamedScheduleEntryRepository(['Class A', 'Class B']),
+    );
+    KiwiContainer().registerInstance<ScheduleFilterRepository>(filterRepo);
+
+    final reminders = _MultiSlowReminderController({
+      'Class A': classARemoval,
+      'Class B': classBRemoval,
+    });
+    await tester.pumpWidget(_app(reminders));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Class A'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Hide and remove reminders'));
+    await tester.pump();
+
+    await tester.tap(find.text('Class B'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Hide and remove reminders'));
+    await tester.pump();
+
+    final NavigatorState navigator = tester.state(find.byType(Navigator));
+    navigator.maybePop();
+    await tester.pump();
+
+    classBRemoval.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      find.byType(ScheduleFilterPage),
+      findsOneWidget,
+      reason: 'The earlier Class A removal is still in flight.',
+    );
+    expect(filterRepo.savedHiddenNames, isEmpty);
+
+    classARemoval.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ScheduleFilterPage), findsNothing);
+    expect(filterRepo.savedHiddenNames, containsAll(['Class A', 'Class B']));
+  });
+
   testWidgets(
     'back navigation during slow reminder removal waits and persists hidden class',
     (tester) async {
@@ -207,6 +259,39 @@ class _SlowReminderController extends ChangeNotifier
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MultiSlowReminderController extends ChangeNotifier
+    implements ClassReminderController {
+  final Map<String, Completer<void>> removals;
+
+  _MultiSlowReminderController(this.removals);
+
+  @override
+  bool hasReminderForTitle(String title) => removals.containsKey(title);
+
+  @override
+  Future<void> removeRemindersForTitle(String title) async {
+    await removals[title]!.future;
+    removals.remove(title);
+    notifyListeners();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _NamedScheduleEntryRepository implements ScheduleEntryRepository {
+  final List<String> names;
+
+  _NamedScheduleEntryRepository(this.names);
+
+  @override
+  Future<List<String>> queryAllNamesOfScheduleEntries() async => names;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('Unexpected call: $invocation');
 }
 
 class _FakeScheduleEntryRepository implements ScheduleEntryRepository {

--- a/test/schedule/ui/weeklyschedule/reminder_configuration_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/reminder_configuration_sheet_test.dart
@@ -46,6 +46,23 @@ void main() {
     expect(icon.color, foreground);
   });
 
+  testWidgets('German recurring disclaimer is concise and title-specific', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(locale: const Locale('de')));
+
+    await tester.tap(find.text('Jeder Termin'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Abgleich nach Kursname'), findsOneWidget);
+    expect(
+      find.text(
+        'Gilt für künftige Termine mit demselben Kursnamen. Wird er geändert, greift die Erinnerung nicht mehr.',
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('saves the selected offset and scope', (tester) async {
     Duration? savedOffset;
     ClassReminderScope? savedScope;
@@ -98,9 +115,10 @@ Widget _app({
   Future<void> Function(Duration, ClassReminderScope)? onSave,
   ThemeData? theme,
   ClassReminderRule? existingRule,
+  Locale locale = const Locale('en'),
 }) => MaterialApp(
   theme: theme,
-  locale: const Locale('en'),
+  locale: locale,
   localizationsDelegates: const [
     LocalizationDelegate(),
     GlobalMaterialLocalizations.delegate,

--- a/test/schedule/ui/weeklyschedule/reminder_configuration_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/reminder_configuration_sheet_test.dart
@@ -66,11 +66,38 @@ void main() {
     expect(savedOffset, const Duration(minutes: 30));
     expect(savedScope, ClassReminderScope.recurring);
   });
+
+  testWidgets('custom offset cannot be saved until it is positive', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        existingRule: ClassReminderRule(
+          id: 'custom',
+          scope: ClassReminderScope.oneTime,
+          canonicalTitle: 'Recht',
+          offset: const Duration(minutes: 10),
+          sourceIdentity: 'rapla:a',
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pump();
+
+    FilledButton saveButton() =>
+        tester.widget(find.widgetWithText(FilledButton, 'Save reminder'));
+    expect(saveButton().onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField), '10');
+    await tester.pump();
+    expect(saveButton().onPressed, isNotNull);
+  });
 }
 
 Widget _app({
   Future<void> Function(Duration, ClassReminderScope)? onSave,
   ThemeData? theme,
+  ClassReminderRule? existingRule,
 }) => MaterialApp(
   theme: theme,
   locale: const Locale('en'),
@@ -83,7 +110,7 @@ Widget _app({
   supportedLocales: const [Locale('en'), Locale('de')],
   home: Scaffold(
     body: ReminderConfigurationSheet(
-      existingRule: null,
+      existingRule: existingRule,
       onSave: onSave ?? (_, _) async {},
     ),
   ),

--- a/test/schedule/ui/weeklyschedule/reminder_configuration_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/reminder_configuration_sheet_test.dart
@@ -18,6 +18,34 @@ void main() {
     expect(find.textContaining('same displayed class name'), findsOneWidget);
   });
 
+  testWidgets('recurring disclaimer uses its container foreground color', (
+    tester,
+  ) async {
+    const foreground = Color(0xff102030);
+    await tester.pumpWidget(
+      _app(
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.teal,
+            brightness: Brightness.dark,
+          ).copyWith(onSecondaryContainer: foreground),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Every occurrence'));
+    await tester.pumpAndSettle();
+
+    final title = tester.widget<Text>(find.text('Matches by class name'));
+    final description = tester.widget<Text>(
+      find.textContaining('same displayed class name'),
+    );
+    final icon = tester.widget<Icon>(find.byIcon(Icons.info_outline));
+    expect(title.style?.color, foreground);
+    expect(description.style?.color, foreground);
+    expect(icon.color, foreground);
+  });
+
   testWidgets('saves the selected offset and scope', (tester) async {
     Duration? savedOffset;
     ClassReminderScope? savedScope;
@@ -40,20 +68,23 @@ void main() {
   });
 }
 
-Widget _app({Future<void> Function(Duration, ClassReminderScope)? onSave}) =>
-    MaterialApp(
-      locale: const Locale('en'),
-      localizationsDelegates: const [
-        LocalizationDelegate(),
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [Locale('en'), Locale('de')],
-      home: Scaffold(
-        body: ReminderConfigurationSheet(
-          existingRule: null,
-          onSave: onSave ?? (_, _) async {},
-        ),
-      ),
-    );
+Widget _app({
+  Future<void> Function(Duration, ClassReminderScope)? onSave,
+  ThemeData? theme,
+}) => MaterialApp(
+  theme: theme,
+  locale: const Locale('en'),
+  localizationsDelegates: const [
+    LocalizationDelegate(),
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+  ],
+  supportedLocales: const [Locale('en'), Locale('de')],
+  home: Scaffold(
+    body: ReminderConfigurationSheet(
+      existingRule: null,
+      onSave: onSave ?? (_, _) async {},
+    ),
+  ),
+);

--- a/test/schedule/ui/weeklyschedule/reminder_configuration_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/reminder_configuration_sheet_test.dart
@@ -1,0 +1,59 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/reminder_configuration_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('recurring selection shows name-matching disclaimer', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app());
+
+    await tester.tap(find.text('Every occurrence'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Matches by class name'), findsOneWidget);
+    expect(find.textContaining('same displayed class name'), findsOneWidget);
+  });
+
+  testWidgets('saves the selected offset and scope', (tester) async {
+    Duration? savedOffset;
+    ClassReminderScope? savedScope;
+    await tester.pumpWidget(
+      _app(
+        onSave: (offset, scope) async {
+          savedOffset = offset;
+          savedScope = scope;
+        },
+      ),
+    );
+
+    await tester.tap(find.text('30 minutes before'));
+    await tester.tap(find.text('Every occurrence'));
+    await tester.tap(find.text('Save reminder'));
+    await tester.pumpAndSettle();
+
+    expect(savedOffset, const Duration(minutes: 30));
+    expect(savedScope, ClassReminderScope.recurring);
+  });
+}
+
+Widget _app({Future<void> Function(Duration, ClassReminderScope)? onSave}) =>
+    MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: const [
+        LocalizationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('de')],
+      home: Scaffold(
+        body: ReminderConfigurationSheet(
+          existingRule: null,
+          onSave: onSave ?? (_, _) async {},
+        ),
+      ),
+    );

--- a/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet_test.dart
@@ -49,6 +49,46 @@ void main() {
     expect(find.textContaining('A very long details line'), findsOneWidget);
   });
 
+  testWidgets('header action stays pinned to the top right for any title', (
+    tester,
+  ) async {
+    Future<Offset> pumpHeader(String title) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.all(24),
+              child: ScheduleEntryDetailHeaderLayout(
+                leading: const SizedBox(width: 120, height: 80),
+                title: Text(title),
+                trailing: IconButton(
+                  key: const ValueKey('fixed-reminder-action'),
+                  onPressed: () {},
+                  icon: const Icon(Icons.notifications_none_outlined),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      return tester.getTopRight(
+        find.byKey(const ValueKey('fixed-reminder-action')),
+      );
+    }
+
+    final shortTitlePosition = await pumpHeader('Recht');
+    final longTitlePosition = await pumpHeader(
+      'A considerably longer class title that wraps over several lines',
+    );
+    final headerRight = tester.getTopRight(
+      find.byType(ScheduleEntryDetailHeaderLayout),
+    );
+
+    expect(longTitlePosition.dx, shortTitlePosition.dx);
+    expect(longTitlePosition.dy, shortTitlePosition.dy);
+    expect(longTitlePosition.dx, headerRight.dx);
+  });
+
   testWidgets('starts at the medium size and is configured to expand', (
     tester,
   ) async {
@@ -154,45 +194,42 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets(
-    'snapping recovers after a snap is interrupted by a drag',
-    (tester) async {
-      await tester.pumpWidget(
-        _buildApp(entry: _entry(details: 'Short details')),
-      );
-      await _showSheet(tester);
-      await tester.pumpAndSettle();
+  testWidgets('snapping recovers after a snap is interrupted by a drag', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));
+    await _showSheet(tester);
+    await tester.pumpAndSettle();
 
-      final scrollable = find.byType(SingleChildScrollView);
-      final sheet = tester.widget<DraggableScrollableSheet>(
-        find.byType(DraggableScrollableSheet),
-      );
+    final scrollable = find.byType(SingleChildScrollView);
+    final sheet = tester.widget<DraggableScrollableSheet>(
+      find.byType(DraggableScrollableSheet),
+    );
 
-      // 1. Start a snap toward expanded, then interrupt it mid-flight.
-      await tester.drag(scrollable, const Offset(0, -220));
-      await tester.pump(const Duration(milliseconds: 50)); // snap mid-flight
-      await tester.drag(scrollable, const Offset(0, 60)); // interrupts the snap
-      await tester.pumpAndSettle();
+    // 1. Start a snap toward expanded, then interrupt it mid-flight.
+    await tester.drag(scrollable, const Offset(0, -220));
+    await tester.pump(const Duration(milliseconds: 50)); // snap mid-flight
+    await tester.drag(scrollable, const Offset(0, 60)); // interrupts the snap
+    await tester.pumpAndSettle();
 
-      // 2. Re-establish a known expanded state with a direct (non-snap) drag.
-      await tester.drag(scrollable, const Offset(0, -400)); // clamps at max
-      await tester.pump();
+    // 2. Re-establish a known expanded state with a direct (non-snap) drag.
+    await tester.drag(scrollable, const Offset(0, -400)); // clamps at max
+    await tester.pump();
 
-      // 3. Slowly drag down to an intermediate size and release with almost no
-      //    velocity. A recovered snap settles at the standard size; a guard
-      //    stuck true (interrupted animateTo never completing) leaves it
-      //    mid-screen.
-      await tester.timedDrag(
-        scrollable,
-        const Offset(0, 210),
-        const Duration(seconds: 2),
-      );
-      await tester.pumpAndSettle();
+    // 3. Slowly drag down to an intermediate size and release with almost no
+    //    velocity. A recovered snap settles at the standard size; a guard
+    //    stuck true (interrupted animateTo never completing) leaves it
+    //    mid-screen.
+    await tester.timedDrag(
+      scrollable,
+      const Offset(0, 210),
+      const Duration(seconds: 2),
+    );
+    await tester.pumpAndSettle();
 
-      expect(_currentSheetSize(tester), closeTo(sheet.initialChildSize, 0.06));
-      expect(tester.takeException(), isNull);
-    },
-  );
+    expect(_currentSheetSize(tester), closeTo(sheet.initialChildSize, 0.06));
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('dragging the sheet far down dismisses it', (tester) async {
     await tester.pumpWidget(_buildApp(entry: _entry(details: 'Short details')));

--- a/test/schedule/ui/weeklyschedule/schedule_entry_reminder_indicator_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_entry_reminder_indicator_test.dart
@@ -1,0 +1,42 @@
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_entry_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows filled bell only for an active reminder', (tester) async {
+    await tester.pumpWidget(_app(active: true));
+    expect(find.byIcon(Icons.notifications), findsOneWidget);
+
+    await tester.pumpWidget(_app(active: false));
+    expect(find.byIcon(Icons.notifications), findsNothing);
+  });
+
+  testWidgets('shows muted bell when reminder is paused', (tester) async {
+    await tester.pumpWidget(_app(active: true, paused: true));
+    expect(find.byIcon(Icons.notifications_off_outlined), findsOneWidget);
+  });
+}
+
+Widget _app({required bool active, bool paused = false}) => MaterialApp(
+  home: Scaffold(
+    body: SizedBox(
+      width: 100,
+      height: 60,
+      child: ScheduleEntryWidget(
+        scheduleEntry: ScheduleEntry(
+          start: DateTime(2026, 7, 20, 9),
+          end: DateTime(2026, 7, 20, 11),
+          title: 'Recht',
+          details: '',
+          professor: '',
+          room: '',
+          type: ScheduleEntryType.Class,
+        ),
+        onScheduleEntryTap: (_) {},
+        reminderActive: active,
+        reminderPaused: paused,
+      ),
+    ),
+  ),
+);

--- a/test/schedule/ui/weeklyschedule/schedule_entry_reminder_readiness_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_entry_reminder_readiness_test.dart
@@ -1,0 +1,74 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'reminder action stays disabled until controller initialization',
+    (tester) async {
+      final reminders = _ReadyReminderController();
+      await tester.pumpWidget(_app(reminders));
+
+      var button = tester.widget<IconButton>(
+        find.byKey(const ValueKey('class-reminder-button')),
+      );
+      expect(button.onPressed, isNull);
+
+      reminders.ready = true;
+      reminders.notifyListeners();
+      await tester.pump();
+
+      button = tester.widget<IconButton>(
+        find.byKey(const ValueKey('class-reminder-button')),
+      );
+      expect(button.onPressed, isNotNull);
+    },
+  );
+}
+
+Widget _app(ClassReminderController reminders) => MaterialApp(
+  locale: const Locale('en'),
+  supportedLocales: const [Locale('en'), Locale('de')],
+  localizationsDelegates: const [
+    LocalizationDelegate(),
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+  ],
+  home: Scaffold(
+    body: ScheduleEntryDetailBottomSheet(
+      scheduleEntry: ScheduleEntry(
+        start: DateTime(2026, 7, 20, 9),
+        end: DateTime(2026, 7, 20, 11),
+        title: 'Recht',
+        details: '',
+        professor: '',
+        room: '',
+        type: ScheduleEntryType.Class,
+      ),
+      reminderController: reminders,
+    ),
+  ),
+);
+
+class _ReadyReminderController extends ChangeNotifier
+    implements ClassReminderController {
+  bool ready = false;
+
+  @override
+  bool get isInitialized => ready;
+
+  @override
+  bool get permissionsGranted => true;
+
+  @override
+  ClassReminderRule? ruleFor(ScheduleEntry entry) => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/schedule/ui/weeklyschedule/schedule_widget_reminder_listener_test.dart
+++ b/test/schedule/ui/weeklyschedule/schedule_widget_reminder_listener_test.dart
@@ -1,0 +1,106 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/model/schedule.dart';
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/reminders/class_reminder.dart';
+import 'package:dualmate/schedule/reminders/class_reminder_controller.dart';
+import 'package:dualmate/schedule/ui/weeklyschedule/widgets/schedule_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('one schedule layer listener serves all reminder indicators', (
+    tester,
+  ) async {
+    final reminders = _CountingReminderController();
+    final start = DateTime(2026, 7, 20);
+    final entries = List<ScheduleEntry>.generate(
+      20,
+      (index) => ScheduleEntry(
+        start: start.add(Duration(hours: 8 + (index % 8))),
+        end: start.add(Duration(hours: 9 + (index % 8))),
+        title: 'Class $index',
+        details: '',
+        professor: '',
+        room: '',
+        type: ScheduleEntryType.Class,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: const [Locale('en'), Locale('de')],
+        localizationsDelegates: const [
+          LocalizationDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: Scaffold(
+          body: SizedBox(
+            width: 500,
+            height: 800,
+            child: ScheduleWidget(
+              schedule: Schedule.fromList(entries),
+              displayStart: start,
+              displayEnd: start.add(const Duration(days: 4)),
+              onScheduleEntryTap: (_) {},
+              now: start,
+              displayStartHour: 7,
+              displayEndHour: 18,
+              reminderController: reminders,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(reminders.maxActiveListeners, 1);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(reminders.activeListeners, 0);
+  });
+}
+
+class _CountingReminderController extends ChangeNotifier
+    implements ClassReminderController {
+  int activeListeners = 0;
+  int maxActiveListeners = 0;
+
+  @override
+  void addListener(VoidCallback listener) {
+    activeListeners++;
+    if (activeListeners > maxActiveListeners) {
+      maxActiveListeners = activeListeners;
+    }
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    activeListeners--;
+    super.removeListener(listener);
+  }
+
+  @override
+  bool get permissionsGranted => true;
+
+  @override
+  bool get remindersPaused => false;
+
+  @override
+  ClassReminderRule? ruleFor(ScheduleEntry entry) {
+    if (entry.title != 'Class 0') return null;
+    return ClassReminderRule(
+      id: 'class-0',
+      scope: ClassReminderScope.recurring,
+      canonicalTitle: 'Class 0',
+      offset: const Duration(minutes: 15),
+      sourceIdentity: 'rapla:a',
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/schedule/ui/widgets/class_reminder_paused_notice_test.dart
+++ b/test/schedule/ui/widgets/class_reminder_paused_notice_test.dart
@@ -1,0 +1,43 @@
+import 'package:dualmate/common/i18n/localizations.dart';
+import 'package:dualmate/schedule/ui/widgets/class_reminder_paused_notice.dart';
+import 'package:dualmate/ui/banner_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('uses the schedule banner design with concise German copy', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('de'),
+        localizationsDelegates: const [
+          LocalizationDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en'), Locale('de')],
+        home: Scaffold(
+          body: ClassReminderPausedNotice(onFixPermissions: () {}),
+        ),
+      ),
+    );
+
+    expect(find.byType(BannerWidget), findsOneWidget);
+    expect(find.text('Klassenerinnerungen pausiert'), findsOneWidget);
+    expect(
+      find.text(
+        'Aktiviere Benachrichtigungen und genaue Alarme, damit sie wieder funktionieren.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('BERECHTIGUNGEN PRÜFEN'), findsOneWidget);
+
+    final title = tester.widget<Text>(
+      find.text('Klassenerinnerungen pausiert'),
+    );
+    expect(title.style?.fontWeight, FontWeight.w600);
+  });
+}


### PR DESCRIPTION
## Summary

Adds reliable one-time and recurring class reminders to the schedule, with canonical class-name matching, exact Android alarms, durable reconciliation state, and Material 3 configuration UI.

- stores recurring and occurrence-specific rules plus a scheduled-notification manifest
- reconciles refreshed windows asynchronously through one serialized/coalescing queue
- moves, updates, cancels, deduplicates, expires, and restores notifications as schedules or permissions change
- clears source-scoped reminders with confirmation when the schedule source changes
- exposes active/paused reminder states in class details, week blocks, and the schedule permission banner
- deep-links notification taps back to the relevant class
- records privacy-safe reconciliation performance telemetry
- documents the architecture and operational behavior

## Why

Class times and metadata can change after a reminder is created. Persisting stable rule identities and reconciling only refreshed windows keeps reminders calendar-like and reliable without making foreground schedule navigation wait for Android alarm operations.

## Screenshots

| Schedule indicator | Class details |
| --- | --- |
| ![Recurring reminder shown on a schedule class](https://raw.githubusercontent.com/FarisZR/DualMate/media/class-reminder-feature/class-reminder/schedule-reminder-active.png) | ![Bell action in class details](https://raw.githubusercontent.com/FarisZR/DualMate/media/class-reminder-feature/class-reminder/class-details-bell.png) |

| Recurring configuration | Permission handling |
| --- | --- |
| ![Recurring reminder configuration and matching disclaimer](https://raw.githubusercontent.com/FarisZR/DualMate/media/class-reminder-feature/class-reminder/recurring-reminder-config.png) | ![Reliable reminder permissions prompt](https://raw.githubusercontent.com/FarisZR/DualMate/media/class-reminder-feature/class-reminder/reminder-permissions.png) |

Screenshots are hosted on the orphan `media/class-reminder-feature` branch, which contains media files only.

## Validation

- scoped `flutter analyze`: no issues
- reminder identity, repository, reconciliation, queue, configuration, indicator, background-update, and startup-override tests: all passed
- debug and profile fixture APK builds completed
- deployed with Android CLI to Galaxy S21+ (`SM-G996B`, device `RFCR31468LJ`)
- verified on-device: exact-alarm copy, missing-permission gating, recurring disclaimer, reminder persistence, details bell state, and schedule-block indicator


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added class reminders with configurable minute offsets and one-time/recurring scopes, including remove support.
  * Added exact-alarm reminder enablement with in-app permission prompts and notification settings navigation, plus deep-link navigation from reminder notifications.
  * Added reminder-aware pause banner and schedule entry/filter indicators.
  * Added confirmations when changing schedule source with linked reminders, warning that reminders may be removed.
* **Bug Fixes**
  * Improved reminder initialization and background reconciliation robustness.
* **Tests**
  * Added/expanded automated coverage for reminder identity, reconciliation, repositories, and UI flows (including DE/EN).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->