### PR TITLE
Fix widget crash from stale RemoteViews positions

### DIFF
--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/MultiDayViewsFactory.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/MultiDayViewsFactory.kt
@@ -32,11 +32,8 @@ abstract class MultiDayViewsFactory<T>(
     }
 
     override fun getViewAt(position: Int): RemoteViews? {
-        if (position == AdapterView.INVALID_POSITION || position >= visibleRows.size) {
-            return null
-        }
-
-        val row = visibleRows[position]
+        val rows = visibleRows
+        val row = MultiDayWidgetHelper.rowAt(rows, position) ?: return null
         val views = RemoteViews(context.packageName, getRowLayoutId())
         bindDayHeader(views, row.date, row.isToday)
 
@@ -72,7 +69,9 @@ abstract class MultiDayViewsFactory<T>(
     }
 
     override fun getItemId(position: Int): Long {
-        return visibleRows[position].date.toEpochDay()
+        val rows = visibleRows
+        return MultiDayWidgetHelper.stableItemIdAt(rows, position)
+            ?: AdapterView.INVALID_ROW_ID
     }
 
     override fun hasStableIds(): Boolean {

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/widget/MultiDayWidgetHelper.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/widget/MultiDayWidgetHelper.kt
@@ -42,6 +42,14 @@ object MultiDayWidgetHelper {
         return rows.filter { row -> row.isToday || row.items.isNotEmpty() }
     }
 
+    fun <T> rowAt(rows: List<DayRow<T>>, position: Int): DayRow<T>? {
+        return rows.getOrNull(position)
+    }
+
+    fun <T> stableItemIdAt(rows: List<DayRow<T>>, position: Int): Long? {
+        return rowAt(rows, position)?.date?.toEpochDay()
+    }
+
     fun <T> limitItems(items: List<T>, maxItems: Int): VisibleItems<T> {
         val safeMax = max(1, maxItems)
         if (items.size <= safeMax) {

--- a/android/app/src/test/java/com/fariszr/dualmate/widget/MultiDayWidgetHelperTest.kt
+++ b/android/app/src/test/java/com/fariszr/dualmate/widget/MultiDayWidgetHelperTest.kt
@@ -42,6 +42,41 @@ class MultiDayWidgetHelperTest {
     }
 
     @Test
+    fun rowAt_returnsNullForInvalidPositions() {
+        val today = LocalDate.of(2026, 1, 21)
+        val rows = listOf(
+            MultiDayWidgetHelper.DayRow(today, emptyList<String>(), true),
+            MultiDayWidgetHelper.DayRow(today.plusDays(1), listOf("item"), false)
+        )
+
+        assertEquals(null, MultiDayWidgetHelper.rowAt(rows, -1))
+        assertEquals(null, MultiDayWidgetHelper.rowAt(rows, rows.size))
+    }
+
+    @Test
+    fun stableItemIdAt_returnsDateBasedIdForValidPosition() {
+        val today = LocalDate.of(2026, 1, 21)
+        val rows = listOf(
+            MultiDayWidgetHelper.DayRow(today, emptyList<String>(), true)
+        )
+
+        assertEquals(today.toEpochDay(), MultiDayWidgetHelper.stableItemIdAt(rows, 0))
+    }
+
+    @Test
+    fun stableItemIdAt_returnsNullForStalePositionAfterRowsShrink() {
+        val today = LocalDate.of(2026, 1, 21)
+        val originalRows = listOf(
+            MultiDayWidgetHelper.DayRow(today, emptyList<String>(), true),
+            MultiDayWidgetHelper.DayRow(today.plusDays(1), listOf("one"), false),
+            MultiDayWidgetHelper.DayRow(today.plusDays(2), listOf("two"), false)
+        )
+        val refreshedRows = originalRows.take(2)
+
+        assertEquals(null, MultiDayWidgetHelper.stableItemIdAt(refreshedRows, 2))
+    }
+
+    @Test
     fun calculateVisibleDayCount_minHeightShowsOne() {
         val today = LocalDate.of(2026, 1, 21)
         val rows = listOf(


### PR DESCRIPTION
## Summary

- guard `RemoteViewsFactory` item lookups against stale or invalid positions
- return `AdapterView.INVALID_ROW_ID` when the launcher requests an item ID that no longer exists
- use a single immutable row-list snapshot in both `getItemId()` and `getViewAt()`
- add regression coverage for negative, out-of-range, and dataset-shrink positions

## Why

Android launchers can retain an earlier collection count while `onDataSetChanged()` replaces the widget rows with a shorter filtered list. A later Binder callback can therefore request a stale position. The previous direct list access crashed with `IndexOutOfBoundsException: Index: 2, Size: 2`.

The shared factory backs both schedule and canteen widgets.

## Tests

- `./gradlew app:testDebugUnitTest app:assembleDebug`
- 21 Android unit tests passed
- debug APK assembled successfully

Closes #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-day widget handling for unavailable or outdated positions.
  * Prevented invalid widget entries and identifiers when the displayed day list changes.

* **Tests**
  * Added coverage for invalid positions, valid date-based identifiers, and stale entries after the list shrinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->