### PR TITLE
Notify Dualis loaders after failures

### DIFF
--- a/.agents/friction-log/20260819164219-debug-cold-start/friction.md
+++ b/.agents/friction-log/20260819164219-debug-cold-start/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Debug cold start asserts while building ScheduleViewModel provider'
+severity: 'major'
+---
+
+## Expected Behavior
+
+The isolated debug APK starts without Flutter framework assertions.
+
+## Current Behavior
+
+A physical-device debug cold start repeatedly logs a widgets assertion while building ChangeNotifierProvider<ScheduleViewModel> at lib/ui/navigation/navigation_entry.dart:56. The assertion is package:flutter/src/widgets/framework.dart line 5538: !_dirty.
+
+## Possible Solution
+
+Audit startup rebuilds and notifications around NavigationEntry and the ScheduleViewModel provider. This was found during an unrelated Dualis validation and should be fixed separately.
+
+## Minimal Reproducible Example
+
+1. Run flutter build apk --debug --dart-define=PERF_TEST_OFFLINE_FIXTURES=true.
+2. Run android run --apks=build/app/outputs/flutter-apk/app-debug.apk --device=RFCR31468LJ.
+3. Inspect adb logcat during cold startup.
+4. Observe the assertion in two fresh com.fariszr.dualmate.perf processes.
+
+## Context
+
+Device: Samsung SM-G996B, serial RFCR31468LJ. The app remains visible behind the exact-alarm prompt, but startup logs contain the assertion and Sentry captures it. No Schedule code was modified in the Dualis loading-state fix.

--- a/docs/solutions/ui-bugs/dualis-detail-loader-error-cleanup-20260819.md
+++ b/docs/solutions/ui-bugs/dualis-detail-loader-error-cleanup-20260819.md
@@ -1,0 +1,42 @@
+---
+module: Dualis UI
+date: 2026-08-19
+problem_type: ui_bug
+component: frontend_flutter
+symptoms:
+  - "Dualis detail placeholders can remain visible after an unexpected loader failure"
+  - "Loading flags are false internally while listeners retain stale loading state"
+root_cause: detail_loader_failure_skipped_the_loading_state_notification
+resolution_type: code_fix
+severity: medium
+tags: [dualis, modules, semesters, loading, refresh, sentry]
+---
+
+# Dualis detail loaders remain rendered as loading after failures
+
+## Problem
+
+The module overview, semester selector, and current-semester result loaders
+reset their loading flags in `finally`, but notified their UI listeners after
+that block. An unexpected parsing or service exception left the model clean
+internally while the last rendered state could remain a loading placeholder.
+
+## Fix
+
+`loadAllModules`, `loadSemesterByName`, and
+`loadSemesterNamesForCurrentSelection` now notify both their content property
+and loading property from the existing epoch-guarded `finally` blocks. This
+matches `loadStudyGrades`: success, cancellation, and failure all publish the
+cleanup state, while unexpected failures continue propagating to the app-level
+diagnostics and Sentry path.
+
+No other Dualis detail loader had notifications after its cleanup block.
+
+## Regression coverage
+
+Each affected loader has a test that injects an unexpected service failure and
+verifies that:
+
+- the error still propagates;
+- the loading listener observes `true` followed by `false`; and
+- the related content listener receives the guaranteed cleanup notification.

--- a/lib/dualis/ui/viewmodels/study_grades_view_model.dart
+++ b/lib/dualis/ui/viewmodels/study_grades_view_model.dart
@@ -254,10 +254,9 @@ class StudyGradesViewModel extends BaseViewModel {
         return;
       }
       _isLoadingAllModules = false;
+      notifyListeners("allModules");
+      notifyListeners("isLoadingAllModules");
     }
-
-    notifyListeners("allModules");
-    notifyListeners("isLoadingAllModules");
   }
 
   Future<void> loadSemester(String semesterName) async {
@@ -315,10 +314,9 @@ class StudyGradesViewModel extends BaseViewModel {
       }
       _currentLoadingSemesterName = "";
       _isLoadingCurrentSemester = false;
+      notifyListeners("currentSemester");
+      notifyListeners("isLoadingCurrentSemester");
     }
-
-    notifyListeners("currentSemester");
-    notifyListeners("isLoadingCurrentSemester");
   }
 
   Future<void> loadSemesterNames() async {
@@ -362,10 +360,9 @@ class StudyGradesViewModel extends BaseViewModel {
         return;
       }
       _isLoadingSemesterNames = false;
+      notifyListeners("semesterNames");
+      notifyListeners("isLoadingSemesterNames");
     }
-
-    notifyListeners("semesterNames");
-    notifyListeners("isLoadingSemesterNames");
 
     if (epoch == _semesterNamesLoadEpoch) {
       await _loadInitialSemester(

--- a/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
+++ b/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
@@ -58,6 +58,84 @@ void main() {
   );
 
   test(
+    'loadAllModules notifies loading cleanup after an unexpected failure',
+    () async {
+      final service = _StudyGradesTestService(blockFirstModulesRequest: false)
+        ..queryAllModulesError = StateError('module parser regression');
+      final viewModel = StudyGradesViewModel(_buildPreferences(), service);
+      addTearDown(viewModel.dispose);
+      final loadingStates = <bool>[];
+      var contentNotifications = 0;
+      viewModel.addListener(
+        (_) => loadingStates.add(viewModel.isLoadingAllModules),
+        const ['isLoadingAllModules'],
+      );
+      viewModel.addListener((_) => contentNotifications += 1, const [
+        'allModules',
+      ]);
+
+      await expectLater(viewModel.loadAllModules(), throwsA(isA<StateError>()));
+
+      expect(loadingStates, <bool>[true, false]);
+      expect(contentNotifications, 1);
+    },
+  );
+
+  test(
+    'loadSemesterByName notifies loading cleanup after an unexpected failure',
+    () async {
+      final service = _StudyGradesTestService(blockFirstModulesRequest: false)
+        ..querySemesterError = StateError('semester parser regression');
+      final viewModel = StudyGradesViewModel(_buildPreferences(), service);
+      addTearDown(viewModel.dispose);
+      final loadingStates = <bool>[];
+      var contentNotifications = 0;
+      viewModel.addListener(
+        (_) => loadingStates.add(viewModel.isLoadingCurrentSemester),
+        const ['isLoadingCurrentSemester'],
+      );
+      viewModel.addListener((_) => contentNotifications += 1, const [
+        'currentSemester',
+      ]);
+
+      await expectLater(
+        viewModel.loadSemesterByName('SoSe2026'),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(loadingStates, <bool>[true, false]);
+      expect(contentNotifications, 2);
+    },
+  );
+
+  test(
+    'loadSemesterNamesForCurrentSelection notifies loading cleanup after an unexpected failure',
+    () async {
+      final service = _StudyGradesTestService(blockFirstModulesRequest: false)
+        ..querySemesterNamesError = StateError('semester names regression');
+      final viewModel = StudyGradesViewModel(_buildPreferences(), service);
+      addTearDown(viewModel.dispose);
+      final loadingStates = <bool>[];
+      var contentNotifications = 0;
+      viewModel.addListener(
+        (_) => loadingStates.add(viewModel.isLoadingSemesterNames),
+        const ['isLoadingSemesterNames'],
+      );
+      viewModel.addListener((_) => contentNotifications += 1, const [
+        'semesterNames',
+      ]);
+
+      await expectLater(
+        viewModel.loadSemesterNamesForCurrentSelection(),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(loadingStates, <bool>[true, false]);
+      expect(contentNotifications, 1);
+    },
+  );
+
+  test(
     'restores the Dualis session from saved credentials on page open',
     () async {
       final preferences = _buildPreferences();
@@ -242,7 +320,9 @@ class _StudyGradesTestService extends DualisService {
   int queryAllModulesCalls = 0;
   int querySemesterNamesCalls = 0;
   int querySemesterCalls = 0;
+  Object? queryAllModulesError;
   Object? querySemesterNamesError;
+  Object? querySemesterError;
   Object? studyGradesError;
   StudyGrades studyGradesResult = StudyGrades(0, 0, 0, 0);
   String? lastLoginUsername;
@@ -277,6 +357,11 @@ class _StudyGradesTestService extends DualisService {
     queryAllModulesCalls += 1;
     _allModulesCallCount += 1;
     final token = cancellationToken;
+
+    final error = queryAllModulesError;
+    if (error != null) {
+      throw error;
+    }
 
     if (blockFirstModulesRequest) {
       if (_allModulesCallCount == 1) {
@@ -332,6 +417,10 @@ class _StudyGradesTestService extends DualisService {
     CancellationToken? cancellationToken,
   ]) async {
     querySemesterCalls += 1;
+    final error = querySemesterError;
+    if (error != null) {
+      throw error;
+    }
     return Semester(name, const <Module>[]);
   }
 

--- a/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
+++ b/test/dualis/ui/viewmodels/study_grades_view_model_test.dart
@@ -135,6 +135,65 @@ void main() {
     },
   );
 
+  test('loadAllModules ignores stale cleanup notifications', () async {
+    final service = _OverlappingLoadsService();
+    final viewModel = StudyGradesViewModel(_buildPreferences(), service);
+    addTearDown(viewModel.dispose);
+
+    await _expectStaleCleanupNotificationsIgnored(
+      viewModel: viewModel,
+      requests: service.allModulesRequests,
+      startOlderLoad: viewModel.loadAllModules,
+      startNewerLoad: viewModel.loadAllModules,
+      completeRequest: (index) =>
+          service.allModulesRequests.complete(index, const <Module>[]),
+      contentProperty: 'allModules',
+      loadingProperty: 'isLoadingAllModules',
+      isLoading: () => viewModel.isLoadingAllModules,
+    );
+  });
+
+  test('loadSemesterByName ignores stale cleanup notifications', () async {
+    final service = _OverlappingLoadsService();
+    final viewModel = StudyGradesViewModel(_buildPreferences(), service);
+    addTearDown(viewModel.dispose);
+
+    await _expectStaleCleanupNotificationsIgnored(
+      viewModel: viewModel,
+      requests: service.semesterRequests,
+      startOlderLoad: () => viewModel.loadSemesterByName('Older'),
+      startNewerLoad: () => viewModel.loadSemesterByName('Newer'),
+      completeRequest: (index) => service.semesterRequests.complete(
+        index,
+        Semester(index == 0 ? 'Older' : 'Newer', const <Module>[]),
+      ),
+      contentProperty: 'currentSemester',
+      loadingProperty: 'isLoadingCurrentSemester',
+      isLoading: () => viewModel.isLoadingCurrentSemester,
+    );
+  });
+
+  test(
+    'loadSemesterNamesForCurrentSelection ignores stale cleanup notifications',
+    () async {
+      final service = _OverlappingLoadsService();
+      final viewModel = StudyGradesViewModel(_buildPreferences(), service);
+      addTearDown(viewModel.dispose);
+
+      await _expectStaleCleanupNotificationsIgnored(
+        viewModel: viewModel,
+        requests: service.semesterNamesRequests,
+        startOlderLoad: viewModel.loadSemesterNamesForCurrentSelection,
+        startNewerLoad: viewModel.loadSemesterNamesForCurrentSelection,
+        completeRequest: (index) =>
+            service.semesterNamesRequests.complete(index, const <String>[]),
+        contentProperty: 'semesterNames',
+        loadingProperty: 'isLoadingSemesterNames',
+        isLoading: () => viewModel.isLoadingSemesterNames,
+      );
+    },
+  );
+
   test(
     'restores the Dualis session from saved credentials on page open',
     () async {
@@ -303,6 +362,58 @@ Future<void> _waitForDualisRefresh(PreferencesProvider preferences) async {
   }).timeout(const Duration(seconds: 2));
 }
 
+Future<void> _waitUntil(bool Function() condition) async {
+  await Future.doWhile(() async {
+    if (condition()) {
+      return false;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    return true;
+  }).timeout(const Duration(seconds: 2));
+}
+
+Future<void> _expectStaleCleanupNotificationsIgnored<T>({
+  required StudyGradesViewModel viewModel,
+  required _ControllableRequests<T> requests,
+  required Future<void> Function() startOlderLoad,
+  required Future<void> Function() startNewerLoad,
+  required void Function(int index) completeRequest,
+  required String contentProperty,
+  required String loadingProperty,
+  required bool Function() isLoading,
+}) async {
+  var contentNotifications = 0;
+  var loadingNotifications = 0;
+  viewModel.addListener((_) => contentNotifications += 1, <String>[
+    contentProperty,
+  ]);
+  viewModel.addListener((_) => loadingNotifications += 1, <String>[
+    loadingProperty,
+  ]);
+
+  final olderLoad = startOlderLoad();
+  await requests.waitForCount(1);
+  final newerLoad = startNewerLoad();
+  await _waitUntil(() => loadingNotifications >= 2);
+  final contentCountAfterNewerStarted = contentNotifications;
+  final loadingCountAfterNewerStarted = loadingNotifications;
+
+  completeRequest(0);
+  await olderLoad;
+  await requests.waitForCount(2);
+
+  expect(contentNotifications, contentCountAfterNewerStarted);
+  expect(loadingNotifications, loadingCountAfterNewerStarted);
+  expect(isLoading(), isTrue);
+
+  completeRequest(1);
+  await newerLoad;
+
+  expect(contentNotifications, contentCountAfterNewerStarted + 1);
+  expect(loadingNotifications, loadingCountAfterNewerStarted + 1);
+  expect(isLoading(), isFalse);
+}
+
 PreferencesProvider _buildPreferences() {
   return PreferencesProvider(
     _FakePreferencesAccess(),
@@ -438,6 +549,68 @@ class _StudyGradesTestService extends DualisService {
     queryAllModulesCalls = 0;
     querySemesterNamesCalls = 0;
     querySemesterCalls = 0;
+  }
+}
+
+class _OverlappingLoadsService extends DualisService {
+  final allModulesRequests = _ControllableRequests<List<Module>>();
+  final semesterRequests = _ControllableRequests<Semester>();
+  final semesterNamesRequests = _ControllableRequests<List<String>>();
+
+  @override
+  Future<LoginResult> login(
+    String username,
+    String password, [
+    CancellationToken? cancellationToken,
+  ]) async => LoginResult.LoggedIn;
+
+  @override
+  Future<List<Module>> queryAllModules([CancellationToken? cancellationToken]) {
+    return allModulesRequests.add();
+  }
+
+  @override
+  Future<Semester> querySemester(
+    String name, [
+    CancellationToken? cancellationToken,
+  ]) {
+    return semesterRequests.add();
+  }
+
+  @override
+  Future<List<String>> querySemesterNames([
+    CancellationToken? cancellationToken,
+  ]) {
+    return semesterNamesRequests.add();
+  }
+
+  @override
+  Future<StudyGrades> queryStudyGrades([
+    CancellationToken? cancellationToken,
+  ]) async => StudyGrades(0, 0, 0, 0);
+
+  @override
+  Future<void> logout([CancellationToken? cancellationToken]) async {}
+
+  @override
+  void clearCache() {}
+}
+
+class _ControllableRequests<T> {
+  final List<Completer<T>> _requests = [];
+
+  Future<T> add() {
+    final request = Completer<T>();
+    _requests.add(request);
+    return request.future;
+  }
+
+  Future<void> waitForCount(int count) {
+    return _waitUntil(() => _requests.length >= count);
+  }
+
+  void complete(int index, T value) {
+    _requests[index].complete(value);
   }
 }
 


### PR DESCRIPTION
## Summary

- Notify content and loading listeners from each loader's cleanup path.
- Add regression tests for unexpected module, semester, and semester-name loader failures.
- Document the stale-loading-state fix and record cold-start friction.

## Testing

- Not run (no execution evidence provided).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior when multiple requests run concurrently, preventing outdated requests from triggering completion notifications.
  * Loading indicators now clear correctly when module, semester, or semester-name requests encounter unexpected errors.
  * Ensured valid completion notifications continue to be emitted after failed requests.

* **Tests**
  * Added coverage for error handling and concurrent loading scenarios across module, semester, and semester-name data.
  * Verified that stale requests do not emit cleanup notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->