### PR TITLE
Fix Dualis GPA refresh loading state

### DIFF
--- a/docs/solutions/ui-bugs/dualis-gpa-refresh-loading-stuck-20260818.md
+++ b/docs/solutions/ui-bugs/dualis-gpa-refresh-loading-stuck-20260818.md
@@ -1,0 +1,50 @@
+---
+module: Dualis UI
+date: 2026-08-18
+problem_type: ui_bug
+component: frontend_flutter
+symptoms:
+  - "Pull-to-refresh leaves the Dualis GPA and credits summary loading"
+  - "Module results can finish and remain visible while the overview is stuck"
+root_cause: study_grades_failure_skipped_the_loading_state_notification
+resolution_type: code_fix
+severity: medium
+tags: [dualis, grades, gpa, refresh, loading, sentry]
+---
+
+# Dualis GPA summary stuck after pull-to-refresh
+
+## Problem
+
+When the study-grades request failed during a Dualis refresh, the module branch
+could still finish successfully while the GPA and credits summary kept showing
+its loading placeholder. The refresh failure was represented by Sentry issues
+`129756006` and `140729034`.
+
+## Root cause
+
+`StudyGradesViewModel.loadStudyGrades` reset `isLoadingStudyGrades` in its
+`finally` block, but the unexpected exception was rethrown before the property
+change notifications after that block ran. The in-memory flag was therefore
+false while the last rendered UI state still showed loading.
+
+## Fix
+
+- Catch unexpected study-grades failures so a pull-to-refresh completes.
+- Continue reporting unexpected failures through the privacy-safe diagnostics
+  path; expected connectivity and cancellation failures remain suppressed by
+  the existing diagnostics filter.
+- Clear and notify the GPA loading state from `finally`, so cleanup happens on
+  success, cancellation, and failure.
+- Keep the last successfully loaded GPA and credits values when refreshing
+  fails.
+- Do not advance the last-successful-refresh timestamp when the GPA branch
+  fails, allowing the stale-refresh policy to retry it.
+
+## Regression coverage
+
+- A widget test starts the GPA load, verifies the loading placeholder, fails
+  the service request, and verifies that the previous summary is restored.
+- A view-model test exercises the complete forced-refresh path and verifies
+  that the GPA failure does not stop the module and semester-name branches or
+  leave the GPA loading flag set.

--- a/lib/dualis/ui/viewmodels/study_grades_view_model.dart
+++ b/lib/dualis/ui/viewmodels/study_grades_view_model.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dualmate/common/data/preferences/preferences_provider.dart';
+import 'package:dualmate/common/logging/app_diagnostics.dart';
 import 'package:dualmate/common/logging/performance_telemetry.dart';
 import 'package:dualmate/common/ui/viewmodels/base_view_model.dart';
 import 'package:dualmate/common/util/cancelable_mutex.dart';
@@ -164,7 +165,7 @@ class StudyGradesViewModel extends BaseViewModel {
     return _preferencesProvider.getStoreDualisCredentials();
   }
 
-  Future<void> loadStudyGrades() async {
+  Future<bool> loadStudyGrades() async {
     final epoch = ++_studyGradesLoadEpoch;
     _isLoadingStudyGrades = true;
     notifyListeners("isLoadingStudyGrades");
@@ -172,9 +173,10 @@ class StudyGradesViewModel extends BaseViewModel {
     await _studyGradesCancellationToken.acquireAndCancelOther();
     if (epoch != _studyGradesLoadEpoch) {
       _studyGradesCancellationToken.release();
-      return;
+      return false;
     }
 
+    var loaded = false;
     try {
       final loadedStudyGrades = await PerformanceTelemetry.instance.measureTask(
         'dualis.results.parse',
@@ -190,17 +192,28 @@ class StudyGradesViewModel extends BaseViewModel {
       _applyDualisState(() {
         _studyGrades = loadedStudyGrades;
       });
+      loaded = true;
     } on OperationCancelledException catch (_) {
+    } catch (error, stackTrace) {
+      unawaited(
+        AppDiagnostics.instance.reportCaughtException(
+          error,
+          stackTrace,
+          message: 'Dualis study-grades refresh failed',
+          tags: const {'feature': 'dualis', 'operation': 'study_grades'},
+        ),
+      );
     } finally {
       _studyGradesCancellationToken.release();
       if (epoch != _studyGradesLoadEpoch) {
-        return;
+        return false;
       }
       _isLoadingStudyGrades = false;
+      notifyListeners("studyGrades");
+      notifyListeners("isLoadingStudyGrades");
     }
 
-    notifyListeners("studyGrades");
-    notifyListeners("isLoadingStudyGrades");
+    return loaded;
   }
 
   Future<void> loadAllModules() async {
@@ -369,8 +382,9 @@ class StudyGradesViewModel extends BaseViewModel {
       }
 
       final preferredSemesterName = _currentSemesterName;
+      final studyGradesLoad = loadStudyGrades();
       await Future.wait<void>([
-        loadStudyGrades(),
+        studyGradesLoad.then<void>((_) {}),
         loadAllModules(),
         loadSemesterNamesForCurrentSelection(
           preferredSemesterName: preferredSemesterName,
@@ -378,7 +392,9 @@ class StudyGradesViewModel extends BaseViewModel {
         ),
       ]);
 
-      await _preferencesProvider.setDualisLastRefreshAt(DateTime.now());
+      if (await studyGradesLoad) {
+        await _preferencesProvider.setDualisLastRefreshAt(DateTime.now());
+      }
     } finally {
       _refreshInFlight = false;
     }

--- a/test/dualis/ui/study_overview_loading_animation_test.dart
+++ b/test/dualis/ui/study_overview_loading_animation_test.dart
@@ -79,7 +79,23 @@ void main() {
 
     await tester.pumpWidget(_wrapWithApp(viewModel));
 
-    final load = viewModel.loadStudyGrades();
+    final initialLoad = viewModel.loadStudyGrades();
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey<String>('dualis_overview_summary_loading')),
+      findsOneWidget,
+    );
+
+    dualisService.completeStudyGrades(StudyGrades(1.7, 1.8, 210, 96));
+    expect(await initialLoad, isTrue);
+    await tester.pumpAndSettle();
+
+    expect(find.text('1.7'), findsOneWidget);
+    expect(find.text('1.8'), findsOneWidget);
+    expect(find.text('96.0 / 210.0'), findsOneWidget);
+
+    final failedRefresh = viewModel.loadStudyGrades();
     await tester.pump();
 
     expect(
@@ -88,7 +104,7 @@ void main() {
     );
 
     dualisService.failStudyGrades(StateError('student results unavailable'));
-    await expectLater(load, completes);
+    expect(await failedRefresh, isFalse);
     await tester.pumpAndSettle();
 
     expect(
@@ -99,6 +115,9 @@ void main() {
       find.byKey(const ValueKey<String>('dualis_overview_summary')),
       findsOneWidget,
     );
+    expect(find.text('1.7'), findsOneWidget);
+    expect(find.text('1.8'), findsOneWidget);
+    expect(find.text('96.0 / 210.0'), findsOneWidget);
   });
 
   testWidgets('shows loading placeholder while semester modules are fetched', (
@@ -242,7 +261,8 @@ Widget _wrapWithExamResultsApp(StudyGradesViewModel viewModel) {
 class _BlockingDualisService extends DualisService {
   final Completer<List<Module>> _allModulesCompleter =
       Completer<List<Module>>();
-  final Completer<StudyGrades> _studyGradesCompleter = Completer<StudyGrades>();
+  final List<Completer<StudyGrades>> _studyGradesRequests =
+      <Completer<StudyGrades>>[];
   final Map<String, Completer<Semester>> _semesterCompleters =
       <String, Completer<Semester>>{};
 
@@ -280,7 +300,11 @@ class _BlockingDualisService extends DualisService {
   @override
   Future<StudyGrades> queryStudyGrades([
     CancellationToken? cancellationToken,
-  ]) => _studyGradesCompleter.future;
+  ]) {
+    final request = Completer<StudyGrades>();
+    _studyGradesRequests.add(request);
+    return request.future;
+  }
 
   @override
   Future<void> logout([CancellationToken? cancellationToken]) async {}
@@ -295,12 +319,16 @@ class _BlockingDualisService extends DualisService {
     _allModulesCompleter.complete(modules);
   }
 
-  void failStudyGrades(Object error) {
-    if (_studyGradesCompleter.isCompleted) {
-      return;
-    }
-    _studyGradesCompleter.completeError(error, StackTrace.current);
+  void completeStudyGrades(StudyGrades studyGrades) {
+    _nextStudyGradesRequest.complete(studyGrades);
   }
+
+  void failStudyGrades(Object error) {
+    _nextStudyGradesRequest.completeError(error, StackTrace.current);
+  }
+
+  Completer<StudyGrades> get _nextStudyGradesRequest =>
+      _studyGradesRequests.firstWhere((request) => !request.isCompleted);
 
   void completeSemester(String name, Semester semester) {
     final completer = _semesterCompleters.putIfAbsent(

--- a/test/dualis/ui/study_overview_loading_animation_test.dart
+++ b/test/dualis/ui/study_overview_loading_animation_test.dart
@@ -66,6 +66,41 @@ void main() {
     expect(tooltipTarget.height, greaterThan(0));
   });
 
+  testWidgets('restores the GPA summary when refreshing grades fails', (
+    tester,
+  ) async {
+    final dualisService = _BlockingDualisService();
+    final preferences = PreferencesProvider(
+      _FakePreferencesAccess(),
+      _FakeSecureStorageAccess(),
+    );
+    final viewModel = StudyGradesViewModel(preferences, dualisService);
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(_wrapWithApp(viewModel));
+
+    final load = viewModel.loadStudyGrades();
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey<String>('dualis_overview_summary_loading')),
+      findsOneWidget,
+    );
+
+    dualisService.failStudyGrades(StateError('student results unavailable'));
+    await expectLater(load, completes);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>('dualis_overview_summary_loading')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('dualis_overview_summary')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('shows loading placeholder while semester modules are fetched', (
     tester,
   ) async {
@@ -207,6 +242,7 @@ Widget _wrapWithExamResultsApp(StudyGradesViewModel viewModel) {
 class _BlockingDualisService extends DualisService {
   final Completer<List<Module>> _allModulesCompleter =
       Completer<List<Module>>();
+  final Completer<StudyGrades> _studyGradesCompleter = Completer<StudyGrades>();
   final Map<String, Completer<Semester>> _semesterCompleters =
       <String, Completer<Semester>>{};
 
@@ -244,9 +280,7 @@ class _BlockingDualisService extends DualisService {
   @override
   Future<StudyGrades> queryStudyGrades([
     CancellationToken? cancellationToken,
-  ]) async {
-    return StudyGrades(0, 0, 0, 0);
-  }
+  ]) => _studyGradesCompleter.future;
 
   @override
   Future<void> logout([CancellationToken? cancellationToken]) async {}
@@ -259,6 +293,13 @@ class _BlockingDualisService extends DualisService {
       return;
     }
     _allModulesCompleter.complete(modules);
+  }
+
+  void failStudyGrades(Object error) {
+    if (_studyGradesCompleter.isCompleted) {
+      return;
+    }
+    _studyGradesCompleter.completeError(error, StackTrace.current);
   }
 
   void completeSemester(String name, Semester semester) {

--- a/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
+++ b/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
@@ -81,9 +81,7 @@ void main() {
     final success = await viewModel.login(Credentials('u', 'p'));
     expect(success, isTrue);
 
-    while (await preferences.getDualisLastRefreshAt() == null) {
-      await Future<void>.delayed(const Duration(milliseconds: 1));
-    }
+    await _waitForDualisRefresh(preferences);
 
     service.resetCallCounters();
 
@@ -99,13 +97,12 @@ void main() {
       () async {
     final preferences = _buildPreferences();
     final service = _StudyGradesTestService(blockFirstModulesRequest: false);
+    service.studyGradesResult = StudyGrades(1.7, 1.8, 210, 96);
     final viewModel = StudyGradesViewModel(preferences, service);
     addTearDown(viewModel.dispose);
 
     expect(await viewModel.login(Credentials('u', 'p')), isTrue);
-    while (await preferences.getDualisLastRefreshAt() == null) {
-      await Future<void>.delayed(const Duration(milliseconds: 1));
-    }
+    await _waitForDualisRefresh(preferences);
     final lastSuccessfulRefreshAt =
         await preferences.getDualisLastRefreshAt();
 
@@ -118,6 +115,10 @@ void main() {
     expect(service.queryStudyGradesCalls, 1);
     expect(service.queryAllModulesCalls, 1);
     expect(service.querySemesterNamesCalls, 1);
+    expect(viewModel.studyGrades.gpaTotal, 1.7);
+    expect(viewModel.studyGrades.gpaMainModules, 1.8);
+    expect(viewModel.studyGrades.creditsTotal, 210);
+    expect(viewModel.studyGrades.creditsGained, 96);
     expect(
       await preferences.getDualisLastRefreshAt(),
       lastSuccessfulRefreshAt,
@@ -141,10 +142,18 @@ void main() {
     expect(service.maximumConcurrentQueries, 3);
 
     service.releaseQueries();
-    while (await preferences.getDualisLastRefreshAt() == null) {
-      await Future<void>.delayed(const Duration(milliseconds: 1));
-    }
+    await _waitForDualisRefresh(preferences);
   });
+}
+
+Future<void> _waitForDualisRefresh(PreferencesProvider preferences) async {
+  await Future.doWhile(() async {
+    if (await preferences.getDualisLastRefreshAt() != null) {
+      return false;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    return true;
+  }).timeout(const Duration(seconds: 2));
 }
 
 PreferencesProvider _buildPreferences() {
@@ -165,6 +174,7 @@ class _StudyGradesTestService extends DualisService {
   int querySemesterNamesCalls = 0;
   int querySemesterCalls = 0;
   bool studyGradesThrows = false;
+  StudyGrades studyGradesResult = StudyGrades(0, 0, 0, 0);
   String? lastLoginUsername;
   String? lastLoginPassword;
   final Completer<void> secondModulesRequestStarted = Completer<void>();
@@ -230,7 +240,7 @@ class _StudyGradesTestService extends DualisService {
     if (studyGradesThrows) {
       throw StateError('student results unavailable');
     }
-    return StudyGrades(0, 0, 0, 0);
+    return studyGradesResult;
   }
 
   @override

--- a/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
+++ b/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
@@ -95,6 +95,35 @@ void main() {
     expect(service.querySemesterNamesCalls, 1);
   });
 
+  test('refreshData completes and clears GPA loading when grades fail',
+      () async {
+    final preferences = _buildPreferences();
+    final service = _StudyGradesTestService(blockFirstModulesRequest: false);
+    final viewModel = StudyGradesViewModel(preferences, service);
+    addTearDown(viewModel.dispose);
+
+    expect(await viewModel.login(Credentials('u', 'p')), isTrue);
+    while (await preferences.getDualisLastRefreshAt() == null) {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+    final lastSuccessfulRefreshAt =
+        await preferences.getDualisLastRefreshAt();
+
+    service.studyGradesThrows = true;
+    service.resetCallCounters();
+
+    await expectLater(viewModel.refreshData(force: true), completes);
+
+    expect(viewModel.isLoadingStudyGrades, isFalse);
+    expect(service.queryStudyGradesCalls, 1);
+    expect(service.queryAllModulesCalls, 1);
+    expect(service.querySemesterNamesCalls, 1);
+    expect(
+      await preferences.getDualisLastRefreshAt(),
+      lastSuccessfulRefreshAt,
+    );
+  });
+
   test('login refresh keeps the three Dualis branches concurrent', () async {
     final preferences = _buildPreferences();
     final service = _ParallelRefreshService();
@@ -135,6 +164,7 @@ class _StudyGradesTestService extends DualisService {
   int queryAllModulesCalls = 0;
   int querySemesterNamesCalls = 0;
   int querySemesterCalls = 0;
+  bool studyGradesThrows = false;
   String? lastLoginUsername;
   String? lastLoginPassword;
   final Completer<void> secondModulesRequestStarted = Completer<void>();
@@ -197,6 +227,9 @@ class _StudyGradesTestService extends DualisService {
     CancellationToken? cancellationToken,
   ]) async {
     queryStudyGradesCalls += 1;
+    if (studyGradesThrows) {
+      throw StateError('student results unavailable');
+    }
     return StudyGrades(0, 0, 0, 0);
   }
 


### PR DESCRIPTION
## Summary

- Prevent failed Dualis GPA refreshes from leaving the overview stuck in a loading state.
- Preserve the last successful GPA and credits summary when refreshing fails.
- Report unexpected refresh errors and add regression coverage for UI and view-model behavior.

## Testing

- Added widget coverage for restoring the GPA summary after a failed refresh.
- Added view-model coverage for clearing the loading state and preserving the refresh timestamp.
- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Study-grade refreshes now complete reliably even when loading fails.
  * Loading indicators are cleared after errors, while previously loaded GPA information remains visible.
  * The last successful refresh time is preserved when a refresh fails.
  * Other study data continues loading independently of study-grade errors.

* **Tests**
  * Added coverage for failed loading, refresh completion, loading-state cleanup, and retained GPA data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->