### PR TITLE
Add missed reminder battery fallback

### DIFF
--- a/android/app/src/main/kotlin/com/fariszr/dualmate/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/MainActivity.kt
@@ -7,6 +7,7 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.util.Log
@@ -50,6 +51,9 @@ class MainActivity : FlutterActivity() {
                 "openClassReminderNotificationSettings" -> {
                     val channelId = call.argument<String>("channelId")
                     result.success(openNotificationSettings(channelId))
+                }
+                "openClassReminderBatterySettings" -> {
+                    result.success(openClassReminderBatterySettings())
                 }
                 else -> result.notImplemented()
             }
@@ -158,6 +162,39 @@ class MainActivity : FlutterActivity() {
             true
         } catch (error: Exception) {
             Log.w("MainActivity", "Could not open notification settings", error)
+            false
+        }
+    }
+
+    private fun openClassReminderBatterySettings(): Boolean {
+        if (Build.MANUFACTURER.equals("samsung", ignoreCase = true)) {
+            val samsungIntent = Intent(
+                "com.samsung.android.sm.ACTION_OPEN_CHECKABLE_LISTACTIVITY"
+            ).apply {
+                setPackage("com.samsung.android.lool")
+                putExtra("activity_type", 2)
+            }
+            if (tryOpenSettings(samsungIntent)) return true
+        }
+
+        if (tryOpenSettings(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))) {
+            return true
+        }
+
+        return tryOpenSettings(
+            Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.parse("package:$packageName")
+            )
+        )
+    }
+
+    private fun tryOpenSettings(settingsIntent: Intent): Boolean {
+        return try {
+            startActivity(settingsIntent)
+            true
+        } catch (error: Exception) {
+            Log.w("MainActivity", "Could not open settings intent", error)
             false
         }
     }

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/MainActivity.kt
@@ -6,6 +6,7 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -193,7 +194,10 @@ class MainActivity : FlutterActivity() {
         return try {
             startActivity(settingsIntent)
             true
-        } catch (error: Exception) {
+        } catch (error: ActivityNotFoundException) {
+            Log.w("MainActivity", "Could not open settings intent", error)
+            false
+        } catch (error: SecurityException) {
             Log.w("MainActivity", "Could not open settings intent", error)
             false
         }

--- a/docs/solutions/notifications/class-reminder-reliability-hardening-20260718.md
+++ b/docs/solutions/notifications/class-reminder-reliability-hardening-20260718.md
@@ -58,15 +58,42 @@ each card. Rule reloads notify only when effective reminder state changes, and
 foreground schedule refreshes only enqueue reminder reconciliation after the
 unfiltered schedule is persisted.
 
+## Battery-restriction fallback
+
+Exact allow-while-idle alarms remain the default delivery mechanism. DualMate
+does not proactively ask users to disable battery optimization after creating a
+reminder.
+
+On controller initialization and app resume, DualMate checks the existing
+reminder manifest before expired rows are cleaned up. A reminder is considered
+likely missed only when its scheduled time is at least ten minutes in the past
+and its deterministic notification ID is still present in
+`flutter_local_notifications`' pending queue. A fired one-shot notification is
+removed from that queue, so absence from the queue is not treated as proof of a
+miss or delivery.
+
+Detected stale alarms are cancelled and removed from the manifest, then one
+compact localized notice is shown above the schedule. The notice links Galaxy
+devices to Samsung's Never sleeping apps screen and falls back to Android's
+battery-optimization settings and then the app-details screen. No direct
+battery-optimization exemption permission is requested.
+
+Reminder saves for entries that have already started are ignored before any
+permission check, persistence, or reconciliation work. The existing reminder
+button and removal flow remain unchanged.
+
 # Verification
 
-- Full Flutter suite: 548 tests passed.
+- Full Flutter suite: 572 tests passed.
 - Android JVM/unit build: `:app:testDebugUnitTest` passed.
 - `flutter analyze` passed without issues.
 - Regression coverage includes startup dependency readiness, confirmed
   permission denial, channel disablement, settings routing, unfiltered reminder
   reconciliation, filter keep/remove/cancel behavior, ambiguous one-time moves,
   stable Rapla source identity, notification title resolution, and one reminder
-  listener for a multi-entry weekly schedule.
+  listener for a multi-entry weekly schedule. It also covers the missed-alarm
+  queue heuristic, its grace period and permission boundary, localized notice
+  behavior, and the early guard for already-started entries.
 - Galaxy S21+ profile-mode verification covers cold launch, schedule refresh
-  animation, filter interaction, permission notice behavior, and frame timing.
+  animation, filter interaction, permission notice behavior, the compact
+  missed-reminder notice, and opening Samsung's Never sleeping apps screen.

--- a/lib/common/i18n/localization_strings_de.dart
+++ b/lib/common/i18n/localization_strings_de.dart
@@ -208,6 +208,11 @@ final de = {
   "classReminderPausedMessage":
       "Aktiviere Benachrichtigungen und genaue Alarme, damit sie wieder funktionieren.",
   "classReminderFixPermissions": "Berechtigungen prüfen",
+  "classReminderMissedTitle": "Eine Erinnerung wurde möglicherweise verpasst",
+  "classReminderMissedMessage":
+      "Dein Smartphone schränkt DualMate möglicherweise im Hintergrund ein. Erlaube eine uneingeschränkte Akkunutzung, damit Erinnerungen zuverlässiger funktionieren.",
+  "classReminderBatterySettings": "Akkueinstellungen",
+  "classReminderDismiss": "Schließen",
   "classReminderSourceChangeTitle": "Stundenplanquelle ändern?",
   "classReminderSourceChangeMessage":
       "Wenn du deinen Stundenplan änderst, werden alle mit dem aktuellen Stundenplan verknüpften Klassenerinnerungen entfernt.",

--- a/lib/common/i18n/localization_strings_en.dart
+++ b/lib/common/i18n/localization_strings_en.dart
@@ -197,6 +197,11 @@ final en = {
   "classReminderPausedMessage":
       "DualMate cannot deliver reminders reliably because a required permission is disabled.",
   "classReminderFixPermissions": "Fix permissions",
+  "classReminderMissedTitle": "A class reminder may have been missed",
+  "classReminderMissedMessage":
+      "Your phone may be restricting DualMate in the background. Allow unrestricted battery usage to improve reminder reliability.",
+  "classReminderBatterySettings": "Battery settings",
+  "classReminderDismiss": "Dismiss",
   "classReminderSourceChangeTitle": "Change schedule source?",
   "classReminderSourceChangeMessage":
       "Changing your schedule will remove all class reminders linked to the current schedule.",

--- a/lib/common/i18n/localizations.dart
+++ b/lib/common/i18n/localizations.dart
@@ -441,6 +441,12 @@ class L {
       _getValue("classReminderPausedMessage");
   String get classReminderFixPermissions =>
       _getValue("classReminderFixPermissions");
+  String get classReminderMissedTitle => _getValue("classReminderMissedTitle");
+  String get classReminderMissedMessage =>
+      _getValue("classReminderMissedMessage");
+  String get classReminderBatterySettings =>
+      _getValue("classReminderBatterySettings");
+  String get classReminderDismiss => _getValue("classReminderDismiss");
   String get classReminderSourceChangeTitle =>
       _getValue("classReminderSourceChangeTitle");
   String get classReminderSourceChangeMessage =>

--- a/lib/common/ui/notification_api.dart
+++ b/lib/common/ui/notification_api.dart
@@ -29,6 +29,11 @@ typedef NotificationChannelEnabledChecker =
 
 typedef NotificationChannelSettingsOpener = Future<bool> Function();
 
+typedef NotificationPendingIdsLoader =
+    Future<Set<int>> Function(FlutterLocalNotificationsPlugin plugin);
+
+typedef NotificationBatterySettingsOpener = Future<bool> Function();
+
 class NotificationApi {
   static const String classReminderChannelId = 'class_reminders';
   static const MethodChannel _settingsChannel = MethodChannel(
@@ -40,6 +45,8 @@ class NotificationApi {
   final NotificationRuntimePermissionRequester _runtimePermissionRequester;
   final NotificationChannelEnabledChecker _classReminderChannelChecker;
   final NotificationChannelSettingsOpener _classReminderSettingsOpener;
+  final NotificationPendingIdsLoader _pendingNotificationIdsLoader;
+  final NotificationBatterySettingsOpener _classReminderBatterySettingsOpener;
 
   NotificationApi({
     FlutterLocalNotificationsPlugin? localNotificationsPlugin,
@@ -47,6 +54,8 @@ class NotificationApi {
     NotificationRuntimePermissionRequester? runtimePermissionRequester,
     NotificationChannelEnabledChecker? classReminderChannelChecker,
     NotificationChannelSettingsOpener? classReminderSettingsOpener,
+    NotificationPendingIdsLoader? pendingNotificationIdsLoader,
+    NotificationBatterySettingsOpener? classReminderBatterySettingsOpener,
   }) : _localNotificationsPlugin =
            localNotificationsPlugin ?? FlutterLocalNotificationsPlugin(),
        _pluginInitializer = pluginInitializer ?? _defaultPluginInitializer,
@@ -55,7 +64,12 @@ class NotificationApi {
        _classReminderChannelChecker =
            classReminderChannelChecker ?? _defaultClassReminderChannelChecker,
        _classReminderSettingsOpener =
-           classReminderSettingsOpener ?? _defaultClassReminderSettingsOpener;
+           classReminderSettingsOpener ?? _defaultClassReminderSettingsOpener,
+       _pendingNotificationIdsLoader =
+           pendingNotificationIdsLoader ?? _defaultPendingNotificationIdsLoader,
+       _classReminderBatterySettingsOpener =
+           classReminderBatterySettingsOpener ??
+           _defaultClassReminderBatterySettingsOpener;
 
   ///
   /// Initialize the notifications. You can't show any notifications before you
@@ -165,6 +179,20 @@ class NotificationApi {
         false;
   }
 
+  static Future<Set<int>> _defaultPendingNotificationIdsLoader(
+    FlutterLocalNotificationsPlugin plugin,
+  ) async {
+    final requests = await plugin.pendingNotificationRequests();
+    return requests.map((request) => request.id).toSet();
+  }
+
+  static Future<bool> _defaultClassReminderBatterySettingsOpener() async {
+    return await _settingsChannel.invokeMethod<bool>(
+          'openClassReminderBatterySettings',
+        ) ??
+        false;
+  }
+
   ///
   /// Show a notification with the given title and message
   ///
@@ -217,6 +245,20 @@ class NotificationApi {
   Future<bool> openClassReminderSettings() async {
     try {
       return await _classReminderSettingsOpener();
+    } on PlatformException {
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
+  Future<Set<int>> pendingNotificationIds() {
+    return _pendingNotificationIdsLoader(_localNotificationsPlugin);
+  }
+
+  Future<bool> openClassReminderBatterySettings() async {
+    try {
+      return await _classReminderBatterySettingsOpener();
     } on PlatformException {
       return false;
     } on MissingPluginException {
@@ -310,6 +352,12 @@ class VoidNotificationApi extends NotificationApi {
 
   @override
   Future<bool> openClassReminderSettings() => Future.value(false);
+
+  @override
+  Future<Set<int>> pendingNotificationIds() => Future.value(<int>{});
+
+  @override
+  Future<bool> openClassReminderBatterySettings() => Future.value(false);
 
   @override
   Future<bool> canScheduleExactNotifications() => Future.value(false);

--- a/lib/common/ui/notification_api.dart
+++ b/lib/common/ui/notification_api.dart
@@ -252,8 +252,14 @@ class NotificationApi {
     }
   }
 
-  Future<Set<int>> pendingNotificationIds() {
-    return _pendingNotificationIdsLoader(_localNotificationsPlugin);
+  Future<Set<int>> pendingNotificationIds() async {
+    try {
+      return await _pendingNotificationIdsLoader(_localNotificationsPlugin);
+    } on PlatformException {
+      return <int>{};
+    } on MissingPluginException {
+      return <int>{};
+    }
   }
 
   Future<bool> openClassReminderBatterySettings() async {

--- a/lib/schedule/reminders/class_reminder_controller.dart
+++ b/lib/schedule/reminders/class_reminder_controller.dart
@@ -16,11 +16,12 @@ import 'package:dualmate/schedule/reminders/reminder_sync_queue.dart';
 import 'package:dualmate/schedule/service/schedule_source.dart';
 import 'package:flutter/foundation.dart';
 
-enum ReminderActivationResult { active, permissionsRequired }
+enum ReminderActivationResult { active, permissionsRequired, ignoredPastEvent }
 
 class ClassReminderController extends ChangeNotifier {
   static const Duration upcomingWindow = Duration(days: 14);
   static const Duration resumeCleanupStaleness = Duration(hours: 6);
+  static const Duration missedReminderGracePeriod = Duration(minutes: 10);
 
   final ClassReminderRepository _repository;
   final ScheduleProvider _scheduleProvider;
@@ -36,6 +37,7 @@ class ClassReminderController extends ChangeNotifier {
   Map<String, ClassReminderRule> _oneTimeRulesByOccurrence = const {};
   bool _permissionsGranted = false;
   bool _permissionStateKnown = false;
+  bool _hasLikelyMissedReminder = false;
   bool _initialized = false;
   Future<void>? _initializationFuture;
   Future<void>? _permissionRefreshFuture;
@@ -77,6 +79,7 @@ class ClassReminderController extends ChangeNotifier {
   bool get isInitialized => _initialized;
   bool get remindersPaused =>
       hasReminders && _permissionStateKnown && !_permissionsGranted;
+  bool get hasLikelyMissedReminder => _hasLikelyMissedReminder;
   ReminderSyncQueue get queue => _queue;
 
   Future<void> initialize() {
@@ -94,9 +97,10 @@ class ClassReminderController extends ChangeNotifier {
   }
 
   Future<void> _initialize() async {
-    await _cleanupIfNeeded(force: true);
     await _reloadRules();
     await refreshPermissionState(scheduleWhenRestored: false);
+    await _detectLikelyMissedReminders();
+    await _cleanupIfNeeded(force: true);
     if (hasReminders && permissionsGranted) {
       await reconcileUpcoming(waitForCompletion: true);
     } else if (remindersPaused) {
@@ -111,9 +115,14 @@ class ClassReminderController extends ChangeNotifier {
       await initialize();
       return;
     }
-    await _cleanupIfNeeded();
+    final permissionsWereGranted = _permissionsGranted;
     await _reloadRules();
-    await refreshPermissionState();
+    await refreshPermissionState(scheduleWhenRestored: false);
+    await _detectLikelyMissedReminders();
+    await _cleanupIfNeeded();
+    if (!permissionsWereGranted && permissionsGranted && hasReminders) {
+      await reconcileUpcoming(waitForCompletion: false);
+    }
   }
 
   Future<void> refreshPermissionState({bool scheduleWhenRestored = true}) {
@@ -176,6 +185,19 @@ class ClassReminderController extends ChangeNotifier {
     }
   }
 
+  void dismissLikelyMissedReminder() {
+    if (!_hasLikelyMissedReminder) return;
+    _hasLikelyMissedReminder = false;
+    notifyListeners();
+  }
+
+  Future<void> openBatterySettingsForMissedReminder() async {
+    final api = _notificationApi();
+    if (api == null) return;
+    final opened = await api.openClassReminderBatterySettings();
+    if (opened) dismissLikelyMissedReminder();
+  }
+
   ClassReminderRule? ruleFor(ScheduleEntry entry) {
     final canonical = CanonicalClassName.fromTitle(entry.title);
     return _oneTimeRulesByOccurrence[_occurrenceRuleKey(
@@ -210,6 +232,9 @@ class ClassReminderController extends ChangeNotifier {
     required Duration offset,
     required ClassReminderScope scope,
   }) async {
+    if (!entry.start.isAfter(_now())) {
+      return ReminderActivationResult.ignoredPastEvent;
+    }
     await refreshPermissionState(scheduleWhenRestored: false);
     if (!_permissionsGranted)
       return ReminderActivationResult.permissionsRequired;
@@ -458,6 +483,43 @@ class ClassReminderController extends ChangeNotifier {
     try {
       await _repository.deleteExpired(now);
       _lastCleanup = now;
+    } catch (error, trace) {
+      await _reportQueueFailure(error, trace);
+    }
+  }
+
+  Future<void> _detectLikelyMissedReminders() async {
+    if (!_permissionStateKnown || !_permissionsGranted) return;
+    final sourceIdentity = _sourceProvider.currentSourceIdentity;
+    if (sourceIdentity == 'none') return;
+    final api = _notificationApi();
+    if (api == null) return;
+
+    try {
+      final cutoff = _now().subtract(missedReminderGracePeriod);
+      final manifest = await _repository.loadManifestForSource(sourceIdentity);
+      final overdue = manifest
+          .where((row) => !row.scheduledTime.isAfter(cutoff))
+          .toList(growable: false);
+      if (overdue.isEmpty) return;
+
+      final pendingIds = await api.pendingNotificationIds();
+      final missed = overdue
+          .where((row) => pendingIds.contains(row.notificationId))
+          .toList(growable: false);
+      if (missed.isEmpty) return;
+
+      for (final row in missed) {
+        await _scheduler.cancel(row.notificationId);
+      }
+      await _repository.applyManifestChanges(
+        upserts: const [],
+        removals: missed,
+      );
+      if (!_hasLikelyMissedReminder) {
+        _hasLikelyMissedReminder = true;
+        notifyListeners();
+      }
     } catch (error, trace) {
       await _reportQueueFailure(error, trace);
     }

--- a/lib/schedule/ui/schedule_page.dart
+++ b/lib/schedule/ui/schedule_page.dart
@@ -301,6 +301,9 @@ class ClassReminderPauseAwareContent extends StatelessWidget {
       animation: controller,
       child: child,
       builder: (context, schedule) {
+        final remindersPaused = controller.remindersPaused;
+        final showMissedReminder =
+            !remindersPaused && controller.hasLikelyMissedReminder;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -309,17 +312,40 @@ class ClassReminderPauseAwareContent extends StatelessWidget {
                 duration: const Duration(milliseconds: 180),
                 curve: Curves.easeOutCubic,
                 alignment: Alignment.topCenter,
-                heightFactor: controller.remindersPaused ? 1 : 0,
+                heightFactor: remindersPaused ? 1 : 0,
                 child: IgnorePointer(
-                  ignoring: !controller.remindersPaused,
+                  ignoring: !remindersPaused,
                   child: AnimatedOpacity(
                     duration: const Duration(milliseconds: 120),
-                    opacity: controller.remindersPaused ? 1 : 0,
+                    opacity: remindersPaused ? 1 : 0,
                     child: Padding(
                       padding: const EdgeInsets.only(top: 12),
                       child: ClassReminderPausedNotice(
                         onFixPermissions:
                             controller.openReliablePermissionSettings,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            ClipRect(
+              child: AnimatedAlign(
+                duration: const Duration(milliseconds: 180),
+                curve: Curves.easeOutCubic,
+                alignment: Alignment.topCenter,
+                heightFactor: showMissedReminder ? 1 : 0,
+                child: IgnorePointer(
+                  ignoring: !showMissedReminder,
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 120),
+                    opacity: showMissedReminder ? 1 : 0,
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 12),
+                      child: ClassReminderLikelyMissedNotice(
+                        onOpenBatterySettings:
+                            controller.openBatterySettingsForMissedReminder,
+                        onDismiss: controller.dismissLikelyMissedReminder,
                       ),
                     ),
                   ),

--- a/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
+++ b/lib/schedule/ui/weeklyschedule/schedule_entry_detail_bottom_sheet.dart
@@ -340,14 +340,21 @@ class _ScheduleEntryDetailBottomSheetState
       builder: (sheetContext) => ReminderConfigurationSheet(
         existingRule: existingRule,
         onSave: (offset, scope) async {
-          var result = await controller.saveReminder(
+          final result = await controller.saveReminder(
             entry: widget.scheduleEntry,
             offset: offset,
             scope: scope,
           );
-          if (result != ReminderActivationResult.permissionsRequired ||
-              !sheetContext.mounted) {
-            return;
+          if (!sheetContext.mounted) return;
+          switch (result) {
+            case ReminderActivationResult.active:
+              return;
+            case ReminderActivationResult.ignoredPastEvent:
+              // The configuration sheet closes after this callback. Past
+              // events intentionally need no additional message.
+              return;
+            case ReminderActivationResult.permissionsRequired:
+              break;
           }
           final openSettings = await showDialog<bool>(
             context: sheetContext,
@@ -373,7 +380,7 @@ class _ScheduleEntryDetailBottomSheetState
           if (openSettings != true) return;
           await controller.openReliablePermissionSettings();
           if (controller.permissionsGranted) {
-            result = await controller.saveReminder(
+            await controller.saveReminder(
               entry: widget.scheduleEntry,
               offset: offset,
               scope: scope,

--- a/lib/schedule/ui/widgets/class_reminder_paused_notice.dart
+++ b/lib/schedule/ui/widgets/class_reminder_paused_notice.dart
@@ -18,3 +18,74 @@ class ClassReminderPausedNotice extends StatelessWidget {
     );
   }
 }
+
+class ClassReminderLikelyMissedNotice extends StatelessWidget {
+  final VoidCallback onOpenBatterySettings;
+  final VoidCallback onDismiss;
+
+  const ClassReminderLikelyMissedNotice({
+    super.key,
+    required this.onOpenBatterySettings,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final strings = L.of(context);
+    final colors = Theme.of(context).colorScheme;
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12),
+      elevation: 0,
+      color: colors.tertiaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 12, 4, 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Icon(
+                Icons.notifications_paused_outlined,
+                color: colors.onTertiaryContainer,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    strings.classReminderMissedTitle,
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: colors.onTertiaryContainer,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    strings.classReminderMissedMessage,
+                    style: TextStyle(color: colors.onTertiaryContainer),
+                  ),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      onPressed: onOpenBatterySettings,
+                      child: Text(strings.classReminderBatterySettings),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              tooltip: strings.classReminderDismiss,
+              visualDensity: VisualDensity.compact,
+              onPressed: onDismiss,
+              icon: const Icon(Icons.close),
+              color: colors.onTertiaryContainer,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/common/ui/notification_api_test.dart
+++ b/test/common/ui/notification_api_test.dart
@@ -141,6 +141,32 @@ void main() {
     expect(await api.pendingNotificationIds(), {-42, -7});
   });
 
+  test(
+    'pending notification IDs use an empty safe default on platform failure',
+    () async {
+      final api = NotificationApi(
+        pendingNotificationIdsLoader: (_) async {
+          throw PlatformException(code: 'pending-failed');
+        },
+      );
+
+      expect(await api.pendingNotificationIds(), isEmpty);
+    },
+  );
+
+  test(
+    'pending notification IDs use an empty safe default without a plugin',
+    () async {
+      final api = NotificationApi(
+        pendingNotificationIdsLoader: (_) async {
+          throw MissingPluginException('not registered');
+        },
+      );
+
+      expect(await api.pendingNotificationIds(), isEmpty);
+    },
+  );
+
   test('class reminder battery settings use the dedicated opener', () async {
     var opens = 0;
     final api = NotificationApi(

--- a/test/common/ui/notification_api_test.dart
+++ b/test/common/ui/notification_api_test.dart
@@ -133,6 +133,47 @@ void main() {
     expect(opens, 1);
   });
 
+  test('pending class notification requests are exposed as IDs only', () async {
+    final api = NotificationApi(
+      pendingNotificationIdsLoader: (_) async => {-42, -7},
+    );
+
+    expect(await api.pendingNotificationIds(), {-42, -7});
+  });
+
+  test('class reminder battery settings use the dedicated opener', () async {
+    var opens = 0;
+    final api = NotificationApi(
+      classReminderBatterySettingsOpener: () async {
+        opens++;
+        return true;
+      },
+    );
+
+    expect(await api.openClassReminderBatterySettings(), isTrue);
+    expect(opens, 1);
+  });
+
+  test('class reminder battery settings swallow platform failures', () async {
+    final api = NotificationApi(
+      classReminderBatterySettingsOpener: () async {
+        throw PlatformException(code: 'settings-unavailable');
+      },
+    );
+
+    expect(await api.openClassReminderBatterySettings(), isFalse);
+  });
+
+  test(
+    'void notification API has no pending IDs or battery settings',
+    () async {
+      final api = VoidNotificationApi();
+
+      expect(await api.pendingNotificationIds(), isEmpty);
+      expect(await api.openClassReminderBatterySettings(), isFalse);
+    },
+  );
+
   test(
     'class reminders use an exact alarm at the requested Berlin time',
     () async {

--- a/test/schedule/reminders/class_reminder_controller_startup_test.dart
+++ b/test/schedule/reminders/class_reminder_controller_startup_test.dart
@@ -297,6 +297,214 @@ void main() {
     },
   );
 
+  test(
+    'initialization detects an overdue pending alarm before expired cleanup',
+    () async {
+      final now = DateTime(2026, 7, 20, 8);
+      final row = _manifestRow(
+        id: 42,
+        scheduledTime: now.subtract(const Duration(minutes: 30)),
+        classStart: now.subtract(const Duration(minutes: 5)),
+      );
+      final harness = _ReminderHarness(
+        now: now,
+        manifest: [row],
+        pendingIds: {42},
+      );
+      addTearDown(harness.controller.dispose);
+
+      await harness.controller.initialize();
+
+      expect(harness.controller.hasLikelyMissedReminder, isTrue);
+      expect(harness.permissions.pendingReads, 1);
+      expect(harness.scheduler.cancelledIds, [42]);
+      expect(harness.repository.manifest, isEmpty);
+      expect(harness.repository.deleteExpiredCalls, greaterThanOrEqualTo(1));
+    },
+  );
+
+  test(
+    'overdue alarm absent from pending queue is not treated as missed',
+    () async {
+      final now = DateTime(2026, 7, 20, 8);
+      final row = _manifestRow(
+        id: 42,
+        scheduledTime: now.subtract(const Duration(minutes: 30)),
+        classStart: now.add(const Duration(hours: 1)),
+      );
+      final harness = _ReminderHarness(now: now, manifest: [row]);
+      addTearDown(harness.controller.dispose);
+
+      await harness.controller.initialize();
+
+      expect(harness.controller.hasLikelyMissedReminder, isFalse);
+      expect(harness.permissions.pendingReads, 1);
+      expect(harness.scheduler.cancelledIds, isEmpty);
+      expect(harness.repository.manifest, [row]);
+    },
+  );
+
+  test('pending queue is not queried when no alarm is overdue', () async {
+    final now = DateTime(2026, 7, 20, 8);
+    final row = _manifestRow(
+      id: 42,
+      scheduledTime: now.subtract(const Duration(minutes: 9)),
+      classStart: now.add(const Duration(hours: 1)),
+    );
+    final harness = _ReminderHarness(
+      now: now,
+      manifest: [row],
+      pendingIds: {42},
+    );
+    addTearDown(harness.controller.dispose);
+
+    await harness.controller.initialize();
+
+    expect(harness.controller.hasLikelyMissedReminder, isFalse);
+    expect(harness.permissions.pendingReads, 0);
+  });
+
+  test(
+    'denied permissions suppress battery warning and keep paused flow',
+    () async {
+      final now = DateTime(2026, 7, 20, 8);
+      final harness = _ReminderHarness(
+        now: now,
+        rules: [_recurringRule()],
+        manifest: [
+          _manifestRow(
+            id: 42,
+            scheduledTime: now.subtract(const Duration(minutes: 30)),
+            classStart: now.add(const Duration(hours: 1)),
+          ),
+        ],
+        permissionsGranted: false,
+        pendingIds: {42},
+      );
+      addTearDown(harness.controller.dispose);
+
+      await harness.controller.initialize();
+
+      expect(harness.controller.remindersPaused, isTrue);
+      expect(harness.controller.hasLikelyMissedReminder, isFalse);
+      expect(harness.permissions.pendingReads, 0);
+    },
+  );
+
+  test(
+    'multiple overdue pending alarms produce one notice and are consumed',
+    () async {
+      final now = DateTime(2026, 7, 20, 8);
+      final harness = _ReminderHarness(
+        now: now,
+        manifest: [
+          _manifestRow(
+            id: 42,
+            scheduledTime: now.subtract(const Duration(minutes: 30)),
+            classStart: now.add(const Duration(hours: 1)),
+          ),
+          _manifestRow(
+            id: 43,
+            scheduledTime: now.subtract(const Duration(minutes: 11)),
+            classStart: now.add(const Duration(hours: 2)),
+          ),
+        ],
+        pendingIds: {42, 43},
+      );
+      addTearDown(harness.controller.dispose);
+
+      await harness.controller.initialize();
+
+      expect(harness.controller.hasLikelyMissedReminder, isTrue);
+      expect(harness.scheduler.cancelledIds, containsAll([42, 43]));
+      expect(harness.repository.manifest, isEmpty);
+    },
+  );
+
+  test(
+    'missed reminder notice can be dismissed and settings clear on success',
+    () async {
+      final now = DateTime(2026, 7, 20, 8);
+      final harness = _ReminderHarness(
+        now: now,
+        manifest: [
+          _manifestRow(
+            id: 42,
+            scheduledTime: now.subtract(const Duration(minutes: 30)),
+            classStart: now.add(const Duration(hours: 1)),
+          ),
+        ],
+        pendingIds: {42},
+      );
+      addTearDown(harness.controller.dispose);
+      await harness.controller.initialize();
+
+      harness.controller.dismissLikelyMissedReminder();
+      expect(harness.controller.hasLikelyMissedReminder, isFalse);
+
+      harness.repository.manifest.add(
+        _manifestRow(
+          id: 43,
+          scheduledTime: now.subtract(const Duration(minutes: 20)),
+          classStart: now.add(const Duration(hours: 2)),
+        ),
+      );
+      harness.permissions.pendingIds.add(43);
+      await harness.controller.onAppResumed();
+      expect(harness.controller.hasLikelyMissedReminder, isTrue);
+
+      harness.permissions.batterySettingsResult = false;
+      await harness.controller.openBatterySettingsForMissedReminder();
+      expect(harness.controller.hasLikelyMissedReminder, isTrue);
+
+      harness.permissions.batterySettingsResult = true;
+      await harness.controller.openBatterySettingsForMissedReminder();
+      expect(harness.controller.hasLikelyMissedReminder, isFalse);
+      expect(harness.permissions.batterySettingsOpens, 2);
+    },
+  );
+
+  test(
+    'saving a reminder for an already-started entry is ignored early',
+    () async {
+      final now = DateTime(2026, 7, 20, 10);
+      final harness = _ReminderHarness(now: now);
+      addTearDown(harness.controller.dispose);
+
+      final result = await harness.controller.saveReminder(
+        entry: _entry(start: now),
+        offset: const Duration(minutes: 15),
+        scope: ClassReminderScope.oneTime,
+      );
+
+      expect(result, ReminderActivationResult.ignoredPastEvent);
+      expect(harness.permissions.permissionReads, 0);
+      expect(harness.repository.ruleChangeCalls, 0);
+      expect(harness.scheduleProvider.cacheReads, 0);
+    },
+  );
+
+  test(
+    'saving a future reminder retains the existing permission flow',
+    () async {
+      final now = DateTime(2026, 7, 20, 10);
+      final harness = _ReminderHarness(now: now);
+      addTearDown(harness.controller.dispose);
+
+      final result = await harness.controller.saveReminder(
+        entry: _entry(start: now.add(const Duration(hours: 1))),
+        offset: const Duration(minutes: 15),
+        scope: ClassReminderScope.oneTime,
+      );
+      await harness.controller.queue.drain();
+
+      expect(result, ReminderActivationResult.active);
+      expect(harness.permissions.permissionReads, greaterThanOrEqualTo(3));
+      expect(harness.repository.ruleChangeCalls, greaterThanOrEqualTo(1));
+      expect(harness.scheduleProvider.cacheReads, 1);
+    },
+  );
+
   test('failed initialization can be retried', () async {
     final repository = _FailOnceReminderRepository();
     final source = _FakeScheduleSourceProvider();
@@ -408,6 +616,84 @@ class _GrantedNotificationApi extends VoidNotificationApi {
   Future<bool> canScheduleExactNotifications() async => true;
 }
 
+class _PendingNotificationApi extends VoidNotificationApi {
+  final bool permissionsGranted;
+  final Set<int> pendingIds;
+  int pendingReads = 0;
+  int permissionReads = 0;
+  int batterySettingsOpens = 0;
+  bool batterySettingsResult = true;
+
+  _PendingNotificationApi({
+    this.permissionsGranted = true,
+    Set<int>? pendingIds,
+  }) : pendingIds = pendingIds ?? <int>{};
+
+  @override
+  Future<bool> areNotificationsEnabled() async {
+    permissionReads++;
+    return permissionsGranted;
+  }
+
+  @override
+  Future<bool> areClassRemindersEnabled() async {
+    permissionReads++;
+    return permissionsGranted;
+  }
+
+  @override
+  Future<bool> canScheduleExactNotifications() async {
+    permissionReads++;
+    return permissionsGranted;
+  }
+
+  @override
+  Future<Set<int>> pendingNotificationIds() async {
+    pendingReads++;
+    return Set<int>.from(pendingIds);
+  }
+
+  @override
+  Future<bool> openClassReminderBatterySettings() async {
+    batterySettingsOpens++;
+    return batterySettingsResult;
+  }
+}
+
+class _ReminderHarness {
+  late final _TrackingReminderRepository repository;
+  late final _PendingNotificationApi permissions;
+  late final _RecordingScheduler scheduler;
+  late final _FakeScheduleSourceProvider source;
+  late final _TrackingScheduleProvider scheduleProvider;
+  late final ClassReminderController controller;
+
+  _ReminderHarness({
+    required DateTime now,
+    List<ClassReminderRule>? rules,
+    List<ScheduledClassNotification>? manifest,
+    bool permissionsGranted = true,
+    Set<int>? pendingIds,
+  }) {
+    repository = _TrackingReminderRepository(rules: rules, manifest: manifest);
+    permissions = _PendingNotificationApi(
+      permissionsGranted: permissionsGranted,
+      pendingIds: pendingIds,
+    );
+    scheduler = _RecordingScheduler();
+    source = _FakeScheduleSourceProvider();
+    scheduleProvider = _TrackingScheduleProvider(source);
+    controller = ClassReminderController(
+      repository: repository,
+      scheduleProvider: scheduleProvider,
+      sourceProvider: source,
+      scheduler: scheduler,
+      notificationApi: () => permissions,
+      now: () => now,
+    );
+  }
+}
+
 class _MemoryReminderRepository extends ClassReminderRepository {
   _MemoryReminderRepository() : super(_UnusedDatabaseAccess());
 
@@ -478,6 +764,21 @@ class _FakeScheduleProvider extends ScheduleProvider {
     DateTime start,
     DateTime end,
   ) async {
+    return Schedule();
+  }
+}
+
+class _TrackingScheduleProvider extends _FakeScheduleProvider {
+  int cacheReads = 0;
+
+  _TrackingScheduleProvider(super.source);
+
+  @override
+  Future<Schedule> getUnfilteredCachedSchedule(
+    DateTime start,
+    DateTime end,
+  ) async {
+    cacheReads++;
     return Schedule();
   }
 }
@@ -572,3 +873,121 @@ class _ManifestReminderRepository extends _MemoryReminderRepository {
     // No-op: no real database in tests.
   }
 }
+
+class _TrackingReminderRepository extends ClassReminderRepository {
+  final List<ClassReminderRule> rules;
+  final List<ScheduledClassNotification> manifest;
+  int deleteExpiredCalls = 0;
+  int ruleChangeCalls = 0;
+
+  _TrackingReminderRepository({
+    List<ClassReminderRule>? rules,
+    List<ScheduledClassNotification>? manifest,
+  }) : rules = rules ?? <ClassReminderRule>[],
+       manifest = manifest ?? <ScheduledClassNotification>[],
+       super(_UnusedDatabaseAccess());
+
+  @override
+  Future<List<ClassReminderRule>> loadRelevantRules({
+    required String sourceIdentity,
+    required DateTime now,
+  }) async => List<ClassReminderRule>.from(rules);
+
+  @override
+  Future<List<ScheduledClassNotification>> loadManifestForSource(
+    String sourceIdentity,
+  ) async => manifest
+      .where((row) => row.sourceIdentity == sourceIdentity)
+      .toList(growable: false);
+
+  @override
+  Future<List<ScheduledClassNotification>> loadManifestForWindow({
+    required String sourceIdentity,
+    required DateTime start,
+    required DateTime end,
+  }) async => manifest
+      .where(
+        (row) =>
+            row.sourceIdentity == sourceIdentity &&
+            !row.classStart.isBefore(start) &&
+            row.classStart.isBefore(end),
+      )
+      .toList(growable: false);
+
+  @override
+  Future<void> applyManifestChanges({
+    required List<ScheduledClassNotification> upserts,
+    required List<ScheduledClassNotification> removals,
+  }) async {
+    final removedKeys = {
+      for (final row in removals) '${row.ruleId}|${row.occurrenceIdentity}',
+    };
+    manifest.removeWhere(
+      (row) => removedKeys.contains('${row.ruleId}|${row.occurrenceIdentity}'),
+    );
+    for (final row in upserts) {
+      manifest.removeWhere(
+        (existing) =>
+            existing.ruleId == row.ruleId &&
+            existing.occurrenceIdentity == row.occurrenceIdentity,
+      );
+      manifest.add(row);
+    }
+  }
+
+  @override
+  Future<void> applyRuleChanges({
+    required List<ClassReminderRule> upserts,
+    required List<String> removedRuleIds,
+  }) async {
+    ruleChangeCalls++;
+    rules.removeWhere((rule) => removedRuleIds.contains(rule.id));
+    for (final rule in upserts) {
+      rules.removeWhere((existing) => existing.id == rule.id);
+      rules.add(rule);
+    }
+  }
+
+  @override
+  Future<ExpiredReminderDeletionCount> deleteExpired(DateTime now) async {
+    deleteExpiredCalls++;
+    final previousManifestLength = manifest.length;
+    manifest.removeWhere((row) => !row.classStart.isAfter(now));
+    return ExpiredReminderDeletionCount(
+      oneTimeRules: 0,
+      manifestRows: previousManifestLength - manifest.length,
+    );
+  }
+}
+
+ClassReminderRule _recurringRule() => const ClassReminderRule(
+  id: 'recht',
+  scope: ClassReminderScope.recurring,
+  canonicalTitle: 'Recht',
+  offset: Duration(minutes: 30),
+  sourceIdentity: 'rapla:a',
+);
+
+ScheduledClassNotification _manifestRow({
+  required int id,
+  required DateTime scheduledTime,
+  required DateTime classStart,
+}) => ScheduledClassNotification(
+  ruleId: 'rule-$id',
+  occurrenceIdentity: 'occurrence-$id',
+  sourceIdentity: 'rapla:a',
+  notificationId: id,
+  scheduledTime: scheduledTime,
+  classStart: classStart,
+  contentFingerprint: 'fingerprint-$id',
+);
+
+ScheduleEntry _entry({required DateTime start}) => ScheduleEntry(
+  start: start,
+  end: start.add(const Duration(hours: 1)),
+  title: 'Recht',
+  details: '',
+  professor: '',
+  room: '',
+  type: ScheduleEntryType.Class,
+);

--- a/test/schedule/ui/class_reminder_pause_aware_content_test.dart
+++ b/test/schedule/ui/class_reminder_pause_aware_content_test.dart
@@ -40,10 +40,117 @@ void main() {
       );
     },
   );
+
+  testWidgets('missed reminder notice uses English locale and actions', (
+    tester,
+  ) async {
+    final reminders = _FakeReminderController()..missed = true;
+    await tester.pumpWidget(_app(reminders));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('A class reminder may have been missed'), findsOneWidget);
+    expect(
+      find.text(
+        'Your phone may be restricting DualMate in the background. Allow unrestricted battery usage to improve reminder reliability.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Battery settings'), findsOneWidget);
+    expect(
+      find.text('Eine Erinnerung wurde möglicherweise verpasst'),
+      findsNothing,
+    );
+
+    await tester.tap(find.text('Battery settings'));
+    await tester.pump();
+    expect(reminders.batterySettingsOpens, 1);
+
+    await tester.tap(find.byTooltip('Dismiss'));
+    await tester.pump();
+    expect(reminders.dismissals, 1);
+  });
+
+  testWidgets('missed reminder notice uses German locale only', (tester) async {
+    final reminders = _FakeReminderController()..missed = true;
+    await tester.pumpWidget(_app(reminders, locale: const Locale('de')));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(
+      find.text('Eine Erinnerung wurde möglicherweise verpasst'),
+      findsOneWidget,
+    );
+    expect(
+      find.text(
+        'Dein Smartphone schränkt DualMate möglicherweise im Hintergrund ein. Erlaube eine uneingeschränkte Akkunutzung, damit Erinnerungen zuverlässiger funktionieren.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Akkueinstellungen'), findsOneWidget);
+    expect(find.text('A class reminder may have been missed'), findsNothing);
+    expect(find.byTooltip('Schließen'), findsOneWidget);
+  });
+
+  testWidgets('paused permission notice takes precedence over missed notice', (
+    tester,
+  ) async {
+    final reminders = _FakeReminderController()
+      ..paused = true
+      ..missed = true;
+    await tester.pumpWidget(_app(reminders));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Class reminders are paused'), findsOneWidget);
+    expect(
+      find.text('A class reminder may have been missed').hitTestable(),
+      findsNothing,
+    );
+  });
+
+  testWidgets('missed notice preserves schedule state without overflow', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final reminders = _FakeReminderController();
+    await tester.pumpWidget(_app(reminders, textScale: 1.3));
+    final stateBefore = tester.state<_StableScheduleState>(
+      find.byType(_StableSchedule),
+    );
+
+    reminders.missed = true;
+    reminders.notifyListeners();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.state<_StableScheduleState>(find.byType(_StableSchedule)),
+      same(stateBefore),
+    );
+
+    reminders.missed = false;
+    reminders.notifyListeners();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.state<_StableScheduleState>(find.byType(_StableSchedule)),
+      same(stateBefore),
+    );
+  });
 }
 
-Widget _app(ClassReminderController reminders) => MaterialApp(
-  locale: const Locale('en'),
+Widget _app(
+  ClassReminderController reminders, {
+  Locale locale = const Locale('en'),
+  double textScale = 1,
+}) => MaterialApp(
+  locale: locale,
   supportedLocales: const [Locale('en'), Locale('de')],
   localizationsDelegates: const [
     LocalizationDelegate(),
@@ -51,6 +158,12 @@ Widget _app(ClassReminderController reminders) => MaterialApp(
     GlobalWidgetsLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
   ],
+  builder: (context, child) => MediaQuery(
+    data: MediaQuery.of(
+      context,
+    ).copyWith(textScaler: TextScaler.linear(textScale)),
+    child: child!,
+  ),
   home: Scaffold(
     body: ClassReminderPauseAwareContent(
       controller: reminders,
@@ -74,9 +187,15 @@ class _StableScheduleState extends State<_StableSchedule> {
 class _FakeReminderController extends ChangeNotifier
     implements ClassReminderController {
   bool paused = false;
+  bool missed = false;
+  int dismissals = 0;
+  int batterySettingsOpens = 0;
 
   @override
   bool get remindersPaused => paused;
+
+  @override
+  bool get hasLikelyMissedReminder => missed;
 
   @override
   bool get permissionsGranted => !paused;
@@ -89,6 +208,17 @@ class _FakeReminderController extends ChangeNotifier
 
   @override
   Future<void> openReliablePermissionSettings() async {}
+
+  @override
+  void dismissLikelyMissedReminder() {
+    dismissals++;
+    missed = false;
+  }
+
+  @override
+  Future<void> openBatterySettingsForMissedReminder() async {
+    batterySettingsOpens++;
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);


### PR DESCRIPTION
## Summary

- detect likely missed class reminders when an overdue manifest ID remains in the native pending-notification queue
- remove stale alarms and show one compact localized Material 3 notice above the schedule
- route Galaxy devices to Samsung's Never sleeping apps screen, with standard Android battery and app-settings fallbacks
- ignore reminder saves for entries that have already started before permission or persistence work

## Behavior

- keeps the existing notification/channel/exact-alarm permission flow and lazy checks
- does not proactively request a battery exception
- checks for missed reminders only during controller initialization and resume
- avoids pending-notification queries unless an overdue manifest row exists
- keeps the weekly schedule subtree mounted while the notice appears or disappears
- renders only the currently active English or German localization

## Validation

- focused reminder, notification, and notice tests: passed
- `flutter analyze`: no issues
- full Flutter suite: 572 tests passed
- Android JVM tests: `:app:testDebugUnitTest` passed
- final profile APK built, installed, and launched on Galaxy S21+
- Samsung action opened the Never auto sleeping apps screen
- returning to DualMate preserved the schedule and produced no DualMate runtime errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for likely missed class reminders.
  * Added an in-app notice with options to open battery settings or dismiss the notice.
  * Added support for Samsung and Android battery optimization settings.
  * Added English and German translations for the missed-reminder notice.
  * Reminders for events that have already started are now ignored.

* **Bug Fixes**
  * Improved cleanup of overdue scheduled reminders and notification records.

* **Tests**
  * Added coverage for missed reminders, battery settings actions, localization, dismissal, and responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->