### PR TITLE
Fix Rapla v2 no-tooltip metadata parsing

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -197,6 +197,20 @@ flutter {
     source '../..'
 }
 
+// AGP can incorrectly keep the local release APK's native-library merge
+// tasks up-to-date after switching branches. Force these packaging tasks to
+// consume the app.so produced by the current checked-out Flutter sources.
+def localreleasePackagingTasks = [
+    'mergeLocalreleaseReleaseJniLibFolders',
+    'mergeLocalreleaseReleaseNativeLibs',
+    'packageLocalreleaseRelease',
+]
+tasks.configureEach { task ->
+    if (localreleasePackagingTasks.contains(task.name)) {
+        task.outputs.upToDateWhen { false }
+    }
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.4"

--- a/docs/solutions/developer-experience/localrelease-branch-switch-build-cache-20260802.md
+++ b/docs/solutions/developer-experience/localrelease-branch-switch-build-cache-20260802.md
@@ -1,0 +1,28 @@
+---
+title: "Repackage localrelease APK after branch switches"
+category: developer-experience
+date: 2026-08-02
+---
+
+# Repackage localrelease APK after branch switches
+
+Switching branches could leave `build/app/outputs/flutter-apk/app-localrelease-release.apk`
+from the previously checked-out branch. Flutter regenerated the current
+`app.so`, but AGP treated the local release native-library merge and packaging
+tasks as up to date because their paths and filenames did not change.
+
+The app module now forces these local release tasks to run:
+
+- `mergeLocalreleaseReleaseJniLibFolders`
+- `mergeLocalreleaseReleaseNativeLibs`
+- `packageLocalreleaseRelease`
+
+This preserves Flutter's incremental Dart compilation while ensuring the final
+APK is repackaged from the current checkout:
+
+```bash
+flutter build apk --release --flavor localrelease
+```
+
+A full `flutter clean` is still useful when generated platform tooling is
+stale, but it is no longer required solely after switching branches.

--- a/docs/solutions/ui-bugs/rapla-v2-no-tooltip-metadata-20260802.md
+++ b/docs/solutions/ui-bugs/rapla-v2-no-tooltip-metadata-20260802.md
@@ -1,0 +1,52 @@
+---
+title: Parse Rapla v2 metadata without tooltips
+date: 2026-08-02
+category: ui-bugs
+tags:
+  - rapla
+  - schedule
+  - parsing
+  - metadata
+---
+
+# Parse Rapla v2 metadata without tooltips
+
+Rapla v2 calendar cells can omit the legacy tooltip. In that format the anchor
+contains the time and reservation title, followed by sibling `person` and
+`resource` spans. The schedule detail view was parsing the anchor with a fixed
+HTML offset, which left time/title content in `details` and discarded the
+lecturer and room metadata.
+
+## Contract and compatibility
+
+The upstream `HTMLRaplaBlock` implementation in `/home/clawd/rapla` emits the
+tooltip when enabled and otherwise emits the anchor followed by person and
+resource spans. No response-level Rapla version marker is emitted, so the
+parser uses capability detection: tooltip-present cells retain the v1.x parser;
+tooltip-free cells use the sibling-span structure.
+
+## Fix
+
+- Extract the no-tooltip title from DOM nodes after the anchor's first `br`.
+- Collect all non-empty person and resource spans, preserving HTML entities for
+  the existing sanitizer to decode consistently.
+- Keep no-tooltip details empty so time, title, lecturer, and room markup are
+  not duplicated there.
+- Preserve the existing tooltip classification and no-tooltip color/type map.
+
+## Verification
+
+- Added sanitized v1 tooltip and v2 no-tooltip metadata regressions covering
+  title, details, professor, room, and type.
+- `flutter test test/schedule/service/rapla/rapla_metadata_parsing_test.dart`
+  (2 tests passed)
+- `flutter test test/schedule` (262 tests passed)
+- `flutter analyze` (no issues)
+- `dart format --output=none --set-exit-if-changed` on changed Dart files
+- `git diff --check`
+- Connected Galaxy S21+ validation with the sanitized fixture on 5 October
+  2026 showed the title, both lecturers, `Class`, and both rooms in the
+  detail sheet with no duplicated details.
+- `ANDROID_SERIAL=RFCR31468LJ PERF_RUNS=3
+  scripts/run_cold_navigation_perf_suite.sh` completed successfully across
+  all six targets and wrote the cold-start summary.

--- a/lib/schedule/service/rapla/rapla_parsing_utils.dart
+++ b/lib/schedule/service/rapla/rapla_parsing_utils.dart
@@ -8,6 +8,7 @@ class RaplaParsingUtils {
   static const String WEEK_BLOCK_CLASS = "week_block";
   static const String TOOLTIP_CLASS = "tooltip";
   static const String INFOTABLE_CLASS = "infotable";
+  static const String PERSON_CLASS = "person";
   static const String RESOURCE_CLASS = "resource";
   static const String LABEL_CLASS = "label";
   static const String VALUE_CLASS = "value";
@@ -52,7 +53,9 @@ class RaplaParsingUtils {
   };
 
   static ScheduleEntry extractScheduleEntryOrThrow(
-      Element value, DateTime date) {
+    Element value,
+    DateTime date,
+  ) {
     // The tooltip tag contains the most relevant information
     var tooltip = value.getElementsByClassName(TOOLTIP_CLASS);
 
@@ -79,15 +82,20 @@ class RaplaParsingUtils {
     //       tooltip. Then provide a link with a manual to activate it in Rapla
     if (tooltip.isEmpty) {
       var scheduleEntry = extractScheduleDetailsFromCell(
-        timeAndClassName,
+        timeAndClassName[0],
+        value,
         start,
         end,
         value.attributes[STYLE_ATTRIBUTE],
       );
       return improveScheduleEntry(scheduleEntry);
     } else {
-      var scheduleEntry =
-          extractScheduleFromTooltip(tooltip, value, start, end);
+      var scheduleEntry = extractScheduleFromTooltip(
+        tooltip,
+        value,
+        start,
+        end,
+      );
       return improveScheduleEntry(scheduleEntry);
     }
   }
@@ -96,7 +104,8 @@ class RaplaParsingUtils {
     var professor = scheduleEntry.professor;
     if (professor.endsWith(",")) {
       scheduleEntry = scheduleEntry.copyWith(
-          professor: professor.substring(0, professor.length - 1));
+        professor: professor.substring(0, professor.length - 1),
+      );
     }
 
     return scheduleEntry.copyWith(
@@ -108,10 +117,11 @@ class RaplaParsingUtils {
   }
 
   static ScheduleEntry extractScheduleFromTooltip(
-      List<Element> tooltip,
-      Element value,
-      DateTime start,
-      DateTime end) {
+    List<Element> tooltip,
+    Element value,
+    DateTime start,
+    DateTime end,
+  ) {
     var infotable = tooltip[0].getElementsByClassName(INFOTABLE_CLASS);
 
     if (infotable.isEmpty) {
@@ -120,7 +130,8 @@ class RaplaParsingUtils {
 
     Map<String, String> properties = _parsePropertiesTable(infotable[0]);
     var type = _extractEntryType(tooltip, value);
-    var title = properties[CLASS_NAME_LABEL] ??
+    var title =
+        properties[CLASS_NAME_LABEL] ??
         properties[CLASS_TITLE_LABEL] ??
         properties[CLASS_NAME_LABEL_ALTERNATIVE] ??
         "";
@@ -142,34 +153,39 @@ class RaplaParsingUtils {
   }
 
   static ScheduleEntry extractScheduleDetailsFromCell(
-      List<Element> timeAndClassName,
-      DateTime start,
-      DateTime end, [
+    Element anchor,
+    Element cell,
+    DateTime start,
+    DateTime end, [
     String? style,
   ]) {
-    var descriptionHtml = timeAndClassName[0].innerHtml.substring(12);
-    var descriptionParts = descriptionHtml.split("<br>");
-
-    var title = "";
-    var details = "";
-
-    if (descriptionParts.length == 1) {
-      title = descriptionParts[0];
-    } else if (descriptionParts.length > 0) {
-      title = descriptionParts[1];
-      details = descriptionParts.join("\n");
-    }
-
     var scheduleEntry = ScheduleEntry(
       start: start,
       end: end,
-      title: title,
-      details: details,
-      professor: "",
+      title: _extractTitleFromAnchor(anchor),
+      details: "",
+      professor: _extractCellMetadata(cell, PERSON_CLASS),
       type: _mapColorType(style),
-      room: "",
+      room: _extractResources(cell),
     );
     return scheduleEntry;
+  }
+
+  static String _extractTitleFromAnchor(Element anchor) {
+    var lineBreakIndex = anchor.nodes.indexWhere(
+      (node) => node is Element && node.localName == "br",
+    );
+    if (lineBreakIndex == -1) return "";
+
+    return _serializeNodes(anchor.nodes.skip(lineBreakIndex + 1));
+  }
+
+  static String _serializeNodes(Iterable<Node> nodes) {
+    var fragment = DocumentFragment();
+    for (var node in nodes) {
+      fragment.append(node.clone(true));
+    }
+    return fragment.outerHtml;
   }
 
   static ScheduleEntryType _extractEntryType(
@@ -259,8 +275,7 @@ class RaplaParsingUtils {
     var values = infotable.getElementsByClassName(VALUE_CLASS);
 
     for (var i = 0; i < labels.length; i++) {
-      map[labels[i].innerHtml] =
-          i < values.length ? values[i].innerHtml : "";
+      map[labels[i].innerHtml] = i < values.length ? values[i].innerHtml : "";
     }
     return map;
   }
@@ -275,14 +290,17 @@ class RaplaParsingUtils {
   }
 
   static String _extractResources(Element value) {
-    var resources = value.getElementsByClassName(RESOURCE_CLASS);
+    return _extractCellMetadata(value, RESOURCE_CLASS);
+  }
 
-    var resourcesList = <String>[];
-    for (var resource in resources) {
-      resourcesList.add(resource.innerHtml);
-    }
+  static String _extractCellMetadata(Element value, String className) {
+    var metadata = value
+        .getElementsByClassName(className)
+        .where((element) => element.text.trim().isNotEmpty)
+        .map((element) => element.innerHtml)
+        .toList();
 
-    return concatStringList(resourcesList, ", ");
+    return concatStringList(metadata, ", ");
   }
 
   static String readYearOrThrow(Document document) {

--- a/lib/schedule/service/rapla/rapla_parsing_utils.dart
+++ b/lib/schedule/service/rapla/rapla_parsing_utils.dart
@@ -172,12 +172,17 @@ class RaplaParsingUtils {
   }
 
   static String _extractTitleFromAnchor(Element anchor) {
-    var lineBreakIndex = anchor.nodes.indexWhere(
-      (node) => node is Element && node.localName == "br",
-    );
+    var lineBreaks = anchor.getElementsByTagName("br");
+    if (lineBreaks.isEmpty) return "";
+
+    var lineBreak = lineBreaks.first;
+    var parent = lineBreak.parent;
+    if (parent == null) return "";
+
+    var lineBreakIndex = parent.nodes.indexOf(lineBreak);
     if (lineBreakIndex == -1) return "";
 
-    return _serializeNodes(anchor.nodes.skip(lineBreakIndex + 1));
+    return _serializeNodes(parent.nodes.skip(lineBreakIndex + 1));
   }
 
   static String _serializeNodes(Iterable<Node> nodes) {

--- a/test/schedule/service/rapla/html_resources/rapla_v2_link_metadata_response.html
+++ b/test/schedule/service/rapla/html_resources/rapla_v2_link_metadata_response.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <select name="year">
+    <option selected="selected">2026</option>
+  </select>
+  <table class="week_table">
+    <tr>
+      <th class="week_number">KW 41</th>
+      <td class="week_header"><nobr>Mo 05.10.</nobr></td>
+    </tr>
+    <tr>
+      <td class="week_block" style="background-color:#eeeeee">
+        <a href="https://example.invalid"><span class="link">09:00&#160;-10:30<br/>Linked Module</span></a>
+        <br><span class="person">Dr. Link</span>
+        <br><span class="resource">R1</span>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/test/schedule/service/rapla/html_resources/rapla_v2_metadata_response.html
+++ b/test/schedule/service/rapla/html_resources/rapla_v2_metadata_response.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <select name="year">
+    <option selected="selected">2026</option>
+  </select>
+  <table class="week_table">
+    <tr>
+      <th class="week_number">KW 41</th>
+      <td class="week_header"><nobr>Mo 05.10.</nobr></td>
+    </tr>
+    <tr>
+      <td class="week_block" style="background-color:#eeeeee">
+        <a href="#modern">09:00&#160;-10:30<br/>Modern &amp; Module</a>
+        <br><span class="person">Dr. Ada &amp; Lin</span>
+        <br><span class="person">Prof. Bea</span>
+        <br><span class="resource">Room &amp; Lab</span>
+        <br><span class="resource">Room 2</span>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/test/schedule/service/rapla/rapla_metadata_parsing_test.dart
+++ b/test/schedule/service/rapla/rapla_metadata_parsing_test.dart
@@ -9,6 +9,10 @@ Future<void> main() async {
     '${Directory.current.absolute.path}/test/schedule/service/rapla/'
     'html_resources/rapla_v2_metadata_response.html',
   ).readAsString();
+  final v2LinkedNoTooltipResponse = await File(
+    '${Directory.current.absolute.path}/test/schedule/service/rapla/'
+    'html_resources/rapla_v2_link_metadata_response.html',
+  ).readAsString();
 
   test('preserves v1 tooltip metadata and classification', () {
     final result = RaplaResponseParser().parseSchedule(_v1TooltipResponse);
@@ -37,6 +41,24 @@ Future<void> main() async {
     expect(entry.details, isEmpty);
     expect(entry.professor, 'Dr. Ada & Lin, Prof. Bea');
     expect(entry.room, 'Room & Lab, Room 2');
+    expect(entry.type, ScheduleEntryType.Class);
+  });
+
+  test('extracts metadata when v2 link labels wrap the anchor contents', () {
+    final result = RaplaResponseParser().parseSchedule(
+      v2LinkedNoTooltipResponse,
+    );
+
+    expect(result.errors, isEmpty);
+    expect(result.schedule.entries, hasLength(1));
+
+    final entry = result.schedule.entries.single;
+    expect(entry.start, DateTime(2026, 10, 5, 9));
+    expect(entry.end, DateTime(2026, 10, 5, 10, 30));
+    expect(entry.title, 'Linked Module');
+    expect(entry.details, isEmpty);
+    expect(entry.professor, 'Dr. Link');
+    expect(entry.room, 'R1');
     expect(entry.type, ScheduleEntryType.Class);
   });
 }

--- a/test/schedule/service/rapla/rapla_metadata_parsing_test.dart
+++ b/test/schedule/service/rapla/rapla_metadata_parsing_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:dualmate/schedule/model/schedule_entry.dart';
+import 'package:dualmate/schedule/service/rapla/rapla_response_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+  final v2NoTooltipResponse = await File(
+    '${Directory.current.absolute.path}/test/schedule/service/rapla/'
+    'html_resources/rapla_v2_metadata_response.html',
+  ).readAsString();
+
+  test('preserves v1 tooltip metadata and classification', () {
+    final result = RaplaResponseParser().parseSchedule(_v1TooltipResponse);
+
+    expect(result.errors, isEmpty);
+    expect(result.schedule.entries, hasLength(1));
+
+    final entry = result.schedule.entries.single;
+    expect(entry.title, 'Legacy & Module');
+    expect(entry.details, 'Bring <lab> notes & examples');
+    expect(entry.professor, 'Dr. Ada & Lin');
+    expect(entry.room, 'Room & Lab');
+    expect(entry.type, ScheduleEntryType.Class);
+  });
+
+  test('extracts v2 no-tooltip metadata from sibling spans', () {
+    final result = RaplaResponseParser().parseSchedule(v2NoTooltipResponse);
+
+    expect(result.errors, isEmpty);
+    expect(result.schedule.entries, hasLength(1));
+
+    final entry = result.schedule.entries.single;
+    expect(entry.start, DateTime(2026, 10, 5, 9));
+    expect(entry.end, DateTime(2026, 10, 5, 10, 30));
+    expect(entry.title, 'Modern & Module');
+    expect(entry.details, isEmpty);
+    expect(entry.professor, 'Dr. Ada & Lin, Prof. Bea');
+    expect(entry.room, 'Room & Lab, Room 2');
+    expect(entry.type, ScheduleEntryType.Class);
+  });
+}
+
+const _v1TooltipResponse = '''
+<!DOCTYPE html>
+<html>
+<body>
+  <select name="year">
+    <option selected="selected">2026</option>
+  </select>
+  <table class="week_table">
+    <tr>
+      <th class="week_number">KW 1</th>
+      <td class="week_header"><nobr>Mo 05.01.</nobr></td>
+    </tr>
+    <tr>
+      <td class="week_block" style="background-color:#99ccff">
+        <a href="#legacy">09:00&#160;-10:30<br/>Legacy &amp; Module<span class="tooltip">
+          <strong>Vorlesung / Lehrbetrieb</strong>
+          <table class="infotable">
+            <tr><td class="label">Veranstaltungsname:</td><td class="value">Legacy &amp; Module</td></tr>
+            <tr><td class="label">Bemerkung:</td><td class="value">Bring &lt;lab&gt; notes &amp; examples</td></tr>
+            <tr><td class="label">Personen:</td><td class="value">Dr. Ada &amp; Lin,</td></tr>
+            <tr><td class="label">Ressourcen:</td><td class="value">Room &amp; Lab</td></tr>
+          </table>
+        </span></a>
+        <br><span class="person">Dr. Ada &amp; Lin,</span>
+        <br><span class="resource">Room &amp; Lab</span>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+''';


### PR DESCRIPTION
## Summary

- Parse Rapla v2 no-tooltip cells from the anchor and sibling `person`/`resource` spans using DOM semantics.
- Keep the existing tooltip parser for Rapla v1.x and preserve no-tooltip color/type classification.
- Add sanitized v1/v2 regressions and document the upstream HTML contract.

## Validation

- `flutter test test/schedule/service/rapla/rapla_metadata_parsing_test.dart`
- `flutter test test/schedule` (262 tests)
- `flutter analyze`
- `dart format --output=none --set-exit-if-changed`
- `git diff --check`
- Connected Galaxy S21+ validation on the sanitized 5 October fixture: title, lecturers, type, and rooms render correctly without duplicated details.
- `ANDROID_SERIAL=RFCR31468LJ PERF_RUNS=3 scripts/run_cold_navigation_perf_suite.sh` completed across all six targets.

Fixes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved schedule parsing for Rapla data.
  - Schedule entries now more accurately display titles, details, professors, rooms, dates, and times.
  - Enhanced compatibility with both Rapla v1 and v2 metadata formats.
  - Improved handling of schedule cells and event classifications to reduce missing or incorrect information.

- **Tests**
  - Added coverage for metadata extraction, event details, resources, and parser error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->