### PR TITLE
Enable edge-to-edge on older Android versions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -222,6 +222,7 @@ tasks.configureEach { task ->
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.core:core:1.17.0'
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.4"
     testImplementation 'junit:junit:4.13.1'
 

--- a/android/app/src/main/kotlin/com/fariszr/dualmate/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/fariszr/dualmate/MainActivity.kt
@@ -1,23 +1,31 @@
 package com.fariszr.dualmate
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import android.util.Log
 import androidx.annotation.NonNull
+import androidx.core.view.WindowCompat
 import com.fariszr.dualmate.widget.WidgetNavigationExtras
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
-import android.content.ActivityNotFoundException
-import android.content.Intent
-import android.net.Uri
-import android.os.Build
-import android.provider.Settings
-import android.util.Log
 
 class MainActivity : FlutterActivity() {
     private var pendingRoute: String? = null
     private var pendingPayload: Map<String, Any?>? = null
     private var navigationChannel: MethodChannel? = null
     private var notificationSettingsChannel: MethodChannel? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // FlutterActivity resets the system UI flags during onCreate.
+        WindowCompat.enableEdgeToEdge(window)
+    }
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         GeneratedPluginRegistrant.registerWith(flutterEngine)


### PR DESCRIPTION
## Summary
- explicitly enable edge-to-edge through AndroidX for Android versions where the platform does not enforce it
- apply the configuration after `FlutterActivity.onCreate()` because Flutter resets its system UI flags during activity setup
- add AndroidX Core 1.17.0, which provides the window-level compatibility API usable by `FlutterActivity`

## Verification
- `flutter test` — 584 tests passed
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:compileReleaseKotlin`
- Android 11 / API 30 emulator smoke test confirmed the app background renders beneath the status and navigation bar regions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Android window rendering for a more immersive edge-to-edge experience.
  * Improved compatibility with modern Android system UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->